### PR TITLE
Give 'sort' a temporary directory in mappingQualityRescoring

### DIFF
--- a/src/cactus/blast/mappingQualityRescoringAndFiltering.py
+++ b/src/cactus/blast/mappingQualityRescoringAndFiltering.py
@@ -48,7 +48,7 @@ def mappingQualityRescoring(job, inputAlignmentFileID,
     # Mirror and orient alignments, sort, split overlaps and calculate mapping qualities
     cactus_call(parameters=[["cat", inputAlignmentFile],
                             ["cactus_mirrorAndOrientAlignments", logLevel],
-                            ["sort", "-k6,6", "-k7,7n", "-k8,8n"], # This sorts by coordinate
+                            ["sort", "-T{}".format(job.fileStore.getLocalTempDir()), "-k6,6", "-k7,7n", "-k8,8n"], # This sorts by coordinate
                             ["uniq"], # This eliminates any annoying duplicates if lastz reports the alignment in both orientations
                             ["cactus_splitAlignmentOverlaps", logLevel],
                             ["cactus_calculateMappingQualities", logLevel, str(maxAlignmentsPerSite),


### PR DESCRIPTION
This step was failing for me due to /tmp filling up. Setting a different TMPDIR in toil's environment wasn't working due to singularity issues, so I added a flag to the sort command so that toil makes a local temporary directory just for it. This seemed like a more robust solution.