### PR TITLE
Enable singularity with remote job stores in order to run on kubernetes batch system

### DIFF
--- a/src/cactus/pipeline/cactus_workflow.py
+++ b/src/cactus/pipeline/cactus_workflow.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from Cython.Runtime.refnanny import loglevel
 
 #Copyright (C) 2009-2011 by Benedict Paten (benedictpaten@gmail.com)
 #

--- a/src/cactus/progressive/cactus_progressive.py
+++ b/src/cactus/progressive/cactus_progressive.py
@@ -365,24 +365,25 @@ def setupBinaries(options):
     else:
         assert mode == "singularity"
         jobStoreType, locator = Toil.parseLocator(options.jobStore)
-        if jobStoreType != "file":
-            raise RuntimeError("Singularity mode is only supported when using the FileJobStore.")
-        if options.containerImage:
-            imgPath = os.path.abspath(options.containerImage)
-            os.environ["CACTUS_USE_LOCAL_SINGULARITY_IMG"] = "1"
-        else:
-            # When SINGULARITY_CACHEDIR is set, singularity will refuse to store images in the current directory
-            if 'SINGULARITY_CACHEDIR' in os.environ:
-                imgPath = os.path.join(os.environ['SINGULARITY_CACHEDIR'], "cactus.img")
+        if jobStoreType == "file":
+            # if not using a local jobStore, then don't set the `SINGULARITY_CACHEDIR`
+            # in this case, the image will be downloaded on each call
+            if options.containerImage:
+                imgPath = os.path.abspath(options.containerImage)
+                os.environ["CACTUS_USE_LOCAL_SINGULARITY_IMG"] = "1"
             else:
-                imgPath = os.path.join(os.path.abspath(locator), "cactus.img")
-        os.environ["CACTUS_SINGULARITY_IMG"] = imgPath
+                # When SINGULARITY_CACHEDIR is set, singularity will refuse to store images in the current directory
+                if 'SINGULARITY_CACHEDIR' in os.environ:
+                    imgPath = os.path.join(os.environ['SINGULARITY_CACHEDIR'], "cactus.img")
+                else:
+                    imgPath = os.path.join(os.path.abspath(locator), "cactus.img")
+            os.environ["CACTUS_SINGULARITY_IMG"] = imgPath
 
-def importSingularityImage():
+def importSingularityImage(options):
     """Import the Singularity image from Docker if using Singularity."""
     mode = os.environ.get("CACTUS_BINARIES_MODE", "docker")
     localImage = os.environ.get("CACTUS_USE_LOCAL_SINGULARITY_IMG", "0")
-    if mode == "singularity":
+    if mode == "singularity" and Toil.parseLocator(options.jobStore)[0] == "file":
         imgPath = os.environ["CACTUS_SINGULARITY_IMG"]
         # If not using local image, pull the docker image
         if localImage == "0":
@@ -472,7 +473,7 @@ def main():
 
 def runCactusProgressive(options):
     with Toil(options) as toil:
-        importSingularityImage()
+        importSingularityImage(options)
         #Run the workflow
         if options.restart:
             halID = toil.restart()

--- a/src/cactus/progressive/cactus_progressive.py
+++ b/src/cactus/progressive/cactus_progressive.py
@@ -12,6 +12,7 @@ tree.
 
 import os
 import xml.etree.ElementTree as ET
+import timeit
 from argparse import ArgumentParser
 from base64 import b64encode
 from subprocess import check_call
@@ -471,6 +472,12 @@ def main():
         options.retryCount = 5
     runCactusProgressive(options)
 
+    start_time = timeit.default_timer()        
+    runCactusProgressive(options)
+    end_time = timeit.default_timer()
+    run_time = end_time - start_time
+    logger.info("Cactus has finished after {} seconds".format(run_time))
+    
 def runCactusProgressive(options):
     with Toil(options) as toil:
         importSingularityImage(options)

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -17,15 +17,18 @@ import uuid
 import json
 import time
 import signal
+import hashlib
+import tempfile
 
 from urlparse import urlparse
 
 from toil.lib.bioio import logger
 from toil.lib.bioio import system
 from toil.lib.bioio import getLogLevelString
-
+from toil.lib.misc import mkdir_p
 from toil.common import Toil
 from toil.job import Job
+from toil.realtimeLogger import RealtimeLogger
 
 from sonLib.bioio import popenCatch
 from sonLib.bioio import getTempDirectory
@@ -867,10 +870,92 @@ def maxMemUsageOfContainer(containerInfo):
 def singularityCommand(tool=None,
                        work_dir=None,
                        parameters=None,
-                       port=None):
-    base_singularity_call = ["singularity", "--silent", "run", os.environ["CACTUS_SINGULARITY_IMG"]]
-    base_singularity_call.extend(parameters)
-    return base_singularity_call
+                       port=None,
+                       file_store=None):
+    if "CACTUS_SINGULARITY_IMG" in os.environ:
+        # old logic: just run a local image
+        # (this was toggled by only setting CACTUS_SINGULARITY_IMG when using a local jobstore in cactus_progressive.py)
+        base_singularity_call = ["singularity", "--silent", "run", os.environ["CACTUS_SINGULARITY_IMG"]]
+        base_singularity_call.extend(parameters)
+        return base_singularity_call
+    else:
+        # workaround for kubernetes toil: explicitly make a local image
+        # (see https://github.com/vgteam/toil-vg/blob/master/src/toil_vg/singularity.py)
+
+        if parameters is None:
+            parameters = []
+        if work_dir is None:
+            work_dir = os.getcwd()
+
+        baseSingularityCall = ['singularity', '-q', 'exec']
+        
+        # Mount workdir as /mnt and work in there.
+        # Hope the image actually has a /mnt available.
+        # Otherwise this silently doesn't mount.
+        # But with -u (user namespaces) we have no luck pointing in-container
+        # home at anything other than our real home (like something under /var
+        # where Toil puts things).
+        # Note that we target Singularity 3+.
+        baseSingularityCall += ['-u', '-B', '{}:{}'.format(os.path.abspath(work_dir), '/mnt'), '--pwd', '/mnt']
+
+        # Problem: Multiple Singularity downloads sharing the same cache directory will
+        # not work correctly. See https://github.com/sylabs/singularity/issues/3634
+        # and https://github.com/sylabs/singularity/issues/4555.
+
+        # As a workaround, we have out own cache which we manage ourselves.
+        cache_dir = os.path.join(os.environ.get('SINGULARITY_CACHEDIR',  os.path.join(os.environ.get('HOME'), '.singularity')), 'toil')
+        mkdir_p(cache_dir)
+
+        # hack to transform back to docker image
+        if tool == 'cactus':
+            tool = getDockerImage()
+        # not a url or local file? try it as a Docker specifier
+        if not tool.startswith('/') and '://' not in tool:
+            tool = 'docker://' + tool
+
+        # What name in the cache dir do we want?
+        # We cache everything as sandbox directories and not .sif files because, as
+        # laid out in https://github.com/sylabs/singularity/issues/4617, there
+        # isn't a way to run from a .sif file and have write permissions on system
+        # directories in the container, because the .sif build process makes
+        # everything owned by root inside the image. Since some toil-vg containers
+        # (like the R one) want to touch system files (to install R packages at
+        # runtime), we do it this way to act more like Docker.
+        #
+        # Also, only sandbox directories work with user namespaces, and only user
+        # namespaces work inside unprivileged Docker containers like the Toil
+        # appliance.
+        sandbox_dirname = os.path.join(cache_dir, '{}.sandbox'.format(hashlib.sha256(tool).hexdigest()))
+
+        if not os.path.exists(sandbox_dirname):
+            # We atomically drop the sandbox at that name when we get it
+
+            # Make a temp directory to be the sandbox
+            temp_sandbox_dirname = tempfile.mkdtemp(dir=cache_dir)
+
+            # Download with a fresh cache to a sandbox
+            download_env = os.environ.copy()
+            download_env['SINGULARITY_CACHEDIR'] = file_store.getLocalTempDir() if file_store else tempfile.mkdtemp(dir=work_dir)
+            subprocess32.check_call(['singularity', 'build', '-s', '-F', temp_sandbox_dirname, tool], env=download_env)
+
+            # Clean up the Singularity cache since it is single use
+            shutil.rmtree(download_env['SINGULARITY_CACHEDIR'])
+
+            try:
+                # This may happen repeatedly but it is atomic
+                os.rename(temp_sandbox_dirname, sandbox_dirname)
+            except FileExistsError:
+                # Can't rename a directory over another
+                # Make sure someone else has made the directory
+                assert os.path.exists(sandbox_dirname)
+                # Remove our redundant copy
+                shutil.rmtree(temp_sandbox_name)
+
+            # TODO: we could save some downloading by having one process download
+            # and the others wait, but then we would need a real fnctl locking
+            # system here.
+        return baseSingularityCall + [sandbox_dirname] + parameters
+            
 
 def dockerCommand(tool=None,
                   work_dir=None,
@@ -998,7 +1083,7 @@ def cactus_call(tool=None,
                                             entrypoint=entrypoint)
     elif mode == "singularity":
         call = singularityCommand(tool=tool, work_dir=work_dir,
-                                  parameters=parameters, port=port)
+                                  parameters=parameters, port=port, file_store=fileStore)
     else:
         assert mode == "local"
         call = parameters
@@ -1014,11 +1099,25 @@ def cactus_call(tool=None,
     if check_output:
         stdoutFileHandle = subprocess32.PIPE
 
-    _log.info("Running the command %s" % call)
+    RealtimeLogger.info("Running the command {}".format(call))
     process = subprocess32.Popen(call, shell=shell,
                                  stdin=stdinFileHandle, stdout=stdoutFileHandle,
                                  stderr=subprocess32.PIPE if swallowStdErr else sys.stderr,
                                  bufsize=-1)
+
+    if mode == "singularity":
+        # After Singularity exits, it is possible that cleanup of the container's
+        # temporary files is still in progress (sicne it also waits for the
+        # container to exit). If we return immediately and the Toil job then
+        # immediately finishes, we can have a race between Toil's temp
+        # cleanup/space tracking code and Singularity's temp cleanup code to delete
+        # the same directory tree. Toil doesn't handle this well, and crashes when
+        # files it expected to be able to see are missing (at least on some
+        # versions). So we introduce a delay here to try and make sure that
+        # Singularity wins the race with high probability.
+        #
+        # See https://github.com/sylabs/singularity/issues/1255
+        time.sleep(0.5)
 
     if server:
         return process

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -1183,7 +1183,10 @@ class RoundedJob(Job):
         if memory is not None:
             memory = self.roundUp(memory)
         if disk is not None:
-            disk = self.roundUp(disk)
+            # hack: we may need extra space to cook up a singularity image on the fly
+            #       so we add it (1.5G) here.
+            # todo: only do this when needed
+            disk = 1500*1024*1024 + self.roundUp(disk)
         super(RoundedJob, self).__init__(memory=memory, cores=cores, disk=disk,
                                          preemptable=preemptable, unitName=unitName,
                                          checkpoint=checkpoint)


### PR DESCRIPTION
Port over the logic from [toil-vg](https://github.com/vgteam/toil-vg/blob/master/src/toil_vg/singularity.py) to explicitly download singularity images into a local sandbox.  This way they can be run from within docker appliances.    There is a performance concern here, as the images need to be regenerated every time they are run.  

When using a local file store, the old singularity logic of downloading an image once is preserved.  The new logic should only kick in on remote stores, that would have triggered an error with the old code.  

Kubernetes support is currently reliant on using a special toil branch:
```
pip install git+https://github.com/databiosphere/toil.git@72750c175eb84fde0e6d3302283f032edc39038b#egg=toil[all]

TOIL_AWS_SECRET_NAME=shared-s3-credentials TOIL_APPLIANCE_SELF=quay.io/adamnovak/toil:3.22.0a1-72750c175eb84fde0e6d3302283f032edc39038b\
    cactus aws:us-west-2:glennhickey-toiltest3 examples/evolverMammals.txt examples/evolverMammals.hal  --binariesMode singularity --batchSystem kubernetes --realTimeLogging
```