### PR TITLE
correct networkx requirement in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'decorator',
         'subprocess32',
         'psutil',
-        'networkx>=2,<3',
+        'networkx==2.2',
         'cython',
         # Someone uploaded an old version of sonLib to pyPI, so we have to use this name
         'actualSonLib'],


### PR DESCRIPTION
Using `pip install --upgrade .` I had an error with the networkx version:

```
...
  Complete output from command python setup.py egg_info:
    NetworkX 2.3+ requires Python 3.5 or later (2.7 detected). 
...
Command "python setup.py egg_info" failed with error code 1 
```

This was easily fixed by changing the `install_requires` networkx entry in `setup.py`.