### PR TITLE
added crucial Slurm info for running on clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ Example:
 There isn't much to configure if running locally. Most importantly, if on a shared system, you can adjust the maximum number of processors used with `--maxCores <N>` (by default, Cactus will use all cores).
 ### Running on a cluster
 Cactus (through Toil) supports many batch systems, including LSF, SLURM, GridEngine, Parasol, and Torque. To run on a cluster, simply add `--batchSystem <batchSystem>`, e.g. `--batchSystem gridEngine`. If your batch system needs additional configuration, Toil exposes some [environment variables](http://toil.readthedocs.io/en/3.10.1/developingWorkflows/batchSystem.html#batch-system-enivronmental-variables) that can help.
+
+Note that certain Toil environment options may affect its ability to interact with certain batch systems; for example, Slurm will fail to run jobs if the TOIL_WORKDIR variable (or `--workDir` argument) is not set to a shared location accessible by every worker and the Cactus/Toil processes.
 ### Running on the cloud
 Cactus supports running on AWS, Azure, and Google Cloud Platform using [Toil's autoscaling features](https://toil.readthedocs.io/en/latest/running/cloud/cloud.html). For more details on running in AWS, check out [these instructions](doc/running-in-aws.md) (other clouds are similar).
 ## Using the output


### PR DESCRIPTION
Documentation (for cactus and toil both) should probably clearly mention that (at least for Slurm) the workDir directory needs to be a *shared* location -- not merely exist on login/compute nodes.  Currently, workDir defaults to the system's temp directory which will likely exist on each individual machine, but its files will be externally inaccessible.
Note the solution to this issue appears to be the user setting ~/tmp <-- https://github.com/DataBiosphere/toil/issues/2756