### PR TITLE
Evolver test script

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "submodules/cactus2hal"]
 	path = submodules/cactus2hal
 	url = https://github.com/ComparativeGenomicsToolkit/cactus2hal
+[submodule "submodules/kyoto"]
+	path = submodules/kyoto
+	url = https://github.com/ComparativeGenomicsToolkit/kyoto.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: xenial
+dist: bionic
 language: python
 
 python:
@@ -9,11 +9,11 @@ before_install:
   - |
     if [[ "$TRAVIS_OS_NAME" == "linux" && "$CACTUS_BINARIES_MODE" == "local" ]]; then
        sudo apt-get -qq update
-       sudo apt-get install -y libtokyocabinet-dev libkyototycoon-dev kyototycoon libkyotocabinet-dev libhdf5-cpp-11 libhdf5-dev
+       sudo apt-get install -y git gcc g++ build-essential zlib1g-dev wget valgrind libbz2-dev libhiredis-dev pkg-config libhdf5-dev liblzo2-dev
     fi
   - |
     if [[ "$TRAVIS_OS_NAME" == "linux" && "$CACTUS_BINARIES_MODE" == "local" ]]; then
-       sudo apt-get install -y libtokyocabinet-dev libkyototycoon-dev kyototycoon libkyotocabinet-dev libhdf5-cpp-11 libhdf5-dev
+       sudo apt-get install -y git gcc g++ build-essential zlib1g-dev wget valgrind libbz2-dev libhiredis-dev pkg-config libhdf5-dev liblzo2-dev
     fi
   - |
     if [[ ! -z "$SON_TRACE_DATASETS" ]]; then
@@ -37,7 +37,7 @@ script:
   - pip install -e .
   - if [[ "$CACTUS_TEST_CHOICE" == "normal" ]]; then export MAKE_TARGET=test_nonblast; fi
   - if [[ "$CACTUS_TEST_CHOICE" == "blast" ]]; then export MAKE_TARGET=test_blast; fi
-  - if [[ "$CACTUS_BINARIES_MODE" == "local" ]]; then make && PATH=`pwd`/bin:$PATH PYTHONPATH=`pwd`:`pwd`/src travis_wait 50 make ${MAKE_TARGET}; fi
+  - if [[ "$CACTUS_BINARIES_MODE" == "local" ]]; then make && PATH=`pwd`/bin:$PATH PYTHONPATH=`pwd`:`pwd`/src LD_LIBRARY_PATH=`pwd`/lib:${LD_LIBRARY_PATH} travis_wait 50 make ${MAKE_TARGET}; fi
   - if [[ "$CACTUS_BINARIES_MODE" == "docker" ]]; then travis_wait 40 make ${MAKE_TARGET}; fi
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ before_install:
   - |
     if [[ "$TRAVIS_OS_NAME" == "linux" && "$CACTUS_BINARIES_MODE" == "local" ]]; then
        sudo apt-get -qq update
-       sudo apt-get install -y git gcc g++ build-essential zlib1g-dev wget valgrind libbz2-dev libhiredis-dev pkg-config libhdf5-dev liblzo2-dev
+       sudo apt-get install -y git gcc g++ build-essential zlib1g-dev wget valgrind libbz2-dev libhiredis-dev pkg-config libhdf5-dev liblzo2-dev libtokyocabinet-dev
     fi
   - |
     if [[ "$TRAVIS_OS_NAME" == "linux" && "$CACTUS_BINARIES_MODE" == "local" ]]; then
-       sudo apt-get install -y git gcc g++ build-essential zlib1g-dev wget valgrind libbz2-dev libhiredis-dev pkg-config libhdf5-dev liblzo2-dev
+       sudo apt-get install -y git gcc g++ build-essential zlib1g-dev wget valgrind libbz2-dev libhiredis-dev pkg-config libhdf5-dev liblzo2-dev libtokyocabinet-dev
     fi
   - |
     if [[ ! -z "$SON_TRACE_DATASETS" ]]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,24 @@
-FROM ubuntu:16.04 AS builder
+FROM ubuntu:bionic-20200112 AS builder
+
 
 RUN apt-get update
-RUN apt-get install -y git gcc g++ build-essential python3 python3-dev zlib1g-dev libkyototycoon-dev libtokyocabinet-dev libkyotocabinet-dev wget valgrind libbz2-dev libhiredis-dev pkg-config libhdf5-cpp-11 libhdf5-dev
+RUN apt-get install -y git gcc g++ build-essential python3 python3-dev zlib1g-dev wget valgrind libbz2-dev libhiredis-dev pkg-config libhdf5-dev liblzo2-dev
 
-ENV kyotoTycoonIncl -I/usr/include -DHAVE_KYOTO_TYCOON=1
-ENV kyotoTycoonLib -L/usr/lib -Wl,-rpath,/usr/lib -lkyototycoon -lkyotocabinet -lz -lbz2 -lpthread -lm -lstdc++
 RUN mkdir -p /home/cactus
 
 COPY . /home/cactus
 
-RUN cd /home/cactus && make -j 10 clean
-RUN cd /home/cactus && make -j 10
+RUN cd /home/cactus && make -j $(nproc) clean
+RUN cd /home/cactus && make -j $(nproc)
 
 # Create a thinner final Docker image in which only the binaries and necessary data exist.
-FROM ubuntu:16.04
+FROM ubuntu:bionic-20200112
 
 RUN apt-get update
 
-RUN apt-get install -y libkyotocabinet-dev libkyototycoon-dev libtokyocabinet-dev python3 zlib1g-dev python3-dev libbz2-dev build-essential python3-pip git kyototycoon net-tools redis-server libhiredis-dev libhdf5-cpp-11
+RUN apt-get install -y python3 zlib1g-dev python3-dev libbz2-dev build-essential python3-pip git net-tools redis-server libhiredis-dev libhdf5-100 liblzo2-2
 COPY --from=builder /home/cactus/bin/* /usr/local/bin/
+COPY --from=builder /home/cactus/lib/* /usr/local/lib/
 COPY --from=builder /home/cactus/submodules/sonLib/bin/* /usr/local/bin/
 COPY --from=builder /home/cactus/submodules/cactus2hal/bin/* /usr/local/bin/
 COPY --from=builder /home/cactus/submodules/sonLib /tmp/sonLib/
@@ -33,5 +33,7 @@ RUN rm -rf /tmp/sonLib
 
 RUN mkdir /data
 WORKDIR /data
+
+ENV LD_LIBRARY_PATH="/usr/local/lib/:${LD_LIBRARY_PATH}"
 
 ENTRYPOINT ["bash", "/opt/cactus/wrapper.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:bionic-20200112 AS builder
 
 
 RUN apt-get update
-RUN apt-get install -y git gcc g++ build-essential python3 python3-dev zlib1g-dev wget valgrind libbz2-dev libhiredis-dev pkg-config libhdf5-dev liblzo2-dev
+RUN apt-get install -y git gcc g++ build-essential python3 python3-dev zlib1g-dev wget valgrind libbz2-dev libhiredis-dev pkg-config libhdf5-dev liblzo2-dev libtokyocabinet-dev
 
 RUN mkdir -p /home/cactus
 
@@ -16,7 +16,7 @@ FROM ubuntu:bionic-20200112
 
 RUN apt-get update
 
-RUN apt-get install -y python3 zlib1g-dev python3-dev libbz2-dev build-essential python3-pip git net-tools redis-server libhiredis-dev libhdf5-100 liblzo2-2
+RUN apt-get install -y python3 zlib1g-dev python3-dev libbz2-dev build-essential python3-pip git net-tools redis-server libhiredis-dev libhdf5-100 liblzo2-2 libtokyocabinet-dev
 COPY --from=builder /home/cactus/bin/* /usr/local/bin/
 COPY --from=builder /home/cactus/lib/* /usr/local/lib/
 COPY --from=builder /home/cactus/submodules/sonLib/bin/* /usr/local/bin/

--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,11 @@ test_nonblast: ${testModules:%=%_runtest_nonblast}
 ${versionPy}:
 	echo "cactus_commit = '${git_commit}'" >$@
 
+evolver_test:
+	-docker rmi -f evolvertestdocker/cactus:latest
+	docker build --network=host -t evolvertestdocker/cactus:latest . --build-arg CACTUS_COMMIT=${git_commit}
+	PYTHONPATH="" CACTUS_DOCKER_ORG=evolvertestdocker ${PYTHON} -m pytest -s ${pytestOpts} test
+	docker rmi -f evolvertestdocker/cactus:latest
 
 ##
 # clean targets

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ suball.kyoto:
 	cd submodules/kyoto && KT_OPTIONS=--disable-lua ${MAKE} PREFIX=${CWD} && ${MAKE} install
 
 suball.sonLib: suball.kyoto
-	cd submodules/sonLib && ${MAKE}
+	cd submodules/sonLib && PKG_CONFIG_PATH=${CWD}/lib/pkgconfig:${PKG_CONFIG_PATH} ${MAKE}
 	mkdir -p bin
 	ln -f submodules/sonLib/bin/[a-zA-Z]* bin/
 

--- a/Makefile
+++ b/Makefile
@@ -116,10 +116,10 @@ test_nonblast: ${testModules:%=%_runtest_nonblast}
 ${versionPy}:
 	echo "cactus_commit = '${git_commit}'" >$@
 
-evolver_test:
+evolver_test: all
 	-docker rmi -f evolvertestdocker/cactus:latest
 	docker build --network=host -t evolvertestdocker/cactus:latest . --build-arg CACTUS_COMMIT=${git_commit}
-	PYTHONPATH="" CACTUS_DOCKER_ORG=evolvertestdocker ${PYTHON} -m pytest -s ${pytestOpts} test
+	LD_LIBARY_PATH=${PWD}/lib:${LD_LIBARY_PATH} PYTHONPATH="" CACTUS_DOCKER_ORG=evolvertestdocker ${PYTHON} -m pytest -s ${pytestOpts} test
 	docker rmi -f evolvertestdocker/cactus:latest
 
 ##

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ modules = api setup blastLib caf bar blast normalisation hal phylogeny reference
 
 # submodules are in multiple pass to handle dependencies cactus2hal being dependent on
 # both cactus and sonLib
-submodules1 = sonLib cPecan hal matchingAndOrdering pinchesAndCacti
+submodules1 = kyoto sonLib cPecan hal matchingAndOrdering pinchesAndCacti
 submodules2 = cactus2hal
 submodules = ${submodules1} ${submodules2}
 
@@ -121,7 +121,7 @@ ${versionPy}:
 # clean targets
 ##
 selfClean: ${modules:%=clean.%}
-	rm -rf lib/*.h bin/*.dSYM ${versionPy} ${testOutDir}
+	rm -rf include/* lib/*.h bin/*.dSYM ${versionPy} ${testOutDir}
 
 clean.%:
 	cd $* && ${MAKE} clean
@@ -133,7 +133,10 @@ clean: selfClean ${submodules:%=subclean.%}
 ##
 suball1: ${submodules1:%=suball.%}
 suball2: ${submodules2:%=suball.%}
-suball.sonLib:
+suball.kyoto:
+	cd submodules/kyoto && KT_OPTIONS=--disable-lua ${MAKE} PREFIX=${CWD} && ${MAKE} install
+
+suball.sonLib: suball.kyoto
 	cd submodules/sonLib && ${MAKE}
 	mkdir -p bin
 	ln -f submodules/sonLib/bin/[a-zA-Z]* bin/

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ python3 -m pip install virtualenv
 
 To set up a virtual environment in the directory `cactus_env`, run:
 ```
-python3 -m virtualenv cactus_env
+virtualenv -p python3.6 cactus_env
 ```
 
 Then, to enter the virtualenv, run:

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ IMPORTANT:  It is highly recommend that one **not** run Cactus using the Toil Gr
 ### Compile Cactus executables (if not using Docker/Singularity)
 By default Cactus uses containers to distribute its binaries, because compiling its dependencies can sometimes be a pain. If you can use Docker or Singularity, *which we highly recommend*, you can skip this section since all that needs to be installed in that case is the Python workflow as described above. However, in some environments (e.g. HPC clusters) you won't be able to use Docker or Singularity, so you will have to compile the binaries and install a few dependencies. Looking at the [Dockerfile](Dockerfile) itself can serve as a guide for building on Ubuntu. 
 
-HDF5 is a compile-time dependencies.
+HDF5 is a compile-time dependency.
 Compile time settings can be overridden by creating a make include file 
 ```
 include.local.mk

--- a/README.md
+++ b/README.md
@@ -68,30 +68,26 @@ IMPORTANT:  The `--recursive` option is required to download submodules.  If you
 IMPORTANT:  It is highly recommend that one **not** run Cactus using the Toil Grid Engine-like batch systems (GridEngine, HTCondor, LSF, SLURM, or Torque).  Cactus creates a very large number of small jobs, which can overwhelm these systems.
 
 ### Compile Cactus executables (if not using Docker/Singularity)
-By default Cactus uses containers to distribute its binaries, because compiling its dependencies can sometimes be a pain. If you can use Docker or Singularity, *which we highly recommend*, you can skip this section since all that needs to be installed in that case is the Python workflow as described above. However, in some environments (e.g. HPC clusters) you won't be able to use Docker or Singularity, so you will have to compile the binaries and install a few dependencies.
+By default Cactus uses containers to distribute its binaries, because compiling its dependencies can sometimes be a pain. If you can use Docker or Singularity, *which we highly recommend*, you can skip this section since all that needs to be installed in that case is the Python workflow as described above. However, in some environments (e.g. HPC clusters) you won't be able to use Docker or Singularity, so you will have to compile the binaries and install a few dependencies. Looking at the [Dockerfile](Dockerfile) itself can serve as a guide for building on Ubuntu. 
 
-The HDF5 and the KV database KyotoTycoon are compile-time dependencies.
+HDF5 is a compile-time dependencies.
 Compile time settings can be overridden by creating a make include file 
 ```
 include.local.mk
 ```
 in the top level cactus directory.
 
-HDF5 is available through most package managers or can be manual installed from source files at [The HDF Group](https://www.hdfgroup.org/).   HDF5 should be configured with the `--enable-cxx` option. If you've installed it in a non-standard location, have the `h5c++` command in your `PATH` or add this to `include.local.mk`:
+HDF5 is available through most package managers (`apt-get install libhdf5-dev`) or can be manual installed from source files at [The HDF Group](https://www.hdfgroup.org/).   HDF5 should be configured with the `--enable-cxx` option. If you've installed it in a non-standard location, have the `h5c++` command in your `PATH` or add this to `include.local.mk`:
 ```
 export PATH := <hdf5 bin dir>:${PATH}
 ```
 
-KyotoTycoon is available through most package managers under `kyototycoon` or `kyoto-tycoon`. To compile it manually, you are best off using the [unofficial repository](https://github.com/carlosefr/kyoto). If you've installed KyotoTycoon (and its library, KyotoCabinet) from a package manager, you should be OK to go. If you've installed it in a non-standard location, add the following to
-`include.local.mk`:
+KyotoTycoon is compiled as a submodule, but its libraries need to be available at runtime.  One way to do this is to run
 ```
-ttPrefix = <path of the PREFIX where you installed Kyoto>
-export kyotoTycoonIncl = -I${ttPrefix}/include -DHAVE_KYOTO_TYCOON=1
-export kyotoTycoonLib = -L${ttPrefix}/lib -Wl,-rpath,${ttPrefix}/lib -lkyototycoon -lkyotocabinet -lz -lbz2 -lpthread -lm -lstdc++
+export LD_LIBRARY_PATH = <path where cactus is installed>/lib:${LD_LIBRARY_PATH}
 ```
-and copy the `ktserver` binary to somewhere on your PATH, and depending on your install directory, you may also need to add `${ttPrefix}/lib` to your LD_LIBRARY_PATH. 
 
-Once you have HDF5 and KyotoTycoon installed, you should be able to compile Cactus and its dependencies by running:
+Once you have HDF5 installed, you should be able to compile Cactus and its dependencies by running:
 ```
 git submodule update --init
 make

--- a/include.mk
+++ b/include.mk
@@ -35,4 +35,7 @@ inclDirs = api/inc bar/inc caf/inc hal/inc reference/inc submodules/sonLib/C/inc
 
 cflags += ${inclDirs:%=-I${rootPath}/%}
 basicLibs = ${sonLibPath}/sonLib.a ${sonLibPath}/cuTest.a ${dblibs}
-basicLibsDependencies = ${sonLibPath}/sonLib.a ${sonLibPath}/cuTest.a 
+basicLibsDependencies = ${sonLibPath}/sonLib.a ${sonLibPath}/cuTest.a
+
+kyotoTycoonIncl=-I${rootPath}/include -DHAVE_KYOTO_TYCOON=1
+kyotoTycoonLib=-L${rootPath}/lib -Wl,-rpath,${rootPath}/lib -lkyototycoon -lkyotocabinet -lz -lbz2 -lpthread -lm -lstdc++

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -19,7 +19,6 @@ import time
 import signal
 import hashlib
 import tempfile
-import timeit
 
 from urllib.parse import urlparse
 from datetime import datetime
@@ -944,10 +943,9 @@ def singularityCommand(tool=None,
             build_cmd = ['singularity', 'build', '-s', '-F', temp_sandbox_dirname, tool]
 
             cactus_realtime_log_info("Running the command: \"{}\"".format(' '.join(build_cmd)))
-            start_time = timeit.default_timer()
+            start_time = time.time()
             subprocess.check_call(build_cmd, env=download_env)
-            end_time = timeit.default_timer()
-            run_time = end_time - start_time
+            run_time = time.time() - start_time
             cactus_realtime_log_info("Successfully ran the command: \"{}\" in {} seconds".format(' '.join(build_cmd), run_time))
 
             # Clean up the Singularity cache since it is single use
@@ -1116,25 +1114,10 @@ def cactus_call(tool=None,
 
     _log.info("Running the command %s" % call)
     cactus_realtime_log_info("Running the command: \"{}\"".format(' '.join(call)))
-    start_time = timeit.default_timer()
     process = subprocess.Popen(call, shell=shell, encoding="ascii",
                                stdin=stdinFileHandle, stdout=stdoutFileHandle,
                                stderr=subprocess.PIPE if swallowStdErr else sys.stderr,
                                bufsize=-1)
-
-    if mode == "singularity":
-        # After Singularity exits, it is possible that cleanup of the container's
-        # temporary files is still in progress (sicne it also waits for the
-        # container to exit). If we return immediately and the Toil job then
-        # immediately finishes, we can have a race between Toil's temp
-        # cleanup/space tracking code and Singularity's temp cleanup code to delete
-        # the same directory tree. Toil doesn't handle this well, and crashes when
-        # files it expected to be able to see are missing (at least on some
-        # versions). So we introduce a delay here to try and make sure that
-        # Singularity wins the race with high probability.
-        #
-        # See https://github.com/sylabs/singularity/issues/1255
-        time.sleep(0.5)
 
     if server:
         return process
@@ -1167,8 +1150,7 @@ def cactus_call(tool=None,
                                                            json.dumps(features), memUsage))
 
     if process.returncode == 0:
-        end_time = timeit.default_timer()
-        run_time = end_time - start_time
+        run_time = time.time() - start_time
         cactus_realtime_log_info("Successfully ran the command: \"{}\" in {} seconds".format(' '.join(call), run_time))
 
     if check_result:

--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -1,0 +1,109 @@
+import os
+import pytest
+import unittest
+import subprocess
+from sonLib.bioio import getTempDirectory
+
+class TestCase(unittest.TestCase):
+    def setUp(self):
+        self.tempDir = getTempDirectory(os.getcwd())
+        unittest.TestCase.setUp(self)
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        os.system("rm -rf %s" % self.tempDir)
+
+    def _job_store(self, binariesMode):
+        return os.path.join(self.tempDir, 'js-{}'.format(binariesMode))
+
+    def _out_hal(self, binariesMode):
+        return os.path.join(self.tempDir, 'evovler-{}.hal'.format(binariesMode))
+
+    def _run_evolver(self, binariesMode):
+        """ Run the full evolver test, putting the jobstore and output in tempDir 
+        """
+        cmd = ['cactus', self._job_store(binariesMode), './examples/evolverMammals.txt', self._out_hal(binariesMode),
+                               '--binariesMode', binariesMode, '--logInfo', '--realTimeLogging', '--workDir', self.tempDir]
+        # todo: it'd be nice to have an interface for setting tag to something not latest or commit
+        if binariesMode == 'docker':
+            cmd += ['--latest']
+            
+        subprocess.check_call(' '.join(cmd), shell=True)
+
+    def _check_stats(self, halPath, delta_pct=0.25):
+        """ Compare halStats otuput of given file to baseline 
+        """
+        # this is just pasted from a successful run.  it will be used to catch serious regressions
+        ground_truth = '''Anc0, 2, 545125, 9, 0, 14471
+        Anc1, 2, 569645, 6, 16862, 54019
+        simHuman_chr6, 0, 601863, 1, 53463, 0
+        mr, 2, 611571, 3, 52338, 55582
+        simMouse_chr6, 0, 636262, 1, 56172, 0
+        simRat_chr6, 0, 647215, 1, 55687, 0
+        Anc2, 2, 577109, 15, 17350, 57130
+        simCow_chr6, 0, 602619, 1, 56309, 0
+        simDog_chr6, 0, 593897, 1, 55990, 0'''
+
+        # run halStats on the evolver output
+        proc = subprocess.Popen(['bin/halStats',  halPath], stdout=subprocess.PIPE)
+        output, errors = proc.communicate()
+        sts = proc.wait()
+        self.assertEqual(sts, 0)
+        output_stats = ''
+        skip=True
+        
+        # filter out everything but the csv stats from the halStats output
+        for line in output.decode("utf-8").split('\n'):
+            toks = [tok.strip() for tok in str(line).split(',')]
+            if skip:
+                if 'GenomeName' in toks and 'NumChildren' in toks:
+                    skip = False                    
+            else:
+                output_stats += line + '\n'
+
+        # convert csv to dict
+        def csv_to_table(s):
+            t = {}
+            for line in s.split('\n'):
+                toks = [tok.strip() for tok in line.strip().split(',')]
+                if len(toks) == 6:
+                    t[toks[0]] = toks[1:]
+            return t
+
+        # make sure the stats are roughly the same
+        truth_table = csv_to_table(ground_truth)
+        output_table = csv_to_table(output_stats)
+        self.assertEqual(len(truth_table), len(output_table))
+        for key, val in truth_table.items():
+            self.assertTrue(key in output_table)
+            oval = output_table[key]
+            self.assertEqual(len(val), len(oval))
+            for i in range(len(val)):
+                delta = delta_pct * int(val[i])
+                self.assertGreaterEqual(int(oval[i]), int(val[i]) - delta_pct)
+                self.assertLessEqual(int(oval[i]), int(val[i]) + delta_pct)
+            
+    def testEvolverLocal(self):
+        """ Check that the output of halStats on a hal file produced by running cactus with --binariesMode local is 
+        is reasonable
+        """
+        # run cactus
+        self._run_evolver("local")
+
+        # check the output
+        self._check_stats(self._out_hal("local"))
+
+    def testEvolverDocker(self):
+        """ Check that the output of halStats on a hal file produced by running cactus with --binariesMode docker is 
+        is reasonable.  Note: the local image being tested should be set up via CACTUS_DOCKER_ORG (with tag==latest)
+        """
+        # run cactus
+        self._run_evolver("docker")
+
+        # check the output
+        self._check_stats(self._out_hal("docker"))
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -34,15 +34,15 @@ class TestCase(unittest.TestCase):
         """ Compare halStats otuput of given file to baseline 
         """
         # this is just pasted from a successful run.  it will be used to catch serious regressions
-        ground_truth = '''Anc0, 2, 545125, 9, 0, 14471
-        Anc1, 2, 569645, 6, 16862, 54019
-        simHuman_chr6, 0, 601863, 1, 53463, 0
-        mr, 2, 611571, 3, 52338, 55582
-        simMouse_chr6, 0, 636262, 1, 56172, 0
-        simRat_chr6, 0, 647215, 1, 55687, 0
-        Anc2, 2, 577109, 15, 17350, 57130
-        simCow_chr6, 0, 602619, 1, 56309, 0
-        simDog_chr6, 0, 593897, 1, 55990, 0'''
+        ground_truth = '''Anc0, 2, 543803, 22, 0, 5169
+        Anc1, 2, 568840, 32, 7511, 33681
+        simHuman_chr6, 0, 601863, 1, 33051, 0
+        mr, 2, 611438, 17, 31652, 34064
+        simMouse_chr6, 0, 636262, 1, 34566, 0
+        simRat_chr6, 0, 647215, 1, 34080, 0
+        Anc2, 2, 576869, 49, 8024, 36376
+        simCow_chr6, 0, 602619, 1, 35306, 0
+        simDog_chr6, 0, 593897, 1, 35153, 0'''
 
         # run halStats on the evolver output
         proc = subprocess.Popen(['bin/halStats',  halPath], stdout=subprocess.PIPE)
@@ -79,9 +79,17 @@ class TestCase(unittest.TestCase):
             oval = output_table[key]
             self.assertEqual(len(val), len(oval))
             for i in range(len(val)):
-                delta = delta_pct * int(val[i])
-                self.assertGreaterEqual(int(oval[i]), int(val[i]) - delta_pct)
-                self.assertLessEqual(int(oval[i]), int(val[i]) + delta_pct)
+                is_leaf = key.startswith('sim')
+                # exact comparison for NumChildren and, for leaves, Lengh and NumSequences
+                exact_comp = i == 0 or (is_leaf and i in [1,2])
+                # no comparison for NumSequences in Ancestors as it seems to be all over the place
+                no_comp = i == 2 and not is_leaf
+                if exact_comp:
+                    self.assertEqual(int(oval[i]), int(val[i]))
+                elif not no_comp:
+                    delta = delta_pct * int(val[i])
+                    self.assertGreaterEqual(int(oval[i]), int(val[i]) - delta)
+                    self.assertLessEqual(int(oval[i]), int(val[i]) + delta)
             
     def testEvolverLocal(self):
         """ Check that the output of halStats on a hal file produced by running cactus with --binariesMode local is 


### PR DESCRIPTION
`ktserver` and the `cactus` command line and `hal` output aren't covered by the current unit tests.  So relying on `make test`, as is implemented in Travis, can miss fairly major regressions.  

To get around this, I've been running the evolver example by hand and awful lot.  This script makes that slightly less annoying by having
```
make evolver_test
```
run the whole pipeline on the whole evolver tree twice: once on local binaries, and once with on (a locally built) docker image. 

If everything runs through, the test will pass if the output of halStats looks something like (<25% different) the output of the current version.  This ought to catch stuff like empty or corrupt hal files or missing genomes.  There are probably some easy improvements (coverage? exact sequence length / fasta check?)

Hopefully this can make it to gitlab as a barrier to merging into master at some point.  It's about 1.5 hours on my desktop which would be about $0.60 on a c5.4xlarge on the spot market.   



