### PR TITLE
When SINGULARITY_CACHEDIR is set, all images must be stored there

### DIFF
--- a/src/cactus/progressive/cactus_progressive.py
+++ b/src/cactus/progressive/cactus_progressive.py
@@ -358,7 +358,11 @@ def setupBinaries(options):
         jobStoreType, locator = Toil.parseLocator(options.jobStore)
         if jobStoreType != "file":
             raise RuntimeError("Singularity mode is only supported when using the FileJobStore.")
-        imgPath = os.path.join(os.path.abspath(locator), "cactus.img")
+        # When SINGULARITY_CACHEDIR is set, singularity will refuse to store images in the current directory
+        if 'SINGULARITY_CACHEDIR' in os.environ:
+            imgPath = os.path.join(os.environ['SINGULARITY_CACHEDIR'], "cactus.img")
+        else:
+            imgPath = os.path.join(os.path.abspath(locator), "cactus.img")
         os.environ["CACTUS_SINGULARITY_IMG"] = imgPath
 
 def importSingularityImage():
@@ -376,6 +380,8 @@ def importSingularityImage():
         # point to a path instead of a name in the CWD. So we change
         # to the proper directory manually, then change back after the
         # image is pulled.
+        # NOTE: singularity writes images in the current directory only
+        #       when SINGULARITY_CACHEDIR is not set
         oldCWD = os.getcwd()
         os.chdir(os.path.dirname(imgPath))
         # --size is deprecated starting in 2.4, but is needed for 2.3 support. Keeping it in for now.


### PR DESCRIPTION
By default, singularity keeps the images (or at least the layers) under `~/.singularity`. On our cluster, the home directory is quota-ed and the Systems team recommends setting the environment variable `SINGULARITY_CACHEDIR`. When it is set, singularity will store the layers *and* images there, but cactus expects the image to be built and stored in `<jobStorePath>` (by changing the current  working directory). Because of that, cactus fails:
```
$ echo $SINGULARITY_CACHEDIR
/nfs/production/panda/ensembl/compara/muffato/singularity
$ cd /hps/nobackup/production/ensembl/muffato/sing/
$ cactus --binariesMode singularity job_store examples/evolverMammals.txt align2.hal
(...)
The workflow ID is: '729c211f-3d00-490a-aba7-6bf14063d76d'
(...)
Docker image path: quay.io/comparative-genomics-toolkit/cactus:2c4e64cb12efd82d24f4e451527118527bba1433
Cache folder set to /nfs/production/panda/ensembl/compara/muffato/singularity/docker
[16/16] |===================================| 100.0%
Importing: base Singularity environment
Importing: /nfs/production/panda/ensembl/compara/muffato/singularity/docker/sha256:50aff78429b146489e8a6cb9334d93a6d81d5de2edc4fbf5e2d4d9253625753e.tar.gz
Importing: /nfs/production/panda/ensembl/compara/muffato/singularity/docker/sha256:f6d82e297bce031a3de1fa8c1587535e34579abce09a61e37f5a225a8667422f.tar.gz
Importing: /nfs/production/panda/ensembl/compara/muffato/singularity/docker/sha256:275abb2c8a6f1ce8e67a388a11f3cc014e98b36ff993a6ed1cc7cd6ecb4dd61b.tar.gz
Importing: /nfs/production/panda/ensembl/compara/muffato/singularity/docker/sha256:9f15a39356d6fc1df0a77012bf1aa2150b683e46be39d1c51bc7a320f913e322.tar.gz
Importing: /nfs/production/panda/ensembl/compara/muffato/singularity/docker/sha256:fc0342a94c89e477c821328ccb542e6fb86ce4ef4ebbf1098e85669e051ef0dd.tar.gz
Importing: /nfs/production/panda/ensembl/compara/muffato/singularity/docker/sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4.tar.gz
Importing: /nfs/production/panda/ensembl/compara/muffato/singularity/docker/sha256:cf8fbcfbc13ceca80bd099d7d6131e288ab6a3eeb2a5f74968594d08dce7ce41.tar.gz
Importing: /nfs/production/panda/ensembl/compara/muffato/singularity/docker/sha256:797e37204f876a928ad7635aafb25a3f2a3543530d29a3c4d1899d2ddf46af55.tar.gz
Importing: /nfs/production/panda/ensembl/compara/muffato/singularity/docker/sha256:4150fef6dd5b52d55858d0af0db0aca0b8ed14bf3d9fc4e1742535a88d303902.tar.gz
Importing: /nfs/production/panda/ensembl/compara/muffato/singularity/docker/sha256:ddd0426fe140c443ef31a23d10cbc4b684187f25ddcf088c7eb7ddc534c6dcc3.tar.gz
Importing: /nfs/production/panda/ensembl/compara/muffato/singularity/docker/sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4.tar.gz
Importing: /nfs/production/panda/ensembl/compara/muffato/singularity/docker/sha256:d76be3a91cefb39c64d85c864c29d96c9067dcdcec8ccf197e7a9599106ab013.tar.gz
Importing: /nfs/production/panda/ensembl/compara/muffato/singularity/docker/sha256:ab89e618b076e17fb3d8b11d3c358021b0d1da968c397c5171cecb3226527aa6.tar.gz
Importing: /nfs/production/panda/ensembl/compara/muffato/singularity/docker/sha256:f2ec8461185cb57e644fa41ad843725c025f1a2a3d9f20e90898c5bb58aad606.tar.gz
Importing: /nfs/production/panda/ensembl/compara/muffato/singularity/docker/sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4.tar.gz
Importing: /nfs/production/panda/ensembl/compara/muffato/singularity/docker/sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4.tar.gz
Importing: /nfs/production/panda/ensembl/compara/muffato/singularity/metadata/sha256:12465d975226060a18f2ae28bd25c305b6109ef02cb5e963c14d01216b7d826b.tar.gz
WARNING: Building container as an unprivileged user. If you run this container as root
WARNING: it may be missing some functionality.
Building Singularity image...
Singularity container built: /nfs/production/panda/ensembl/compara/muffato/singularity/cactus.img
Cleaning up...
Done. Container is at: /nfs/production/panda/ensembl/compara/muffato/singularity/cactus.img

(...)
=========> Failed job 'logAssemblyStats' L/1/jobn4RcOD
---TOIL WORKER OUTPUT LOG---
INFO:toil:Running Toil version 3.13.0-3cb535425306955028ed7604114f772990d00440.
WARNING:toil.resource:'JTRES_68fd17841cf3e99f1fa3326fee8713b3' may exist, but is not yet referenced by the worker (KeyError from os.environ[]).
WARNING:toil.resource:'JTRES_68fd17841cf3e99f1fa3326fee8713b3' may exist, but is not yet referenced by the worker (KeyError from os.environ[]).
INFO:cactus.shared.common:Work dirs: set([u'/tmp/toil-2b2ce12d-5144-4dbb-835a-60f4cadc0192-1256a636-686a-41e4-8d0b-3edb954530ed/tmp8WXnvI/15effeda-895d-4ca2-b34f-f0896f4750a8'])
INFO:cactus.shared.common:Docker work dir: /tmp/toil-2b2ce12d-5144-4dbb-835a-60f4cadc0192-1256a636-686a-41e4-8d0b-3edb954530ed/tmp8WXnvI/15effeda-895d-4ca2-b34f-f0896f4750a8
INFO:cactus.shared.common:Running the command ['singularity', '--silent', 'run', u'/hps/nobackup/production/ensembl/muffato/sing/job_store/cactus.img', u'cactus_analyseAssembly', u'tmpe7JMrx.tmp']
ERROR  : Image path doesn't exists
ABORT  : Retval = 255
Traceback (most recent call last):
  File "/homes/muffato/src/local/virtualenv/cactus/lib/python2.7/site-packages/toil/worker.py", line 316, in main
    job._runner(jobGraph=jobGraph, jobStore=jobStore, fileStore=fileStore)
  File "/homes/muffato/src/local/virtualenv/cactus/lib/python2.7/site-packages/toil/job.py", line 1323, in _runner
    returnValues = self._run(jobGraph, fileStore)
  File "/homes/muffato/src/local/virtualenv/cactus/lib/python2.7/site-packages/toil/job.py", line 1268, in _run
    return self.run(fileStore)
  File "/homes/muffato/src/local/virtualenv/cactus/lib/python2.7/site-packages/toil/job.py", line 1452, in run
    rValue = userFunction(*((self,) + tuple(self._args)), **self._kwargs)
  File "/homes/muffato/src/local/virtualenv/cactus/lib/python2.7/site-packages/cactus/progressive/cactus_progressive.py", line 201, in logAssemblyStats
    analysisString = cactus_call(parameters=["cactus_analyseAssembly", sequenceFile], check_output=True)
  File "/homes/muffato/src/local/virtualenv/cactus/lib/python2.7/site-packages/cactus/shared/common.py", line 1022, in cactus_call
    raise RuntimeError("Command %s failed with output: %s" % (call, output))
RuntimeError: Command ['singularity', '--silent', 'run', u'/hps/nobackup/production/ensembl/muffato/sing/job_store/cactus.img', u'cactus_analyseAssembly', u'tmpe7JMrx.tmp'] failed with output:
ERROR:toil.worker:Exiting the worker because of a failed job on host ebi6-033.ebi.ac.uk
WARNING:toil.jobGraph:Due to failure we are reducing the remaining retry count of job 'logAssemblyStats' L/1/jobn4RcOD with ID L/1/jobn4RcOD to 0
<=========
```

The patch changes the assumption and make cactus honour `SINGULARITY_CACHEDIR`