### PR TITLE
Easier build on Ubuntu 18.04 Bionic

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "submodules/cactus2hal"]
 	path = submodules/cactus2hal
 	url = https://github.com/ComparativeGenomicsToolkit/cactus2hal
+[submodule "submodules/kyoto"]
+	path = submodules/kyoto
+	url = https://github.com/ComparativeGenomicsToolkit/kyoto.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: xenial
+dist: bionic
 language: python
 
 python:
@@ -9,11 +9,11 @@ before_install:
   - |
     if [[ "$TRAVIS_OS_NAME" == "linux" && "$CACTUS_BINARIES_MODE" == "local" ]]; then
        sudo apt-get -qq update
-       sudo apt-get install -y libtokyocabinet-dev libkyototycoon-dev kyototycoon libkyotocabinet-dev libhdf5-cpp-11 libhdf5-dev
+       sudo apt-get install -y git gcc g++ build-essential zlib1g-dev wget valgrind libbz2-dev libhiredis-dev pkg-config libhdf5-dev liblzo2-dev
     fi
   - |
     if [[ "$TRAVIS_OS_NAME" == "linux" && "$CACTUS_BINARIES_MODE" == "local" ]]; then
-       sudo apt-get install -y libtokyocabinet-dev libkyototycoon-dev kyototycoon libkyotocabinet-dev libhdf5-cpp-11 libhdf5-dev
+       sudo apt-get install -y git gcc g++ build-essential zlib1g-dev wget valgrind libbz2-dev libhiredis-dev pkg-config libhdf5-dev liblzo2-dev
     fi
   - |
     if [[ ! -z "$SON_TRACE_DATASETS" ]]; then
@@ -37,7 +37,7 @@ script:
   - pip install -e .
   - if [[ "$CACTUS_TEST_CHOICE" == "normal" ]]; then export MAKE_TARGET=test_nonblast; fi
   - if [[ "$CACTUS_TEST_CHOICE" == "blast" ]]; then export MAKE_TARGET=test_blast; fi
-  - if [[ "$CACTUS_BINARIES_MODE" == "local" ]]; then make && PATH=`pwd`/bin:$PATH PYTHONPATH=`pwd`:`pwd`/src travis_wait 50 make ${MAKE_TARGET}; fi
+  - if [[ "$CACTUS_BINARIES_MODE" == "local" ]]; then make && PATH=`pwd`/bin:$PATH PYTHONPATH=`pwd`:`pwd`/src LD_LIBRARY_PATH=`pwd`/lib:${LD_LIBRARY_PATH} travis_wait 50 make ${MAKE_TARGET}; fi
   - if [[ "$CACTUS_BINARIES_MODE" == "docker" ]]; then travis_wait 40 make ${MAKE_TARGET}; fi
 os:
   - linux

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,24 @@
-FROM ubuntu:16.04 AS builder
+FROM ubuntu:bionic-20200112 AS builder
+
 
 RUN apt-get update
-RUN apt-get install -y git gcc g++ build-essential python3 python3-dev zlib1g-dev libkyototycoon-dev libtokyocabinet-dev libkyotocabinet-dev wget valgrind libbz2-dev libhiredis-dev pkg-config libhdf5-cpp-11 libhdf5-dev
+RUN apt-get install -y git gcc g++ build-essential python3 python3-dev zlib1g-dev wget valgrind libbz2-dev libhiredis-dev pkg-config libhdf5-dev liblzo2-dev
 
-ENV kyotoTycoonIncl -I/usr/include -DHAVE_KYOTO_TYCOON=1
-ENV kyotoTycoonLib -L/usr/lib -Wl,-rpath,/usr/lib -lkyototycoon -lkyotocabinet -lz -lbz2 -lpthread -lm -lstdc++
 RUN mkdir -p /home/cactus
 
 COPY . /home/cactus
 
-RUN cd /home/cactus && make -j 10 clean
-RUN cd /home/cactus && make -j 10
+RUN cd /home/cactus && make -j $(nproc) clean
+RUN cd /home/cactus && make -j $(nproc)
 
 # Create a thinner final Docker image in which only the binaries and necessary data exist.
-FROM ubuntu:16.04
+FROM ubuntu:bionic-20200112
 
 RUN apt-get update
 
-RUN apt-get install -y libkyotocabinet-dev libkyototycoon-dev libtokyocabinet-dev python3 zlib1g-dev python3-dev libbz2-dev build-essential python3-pip git kyototycoon net-tools redis-server libhiredis-dev libhdf5-cpp-11
+RUN apt-get install -y python3 zlib1g-dev python3-dev libbz2-dev build-essential python3-pip git net-tools redis-server libhiredis-dev libhdf5-100 liblzo2-2
 COPY --from=builder /home/cactus/bin/* /usr/local/bin/
+COPY --from=builder /home/cactus/lib/* /usr/local/lib/
 COPY --from=builder /home/cactus/submodules/sonLib/bin/* /usr/local/bin/
 COPY --from=builder /home/cactus/submodules/cactus2hal/bin/* /usr/local/bin/
 COPY --from=builder /home/cactus/submodules/sonLib /tmp/sonLib/
@@ -33,5 +33,7 @@ RUN rm -rf /tmp/sonLib
 
 RUN mkdir /data
 WORKDIR /data
+
+ENV LD_LIBRARY_PATH="/usr/local/lib/:${LD_LIBRARY_PATH}"
 
 ENTRYPOINT ["bash", "/opt/cactus/wrapper.sh"]

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ modules = api setup blastLib caf bar blast normalisation hal phylogeny reference
 
 # submodules are in multiple pass to handle dependencies cactus2hal being dependent on
 # both cactus and sonLib
-submodules1 = sonLib cPecan hal matchingAndOrdering pinchesAndCacti
+submodules1 = kyoto sonLib cPecan hal matchingAndOrdering pinchesAndCacti
 submodules2 = cactus2hal
 submodules = ${submodules1} ${submodules2}
 
@@ -121,7 +121,7 @@ ${versionPy}:
 # clean targets
 ##
 selfClean: ${modules:%=clean.%}
-	rm -rf lib/*.h bin/*.dSYM ${versionPy} ${testOutDir}
+	rm -rf include/* lib/*.h bin/*.dSYM ${versionPy} ${testOutDir}
 
 clean.%:
 	cd $* && ${MAKE} clean
@@ -133,7 +133,10 @@ clean: selfClean ${submodules:%=subclean.%}
 ##
 suball1: ${submodules1:%=suball.%}
 suball2: ${submodules2:%=suball.%}
-suball.sonLib:
+suball.kyoto:
+	cd submodules/kyoto && KT_OPTIONS=--disable-lua ${MAKE} PREFIX=${CWD} && ${MAKE} install
+
+suball.sonLib: suball.kyoto
 	cd submodules/sonLib && ${MAKE}
 	mkdir -p bin
 	ln -f submodules/sonLib/bin/[a-zA-Z]* bin/

--- a/README.md
+++ b/README.md
@@ -65,30 +65,26 @@ pip install --upgrade .
 IMPORTANT:  It is highly recommend that one **not** run Cactus using the Toil Grid Engine-like batch systems (GridEngine, HTCondor, LSF, SLURM, or Torque).  Cactus creates a very large number of small jobs, which can overwhelm these systems.
 
 ### Compile Cactus executables (if not using Docker/Singularity)
-By default Cactus uses containers to distribute its binaries, because compiling its dependencies can sometimes be a pain. If you can use Docker or Singularity, *which we highly recommend*, you can skip this section since all that needs to be installed in that case is the Python workflow as described above. However, in some environments (e.g. HPC clusters) you won't be able to use Docker or Singularity, so you will have to compile the binaries and install a few dependencies.
+By default Cactus uses containers to distribute its binaries, because compiling its dependencies can sometimes be a pain. If you can use Docker or Singularity, *which we highly recommend*, you can skip this section since all that needs to be installed in that case is the Python workflow as described above. However, in some environments (e.g. HPC clusters) you won't be able to use Docker or Singularity, so you will have to compile the binaries and install a few dependencies. Looking at the [Dockerfile](Dockerfile) itself can serve as a guide for building on Ubuntu. 
 
-The HDF5 and the KV database KyotoTycoon are compile-time dependencies.
+HDF5 is a compile-time dependencies.
 Compile time settings can be overridden by creating a make include file 
 ```
 include.local.mk
 ```
 in the top level cactus directory.
 
-HDF5 is available through most package managers or can be manual installed from source files at [The HDF Group](https://www.hdfgroup.org/).   HDF5 should be configured with the `--enable-cxx` option. If you've installed it in a non-standard location, have the `h5c++` command in your `PATH` or add this to `include.local.mk`:
+HDF5 is available through most package managers (`apt-get install libhdf5-dev`) or can be manual installed from source files at [The HDF Group](https://www.hdfgroup.org/).   HDF5 should be configured with the `--enable-cxx` option. If you've installed it in a non-standard location, have the `h5c++` command in your `PATH` or add this to `include.local.mk`:
 ```
 export PATH := <hdf5 bin dir>:${PATH}
 ```
 
-KyotoTycoon is available through most package managers under `kyototycoon` or `kyoto-tycoon`. To compile it manually, you are best off using the [unofficial repository](https://github.com/carlosefr/kyoto). If you've installed KyotoTycoon (and its library, KyotoCabinet) from a package manager, you should be OK to go. If you've installed it in a non-standard location, add the following to
-`include.local.mk`:
+KyotoTycoon is compiled as a submodule, but its libraries need to be available at runtime.  One way to do this is to run
 ```
-ttPrefix = <path of the PREFIX where you installed Kyoto>
-export kyotoTycoonIncl = -I${ttPrefix}/include -DHAVE_KYOTO_TYCOON=1
-export kyotoTycoonLib = -L${ttPrefix}/lib -Wl,-rpath,${ttPrefix}/lib -lkyototycoon -lkyotocabinet -lz -lbz2 -lpthread -lm -lstdc++
+export LD_LIBRARY_PATH = <path where cactus is installed>/lib:${LD_LIBRARY_PATH}
 ```
-and copy the `ktserver` binary to somewhere on your PATH, and depending on your install directory, you may also need to add `${ttPrefix}/lib` to your LD_LIBRARY_PATH. 
 
-Once you have HDF5 and KyotoTycoon installed, you should be able to compile Cactus and its dependencies by running:
+Once you have HDF5 installed, you should be able to compile Cactus and its dependencies by running:
 ```
 git submodule update --init
 make

--- a/include.mk
+++ b/include.mk
@@ -35,4 +35,7 @@ inclDirs = api/inc bar/inc caf/inc hal/inc reference/inc submodules/sonLib/C/inc
 
 cflags += ${inclDirs:%=-I${rootPath}/%}
 basicLibs = ${sonLibPath}/sonLib.a ${sonLibPath}/cuTest.a ${dblibs}
-basicLibsDependencies = ${sonLibPath}/sonLib.a ${sonLibPath}/cuTest.a 
+basicLibsDependencies = ${sonLibPath}/sonLib.a ${sonLibPath}/cuTest.a
+
+kyotoTycoonIncl=-I${rootPath}/include -DHAVE_KYOTO_TYCOON=1
+kyotoTycoonLib=-L${rootPath}/lib -Wl,-rpath,${rootPath}/lib -lkyototycoon -lkyotocabinet -lz -lbz2 -lpthread -lm -lstdc++


### PR DESCRIPTION
Cactus has gotten into a bit of a catch 22 lately, making it even more difficult than usual to build.  Python 3.6, now required to run it, is very difficult to install on Ubuntu 16.04 systems.  But Kyoto Tycoon, also required, is very difficult to install on 18.04 systems, especially via apt.  

Personally I've only been able to run it in a combination of environments:  Use the Cactus binaries docker (Ubuntu 16.04) to run containers on a Ubuntu 18.04.  But this mix doesn't work for local setups or the increasing number of people who just want one Docker image where they can run everything.  

So this PR is an attempt to bring the Dockerfile from Ubuntu 16.04 to 18.04, as well as the travis build.  In doing this, it should make it possible for others to use the same invocations to build (and run!) locally on their 18.04 systems.  Once this works and is merged, it should be fairly straightforward to provide an additional Dockerfile that actually has the cactus executable in it. 

Since kyoto tycoon is no longer supported in apt, I added it back as a submodule (via our own fork).   Hurray!  