### PR TITLE
Update RoundedJob to work with latest Toil

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
   - sudo pip install --upgrade pip requests pathlib2
   - sudo pip install --ignore-installed --upgrade six
 # install toil / cactus
-  - sudo pip install --pre toil
+  - sudo pip install toil
   - sudo pip install -e .
   - if [[ "$CACTUS_TEST_CHOICE" == "normal" ]]; then export MAKE_TARGET=test_nonblast; fi
   - if [[ "$CACTUS_TEST_CHOICE" == "blast" ]]; then export MAKE_TARGET=test_blast; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
   - sudo pip install --upgrade pip requests pathlib2
   - sudo pip install --ignore-installed --upgrade six
 # install toil / cactus
-  - sudo pip install toil
+  - sudo pip install toil==3.20.0
   - sudo pip install -e .
   - if [[ "$CACTUS_TEST_CHOICE" == "normal" ]]; then export MAKE_TARGET=test_nonblast; fi
   - if [[ "$CACTUS_TEST_CHOICE" == "blast" ]]; then export MAKE_TARGET=test_blast; fi

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -1106,10 +1106,15 @@ class RoundedJob(Job):
             return bytesRequirement
         return (bytesRequirement // self.roundingAmount + 1) * self.roundingAmount
 
-    def _runner(self, jobGraph, jobStore, fileStore):
+    def _runner(self, jobGraph, jobStore, fileStore, defer=None):
         if jobStore.config.workDir is not None:
             os.environ['TMPDIR'] = fileStore.getLocalTempDir()
-        super(RoundedJob, self)._runner(jobGraph=jobGraph, jobStore=jobStore, fileStore=fileStore)
+        if defer:
+            # Toil v 3.21 or later
+            super(RoundedJob, self)._runner(jobGraph=jobGraph, jobStore=jobStore, fileStore=fileStore, defer=defer)
+        else:
+            # Older versions of toil
+            super(RoundedJob, self)._runner(jobGraph=jobGraph, jobStore=jobStore, fileStore=fileStore)
 
 def readGlobalFileWithoutCache(fileStore, jobStoreID):
     """Reads a jobStoreID into a file and returns it, without touching


### PR DESCRIPTION
`RoundedJob`'s super class got a new argument, `defer` in its `_runner()` method in the latest Toil (see discussion in https://github.com/DataBiosphere/toil/issues/2854).  We update it accordingly (and keep it optional to preserve backward compatibility)  
Should resolve #106
