### PR TITLE
fixed typo

### DIFF
--- a/src/cactus/progressive/cactus_progressive.py
+++ b/src/cactus/progressive/cactus_progressive.py
@@ -338,7 +338,7 @@ def setupBinaries(options):
         if find_executable('docker') is None:
             raise RuntimeError("The `docker` executable wasn't found on the "
                                "system. Please install Docker if possible, or "
-                               "use --binaryMode local and add cactus's bin "
+                               "use --binariesMode local and add cactus's bin "
                                "directory to your PATH.")
     # If running without Docker, verify that we can find the Cactus executables
     elif mode == "local":


### PR DESCRIPTION
The error message when docker or singularity isn't installed said to use `--binaryMode local` instead of `--binariesMode local`. `--binaryMode local` results in an unrecognized argument error.