### PR TITLE
More efficient Singularity support with remote job stores

### DIFF
--- a/src/cactus/blast/mappingQualityRescoringAndFiltering.py
+++ b/src/cactus/blast/mappingQualityRescoringAndFiltering.py
@@ -52,12 +52,14 @@ def mappingQualityRescoring(job, inputAlignmentFileID,
                             ["uniq"], # This eliminates any annoying duplicates if lastz reports the alignment in both orientations
                             ["cactus_splitAlignmentOverlaps", logLevel],
                             ["cactus_calculateMappingQualities", logLevel, str(maxAlignmentsPerSite),
-                             str(minimumMapQValue), str(alpha)] + tempAlignmentFiles])
+                             str(minimumMapQValue), str(alpha)] + tempAlignmentFiles],
+                fileStore=job.fileStore)
 
     # Merge together the output files in order
     secondaryTempAlignmentFile = job.fileStore.getLocalTempFile()
     if len(tempAlignmentFiles) > 1:
-        cactus_call(parameters=[["cat" ] + tempAlignmentFiles[1:]], outfile=secondaryTempAlignmentFile)
+        cactus_call(parameters=[["cat" ] + tempAlignmentFiles[1:]], outfile=secondaryTempAlignmentFile,
+                    fileStore=job.fileStore)
 
     job.fileStore.logToMaster("Filtered, non-overlapping primary cigar file has %s lines" % countLines(tempAlignmentFiles[0]))
     job.fileStore.logToMaster("Filtered, non-overlapping secondary cigar file has %s lines" % countLines(secondaryTempAlignmentFile))

--- a/src/cactus/pipeline/ktserverToil.py
+++ b/src/cactus/pipeline/ktserverToil.py
@@ -39,7 +39,7 @@ class KtServerService(Job.Service):
     def stop(self, job):
         self.check()
         try:
-            stopKtserver(self.dbElem)
+            stopKtserver(self.dbElem, fileStore=job.fileStore)
         except:
             # Server is probably already terminated
             pass

--- a/src/cactus/preprocessor/cactus_preprocessor.py
+++ b/src/cactus/preprocessor/cactus_preprocessor.py
@@ -91,7 +91,8 @@ class MergeChunks2(RoundedJob):
         chunkList = [os.path.basename(chunk) for chunk in chunkList]
         outSequencePath = fileStore.getLocalTempFile()
         cactus_call(outfile=outSequencePath, stdin_string=" ".join(chunkList),
-                    parameters=["cactus_batch_mergeChunks"])
+                    parameters=["cactus_batch_mergeChunks"],
+                    fileStore=fileStore)
         return fileStore.writeGlobalFile(outSequencePath)
 
 class PreprocessSequence(RoundedJob):
@@ -136,7 +137,8 @@ class PreprocessSequence(RoundedJob):
             inChunkDirectory = getTempDirectory(rootDir=fileStore.getLocalTempDir())
             inChunkList = runGetChunks(sequenceFiles=[inSequence], chunksDir=inChunkDirectory,
                                        chunkSize=self.prepOptions.chunkSize,
-                                       overlapSize=0)
+                                       overlapSize=0,
+                                       fileStore=fileStore)
             inChunkList = [os.path.abspath(path) for path in inChunkList]
         logger.info("Chunks = %s" % inChunkList)
 

--- a/src/cactus/preprocessor/lastzRepeatMasking/cactus_lastzRepeatMask.py
+++ b/src/cactus/preprocessor/lastzRepeatMasking/cactus_lastzRepeatMask.py
@@ -50,7 +50,8 @@ class LastzRepeatMaskJob(RoundedJob):
                     parameters=["cactus_fasta_fragments.py",
                                 "--fragment=%s" % str(self.repeatMaskOptions.fragment),
                                 "--step=%s" % (str(self.repeatMaskOptions.fragment / 2)),
-                                "--origin=zero"])
+                                "--origin=zero"],
+                    fileStore=fileStore)
         return fragments
 
     def alignFastaFragments(self, fileStore, targetFiles, fragments):
@@ -73,7 +74,8 @@ class LastzRepeatMaskJob(RoundedJob):
                                 self.repeatMaskOptions.lastzOpts.split() +
                                 ["--querydepth=keep,nowarn:%i" % (self.repeatMaskOptions.period+3),
                                  "--format=general:name1,zstart1,end1,name2,zstart2+,end2+",
-                                 "--markend"])
+                                 "--markend"],
+                    fileStore=fileStore)
         return alignment
 
     def maskCoveredIntervals(self, fileStore, queryFile, alignment):
@@ -87,7 +89,8 @@ class LastzRepeatMaskJob(RoundedJob):
                                 "--queryoffsets",
                                 "--origin=one",
                                 # * 2 takes into account the effect of the overlap
-                                "M=%s" % (int(self.repeatMaskOptions.period*2))])
+                                "M=%s" % (int(self.repeatMaskOptions.period*2))],
+                    fileStore=fileStore)
 
         # the previous lastz command outputs a file of intervals (denoted with indices) to softmask.
         # we finish by applying these intervals to the input file, to produce the final, softmasked output. 
@@ -97,7 +100,8 @@ class LastzRepeatMaskJob(RoundedJob):
         args.append(maskInfo)
         maskedQuery = fileStore.getLocalTempFile()
         cactus_call(infile=queryFile, outfile=maskedQuery,
-                    parameters=["cactus_fasta_softmask_intervals.py"] + args)
+                    parameters=["cactus_fasta_softmask_intervals.py"] + args,
+                    fileStore=fileStore)
         return maskedQuery
 
     def run(self, fileStore):

--- a/src/cactus/progressive/cactus_progressive.py
+++ b/src/cactus/progressive/cactus_progressive.py
@@ -420,11 +420,11 @@ def importSingularityImage(options, toil):
                 check_call(["singularity", "build", "-F", "-s", os.path.basename(imgPath) + ".sb", os.path.basename(imgPath)])
                 # the sandbox is a directory.  we tar it up so it get be uploaded to the job store.
                 # note: the python tarfile module seems about 10x slower than just running tar, so we
-                # stick with the latter.  the --format=posix seems to be necessary to avoid encoding errors when
+                # stick with the latter.  the --format=pax seems to be necessary to avoid encoding errors when
                 # tarring/untarring on different systems (ie unicode vs ascii)
                 # we could gzip by using czf instead of cf and .sb.tar.gz instead of .sb.tar below.  but assume for
                 # now that it's faster to download the uncompressed version than it is to decompress it. 
-                check_call(["tar", "--format=posix", "-cf", os.path.basename(imgPath) + ".sb.tar", os.path.basename(imgPath) + ".sb"])
+                check_call(["tar", "--format=pax", "-cf", os.path.basename(imgPath) + ".sb.tar", os.path.basename(imgPath) + ".sb"])
                 # now upload it to the job store
                 singularity_image_id = toil.importFile("file://" + imgPath + ".sb.tar")
                 # any toil job can use this ID to download the sandbox to its local file store

--- a/src/cactus/progressive/cactus_progressive.py
+++ b/src/cactus/progressive/cactus_progressive.py
@@ -420,10 +420,11 @@ def importSingularityImage(options, toil):
                 check_call(["singularity", "build", "-F", "-s", os.path.basename(imgPath) + ".sb", os.path.basename(imgPath)])
                 # the sandbox is a directory.  we tar it up so it get be uploaded to the job store.
                 # note: the python tarfile module seems about 10x slower than just running tar, so we
-                # stick with the latter
+                # stick with the latter.  the --format=posix seems to be necessary to avoid encoding errors when
+                # tarring/untarring on different systems (ie unicode vs ascii)
                 # we could gzip by using czf instead of cf and .sb.tar.gz instead of .sb.tar below.  but assume for
                 # now that it's faster to download the uncompressed version than it is to decompress it. 
-                check_call(["tar", "cf", os.path.basename(imgPath) + ".sb.tar", os.path.basename(imgPath) + ".sb"])
+                check_call(["tar", "--format=posix", "-cf", os.path.basename(imgPath) + ".sb.tar", os.path.basename(imgPath) + ".sb"])
                 # now upload it to the job store
                 singularity_image_id = toil.importFile("file://" + imgPath + ".sb.tar")
                 # any toil job can use this ID to download the sandbox to its local file store

--- a/src/cactus/progressive/cactus_progressive.py
+++ b/src/cactus/progressive/cactus_progressive.py
@@ -415,8 +415,19 @@ def importSingularityImage(options, toil):
                             "docker://" + getDockerImage()])
 
             if Toil.parseLocator(options.jobStore)[0] != "file":
-                # if we are using a remote jobstore, we pop the singularity image inside for future use
-                singularity_image_id = toil.importFile("file://" + imgPath)
+                # convert the image to a sandbox.  this lets it get run with -u, which seems
+                # to be a requirement with toil on kubernetes
+                check_call(["singularity", "build", "-F", "-s", os.path.basename(imgPath) + ".sb", os.path.basename(imgPath)])
+                # the sandbox is a directory.  we tar it up so it get be uploaded to the job store.
+                # note: the python tarfile module seems about 10x slower than just running tar, so we
+                # stick with the latter
+                # we could gzip by using czf instead of cf and .sb.tar.gz instead of .sb.tar below.  but assume for
+                # now that it's faster to download the uncompressed version than it is to decompress it. 
+                check_call(["tar", "cf", os.path.basename(imgPath) + ".sb.tar", os.path.basename(imgPath) + ".sb"])
+                # now upload it to the job store
+                singularity_image_id = toil.importFile("file://" + imgPath + ".sb.tar")
+                # any toil job can use this ID to download the sandbox to its local file store
+                # it will need to be untarred before being run.
                 os.environ["CACTUS_SINGULARITY_IMG_ID"] = singularity_image_id.pack()
                 
             os.chdir(oldCWD)

--- a/src/cactus/progressive/outgroup.py
+++ b/src/cactus/progressive/outgroup.py
@@ -238,7 +238,7 @@ class GreedyOutgroup(object):
 # Only works with leaves for now (ie will never choose ancestor as outgroup)
 #
 class DynamicOutgroup(GreedyOutgroup):
-    def __init__(self):
+    def __init__(self, fileStore=None):
         self.SeqInfo = namedtuple("SeqInfo", "count totalLen umLen n50 umN50")
         self.sequenceInfo = None
         self.numOG = 1
@@ -252,6 +252,7 @@ class DynamicOutgroup(GreedyOutgroup):
         # distance to sequence endpoint where we consider bases unalignable due
         # to fragmentation. 
         self.edgeLen = 100
+        self.fileStore=fileStore
 
     # create map of leaf id -> sequence stats by scanninf the FASTA
     # files.  will be used to determine assembly quality for each input
@@ -482,7 +483,7 @@ class DynamicOutgroup(GreedyOutgroup):
         isCandidate = False
         if self.candidateSet is not None and event in self.candidateSet:
             isCandidate = True
-        analyseOutput = cactus_call(parameters=cmdLine, work_dir=os.path.dirname(faPath), check_output=True)
+        analyseOutput = cactus_call(parameters=cmdLine, work_dir=os.path.dirname(faPath), check_output=True, fileStore=self.fileStore)
         tsIdx = analyseOutput.index("Total-sequences:")
         assert tsIdx >= 0 and tsIdx < len(analyseOutput) - 1
         numSequences = int(analyseOutput[tsIdx + len("Total-sequences:") + 1])

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -915,9 +915,15 @@ def singularityCommand(tool=None,
     else:
         # we assume that we have the image locally
         img_path = os.environ["CACTUS_SINGULARITY_IMG"]
+    
+    if not work_dir:
+        work_dir = os.getcwd()
+    else:
+        work_dir = os.path.abspath(work_dir)
 
-    base_singularity_call = ["singularity", "--silent", "run", img_path]
-    base_singularity_call.extend(parameters)
+    base_singularity_call = ["singularity", "--silent", "run"]
+    base_singularity_call += ["-B", "{}:{}".format(work_dir, "/mnt"), "--pwd", "/mnt"]
+    base_singularity_call += [img_path] + parameters
     return base_singularity_call
 
 def dockerCommand(tool=None,

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -913,7 +913,7 @@ def singularityCommand(tool=None,
             img_path = os.path.join(file_store.getLocalTempDir(), 'cactus.img.sb')
             file_store.readGlobalFile(FileID.unpack(os.environ["CACTUS_SINGULARITY_IMG_ID"]), img_path + '.tar')
             # extract it
-            untar_cmd = ["tar", "xf", os.path.basename(img_path) + '.tar']
+            untar_cmd = ["tar", "--format=pax", "-xf", os.path.basename(img_path) + '.tar']
             subprocess.check_call(untar_cmd, cwd=os.path.dirname(img_path))
             # remember it
             os.environ["CACTUS_SINGULARITY_IMG"] = img_path

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -908,21 +908,21 @@ def singularityCommand(tool=None,
                        parameters=None,
                        port=None,
                        file_store=None):
-    if "CACTUS_SINGULARITY_IMG_ID" in os.environ:
+    if "CACTUS_DOCKER_IMG_ID" in os.environ:
         if "CACTUS_SINGULARITY_IMG" in os.environ and os.path.exists(os.environ["CACTUS_SINGULARITY_IMG"]):
             # we must have already downloaded it in this job
             img_path = os.environ["CACTUS_SINGULARITY_IMG"]
         else:
             # get it from the file store
             img_path = os.path.join(file_store.getLocalTempDir(), 'cactus.img')
-            file_store.readGlobalFile(FileID.unpack(os.environ["CACTUS_SINGULARITY_IMG_ID"]), img_path)
+            file_store.readGlobalFile(FileID.unpack(os.environ["CACTUS_DOCKER_IMG_ID"]), img_path)
                         
             # Extract with a fresh cache to a sandbox
             temp_sandbox_dirname = tempfile.mkdtemp(dir=file_store.getLocalTempDir())                        
             download_env = os.environ.copy()
             download_env['SINGULARITY_CACHEDIR'] = file_store.getLocalTempDir()
             start_time = timeit.default_timer()
-            sb_command = ['singularity', 'build', '-s', '-F', temp_sandbox_dirname, img_path]
+            sb_command = ['singularity', 'build', '-s', '-F', temp_sandbox_dirname, 'docker-archive://' + img_path]
             # todo: *only* do this on kubernetes, it's a waste of time on mesos and local which can use the image directly
             subprocess.check_call(sb_command, env=download_env)
             end_time = timeit.default_timer()
@@ -1191,7 +1191,7 @@ class RoundedJob(Job):
             memory = self.roundUp(memory)
         if disk is not None:
             disk = self.roundUp(disk)
-            if "CACTUS_SINGULARITY_IMG_ID" in os.environ:
+            if "CACTUS_DOCKER_IMG_ID" in os.environ:
                 # downloading and extracting the singularity sandbox takes some extra disk
                 disk += 2500*1024*1024
 


### PR DESCRIPTION
#108 got Cactus working with kubernetes by porting over toil-vg's strategy of making singularity sandboxes on the fly.  It ran through but was quite slow.   This PR uses a different approach:  The kubernetes image gets built once by the leader (just like when running on a local filestore), and the imported into Toil's jobstore. The toil file id's kept in an environment variable, and used to pull the image as needed into a job's filestore. 

The only catch is that the job's filestore needs to be known inside `cactus_call`, which meant updating a zillion caller functions to pass it in.  
