### PR TITLE
Harmonize cactus_config.xml and cactus_progressive_config.xml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ ${versionPy}:
 evolver_test: all
 	-docker rmi -f evolvertestdocker/cactus:latest
 	docker build --network=host -t evolvertestdocker/cactus:latest . --build-arg CACTUS_COMMIT=${git_commit}
-	LD_LIBARY_PATH=${PWD}/lib:${LD_LIBARY_PATH} PYTHONPATH="" CACTUS_DOCKER_ORG=evolvertestdocker ${PYTHON} -m pytest -s ${pytestOpts} test
+	LD_LIBRARY_PATH=${PWD}/lib:${LD_LIBARY_PATH} PYTHONPATH="" CACTUS_DOCKER_ORG=evolvertestdocker ${PYTHON} -m pytest -s ${pytestOpts} test
 	docker rmi -f evolvertestdocker/cactus:latest
 
 ##

--- a/src/cactus/cactus_config.xml
+++ b/src/cactus/cactus_config.xml
@@ -1,77 +1,261 @@
-<?xml version="1.0" ?>
+<!-- This XML tree contains the parameters to cactus_progressive.py -->
+<!-- The distanceToAddToRootAlignment parameter is how much extra divergence distance to allow when aligning children of the root genome -->
 <cactusWorkflowConfig distanceToAddToRootAlignment="0.1">
-	<constants defaultCpu="1" defaultMemory="mediumMemory" defaultOverlargeCpu="1" defaultOverlargeMemory="mediumMemory">
-		  
-		<defines bigMemory="5000000000" littleMemory="2000000000" mediumMemory="3500000000"/>
-		    
-		<divergences five="0.35" four="0.25" one="0.1" three="0.2" two="0.15" useDefault="0"/>
+	<constants defaultMemory="mediumMemory" defaultOverlargeMemory="mediumMemory" defaultCpu="1" defaultOverlargeCpu="1">
+		<!-- These constants are used to control the amount of memory and cpu the different jobs in a batch are using. -->
+  		<defines littleMemory="2000000000" mediumMemory="3500000000" bigMemory="5000000000"/>
+  		<!-- These constants are used to control parameters that depend on phylogenetic distance. Setting
+  		     useDefault to 0 will force it to use the default divergence controlled parameter -->
+  		<divergences useDefault="0" one="0.1" two="0.15" three="0.2" four="0.25" five="0.35"/>
 	</constants>
-	<preprocessor check="1" checkAssemblyHub="0" memory="littleMemory" preprocessJob="checkUniqueHeaders"/>
-	<preprocessor chunkSize="3000000" lastzOpts="--step=3 --ambiguous=iupac,100,100 --ungapped --queryhsplimit=keep,nowarn:1500" memory="littleMemory" minPeriod="50" preprocessJob="lastzRepeatMask" proportionToSample="0.2" unmask="0"/>
-	                                                                                        
-	<trimBlast doTrimStrategy="1" keepParalogs="0" trimFlanking="10" trimMinSize="100" trimOutgroupDepth="1" trimOutgroupFlanking="2000" trimThreshold="1.0" trimWindowSize="1"/>
+	<!-- The preprocessor tags are used to modify/check the input sequences before alignment -->
+	<!-- The first preprocessor tag checks that the first word of every fasta header is unique, as this is required for HAL. It throws errors if this is not the case -->
+	<!-- The checkAssemblyHub option (if enabled) ensures that the first word contains only alphanumeric or '_', '-', ':', or '.' characters, and is unique. If you don't intend to make an assembly hub, you can turn off this option here. -->
+	<preprocessor check="1" memory="littleMemory" preprocessJob="checkUniqueHeaders" checkAssemblyHub="1"/>
+	<!-- The preprocessor for cactus_lastzRepeatMask masks every seed that is part of more than XX other alignments, this stops a combinatorial explosion in pairwise alignments -->
+	<preprocessor unmask="0" chunkSize="3000000" proportionToSample="0.2" memory="littleMemory" preprocessJob="lastzRepeatMask" minPeriod="50" lastzOpts='--step=3 --ambiguous=iupac,100,100 --ungapped --queryhsplimit=keep,nowarn:1500'/>
+        <!-- Options for trimming ingroups & outgroups using the trim strategy -->
+        <!-- Ingroup trim options: -->
+        <!-- trimFlanking: The length of flanking sequence to attach
+             to the trimmed ingroup sequences -->
+        <!-- trimMinSize: The minimum size of uncovered regions
+             (*before* adding flanking sequence) to output from the
+             trimming process -->
+        <!-- trimThreshold: The minimum fraction of bases in a window
+             that must have coverage >= 1 for it to be considered
+             "covered" and be trimmed away and not be aligned against
+             the next outgroup -->
+        <!-- trimWindowSize: The size of the window to integrate
+             coverage over -->
+        <!-- trimOutgroupDepth: The minimum number of outgroup species
+             that should be aligned to a region before it is trimmed
+             away -->
+        <!-- Outgroup trim options: -->
+        <!-- trimOutgroupFlanking: The amount of flanking sequence to
+             leave on the ends of the trimmed outgroup fragments. NB:
+             this value must be larger than the
+             'splitIndelsLongerThanThis' value in the realign
+             arguments -->
+
+        <!-- keepParalogs: Always align duplicated sequence against
+             all outgroups, instead of stopping at the first
+             one. Intended to be robust against missing data.-->
+        <trimBlast doTrimStrategy="1"
+                   trimFlanking="10"
+                   trimMinSize="100"
+                   trimThreshold="1.0"
+                   trimWindowSize="1"
+                   trimOutgroupFlanking="2000"
+                   trimOutgroupDepth="1"
+                   keepParalogs="0"/>
 	<ktserver memory="mediumMemory"/>
 	<setup makeEventHeadersAlphaNumeric="0"/>
-	        
-	<caf alignmentFilter="filterSecondariesByMultipleSpecies" alpha="0.001" annealingRounds="128" blockTrim="5" chunkSize="25000000" compressFiles="1" deannealingRounds="2 8" doPhylogeny="0" filterByIdentity="0" identityRatio="3" lastzDisk="mediumDisk" lastzMemory="littleMemory" maxAdjacencyComponentSizeRatio="50" maxAlignmentsPerSite="5" maxRecoverableChainLength="500000" maxRecoverableChainsIterations="5" maximumMedianSequenceLengthBetweenLinkedEnds="1000" minLengthForChromosome="1000000" minimumBlockDegree="2" minimumBlockDegreeToCheckSupport="10" minimumBlockHomologySupport="0.05" minimumDistance="0.01" minimumIngroupDegree="1" minimumMapQValue="0.0" minimumNumberOfSpecies="1" minimumOutgroupDegree="0" minimumSequenceLengthForBlast="30" minimumTreeCoverage="0.0" numTreeBuildingThreads="2" overlapSize="10000" phylogenyBreakpointScalingFactor="1.0" phylogenyCostPerDupPerBase="0.00" phylogenyCostPerLossPerBase="0.02" phylogenyDistanceCorrectionMethod="jukesCantor" phylogenyDoSplitsWithSupportHigherThanThisAllAtOnce="0.44" phylogenyHomologyUnitType="chain" phylogenyKeepSingleDegreeBlocks="0" phylogenyMaxBaseDistance="100" phylogenyMaxBlockDistance="50" phylogenyNumTrees="30" phylogenyRootingMethod="bestRecon" phylogenyScoringMethod="reconCost" phylogenySkipSingleCopyBlocks="1" phylogenyTreeBuildingMethod="guidedNeighborJoining,splitDecomposition" proportionOfUnalignedBasesForNewChromosome="0.8" realign="1" realignArguments="--gapGamma 0.0 --matchGamma 0.9 --diagonalExpansion 4 --splitMatrixBiggerThanThis 10 --constraintDiagonalTrim 0 --alignAmbiguityCharacters --splitIndelsLongerThanThis 99" removeRecoverableChains="unequalNumberOfIngroupCopies" runMapQFiltering="1" trim="0 0">
-		<divergence argName="lastzArguments" default="--step=1 --ambiguous=iupac,100,100 --ydrop=3000" five="--step=2 --ambiguous=iupac,100,100 --ydrop=3000" four="--step=3 --ambiguous=iupac,100,100 --ydrop=3000" one="--step=2 --ambiguous=iupac,100,100 --ydrop=3000 --notransition" three="--step=4 --ambiguous=iupac,100,100 --ydrop=3000" two="--step=5 --ambiguous=iupac,100,100 --ydrop=3000"/>
+	<!-- The caf tag contains parameters for the caf algorithm. -->
+	<!-- Increase the chunkSize in the caf tag to reduce the number of blast jobs approximately quadratically -->
+        <!-- Tree-building options:
+                phylogenyNumTrees: Number of trees to sample
+                phylogenyRootingMethod: one of "bestRecon", "longestBranch", or "outgroupBranch".
+                                        bestRecon: choose the root that gives the lowest MP reconciliation cost.
+                                        longestBranch: root on the longest branch
+                                        outgroupBranch: root on the longest outgroup branch
+                phylogenyScoringMethod: The best tree according to one of these scoring metirc is used. One of "reconCost", "nucLikelihood", "reconLikelihood", or "combinedLikelihood".
+                                        reconCost: MP reconciliation cost (in dups/losses)
+                                        nucLikelihood: Likelihood
+                                        reconLikelihood: likelihood when considering the number of duplications per species as Poisson distributed according to the branch length.
+                                        combinedLikelihood: Combination of nucLikelihood and reconLikelihood options.
+                phylogenyBreakpointScalingFactor: weight to apply to the breakpoint information obtained from the sequence graph when building trees.
+                phylogenySkipSingleCopyBlocks: whether or not to skip blocks that contain at most one segment per species (i.e. no duplication is implied from the block).
+                phylogenyMaxBaseDistance: Maximum distance (in bases) to traverse looking for columns.
+                phylogenyMaxBlockDistance: Maximum distance (in blocks) to traverse looking for columns.
+                phylogenyKeepSingleDegreeBlocks: whether or not to keep blocks that contain only one segment.
+                phylogenyTreeBuildingMethod: One of "guidedNeighborJoining" or "neighborJoining".
+                                             guidedNeighborJoining: Use the species tree to bias tree-building toward trees that have low amounts of dups/losses.
+                                             neighborJoining: Traditional neighbor-joining.
+                phylogenyCostPerDupPerBase: For the guided neighbor-joining method only. The number of differences that should be created per base when a join implies a dup.
+                phylogenyCostPerLossPerBase: For the guided neighbor-joining method only. The number of differences that should be created per base, per loss, when a join implies one or more losses.
+                numTreeBuildingThreads: Number of threads in the tree-building pool. Must be greater than 0.
+        -->
+	<caf 
+		chunkSize="25000000"
+		realign="1"
+		realignArguments="--gapGamma 0.0 --matchGamma 0.9 --diagonalExpansion 4 --splitMatrixBiggerThanThis 10 --constraintDiagonalTrim 0 --alignAmbiguityCharacters --splitIndelsLongerThanThis 99"
+		compressFiles="1" 
+		overlapSize="10000" 
+		filterByIdentity="0" 
+		identityRatio="3" 
+		minimumDistance="0.01" 
+		minimumSequenceLengthForBlast="30"
+		annealingRounds="128" 
+		deannealingRounds="2 8"
+		blockTrim="5" 
+		minimumTreeCoverage="0.0" 
+		trim="0 0" 
+		minimumBlockDegree="2"
+		minimumIngroupDegree="1"
+		minimumOutgroupDegree="0"
+        minimumNumberOfSpecies="1"
+        alignmentFilter="filterSecondariesByMultipleSpecies"
+		maxAdjacencyComponentSizeRatio="50"
+		minLengthForChromosome="1000000"
+		proportionOfUnalignedBasesForNewChromosome="0.8"
+		maximumMedianSequenceLengthBetweenLinkedEnds="1000"
+		runMapQFiltering="1"
+		minimumMapQValue="0.0" 
+		maxAlignmentsPerSite="5"
+		alpha="0.001"
+		lastzMemory="littleMemory"
+		lastzDisk="mediumDisk"
+                removeRecoverableChains="unequalNumberOfIngroupCopies"
+                maxRecoverableChainsIterations="5"
+                maxRecoverableChainLength="500000"
+                doPhylogeny="0"
+                phylogenyNumTrees="30"
+                phylogenyRootingMethod="bestRecon"
+                phylogenyScoringMethod="reconCost"
+                phylogenyBreakpointScalingFactor="1.0"
+                phylogenySkipSingleCopyBlocks="1"
+                phylogenyMaxBaseDistance="100"
+                phylogenyMaxBlockDistance="50"
+                phylogenyKeepSingleDegreeBlocks="0"
+                phylogenyTreeBuildingMethod="guidedNeighborJoining,splitDecomposition"
+                phylogenyCostPerDupPerBase="0.00"
+                phylogenyCostPerLossPerBase="0.02"
+                phylogenyDoSplitsWithSupportHigherThanThisAllAtOnce="0.44"
+                numTreeBuildingThreads="2"
+                minimumBlockDegreeToCheckSupport="10"
+                minimumBlockHomologySupport="0.05"
+                phylogenyHomologyUnitType="chain"
+                phylogenyDistanceCorrectionMethod="jukesCantor"
+	        >
+		<!-- The following are parametrised to produce the same results as the default settings, 
+		within a margin of 0.2% sensitivity, should be very fast for close genomes, these were tuned using the blast/blastParametersScript.py
+		We could go even faster for less than 0.05 divergence using, but want to be robust to poor branch length estimates -->
+		<divergence 
+			argName="lastzArguments"
+		 	one="--step=2 --ambiguous=iupac,100,100 --ydrop=3000 --notransition"
+		 	two="--step=5 --ambiguous=iupac,100,100 --ydrop=3000"
+		 	three="--step=4 --ambiguous=iupac,100,100 --ydrop=3000"
+		 	four="--step=3 --ambiguous=iupac,100,100 --ydrop=3000"
+		 	five="--step=2 --ambiguous=iupac,100,100 --ydrop=3000"
+		 	default="--step=1 --ambiguous=iupac,100,100 --ydrop=3000"
+		 />
 		<CactusCafRecursion maxFlowerGroupSize="100000000"/>
-		<CactusCafWrapper maxFlowerGroupSize="25000000" minFlowerSize="1"/>
+		<CactusCafWrapper minFlowerSize="1" maxFlowerGroupSize="25000000"/>
 		<CactusCafWrapperLarge2 overlargeMemory="bigMemory"/>
 	</caf>
-	        
-	<bar alignAmbiguityCharacters="1" anchorMatrixBiggerThanThis="500" bandingLimit="1000000" constraintDiagonalTrim="14" diagonalExpansion="20" gapGamma="0.0" largeEndSize="5000" matchGamma="0.2" minimumBlockDegree="2" minimumCoverageToRescue="0.5" minimumIngroupDegree="1" minimumNumberOfSpecies="1" minimumOutgroupDegree="0" minimumSizeToRescue="100" pruneOutStubAlignments="1" repeatMaskMatrixBiggerThanThis="500" rescue="0" runBar="1" spanningTrees="5" splitMatrixBiggerThanThis="3000" useBanding="1" useProgressiveMerging="1" veryLargeEndSize="2000000">
+	<!-- The caf tag contains parameters for the bar algorithm. -->
+	<!-- The veryLargeEndSize parameter determines how big an end needs to be (in terms of bases in sequences incident with the end)
+	for the end to be aligned on its own. -->
+        <!-- The rescue parameter defines whether to run "bar rescue",
+             which makes single-degree blocks for anything that was
+             covered by an outgroup in the bar phase but is still
+             unaligned at the end of bar. This pushes those regions
+             into the ancestor, hopefully to get aligned to something
+             else eventually -->
+	<bar
+		runBar="1"
+		spanningTrees="5" 
+		gapGamma="0.0"
+		matchGamma="0.2"
+		useBanding="1"
+		bandingLimit="1000000" 
+		splitMatrixBiggerThanThis="3000" 
+        anchorMatrixBiggerThanThis="500"
+        repeatMaskMatrixBiggerThanThis="500"
+		diagonalExpansion="20"
+		constraintDiagonalTrim="14" 
+		minimumBlockDegree="2" 
+		minimumIngroupDegree="1"
+		minimumOutgroupDegree="0"
+                minimumNumberOfSpecies="1"
+		alignAmbiguityCharacters="1"
+		largeEndSize="5000"
+		veryLargeEndSize="2000000"
+		useProgressiveMerging="1"
+		pruneOutStubAlignments="1"
+                rescue="0"
+                minimumSizeToRescue="100"
+                minimumCoverageToRescue="0.5"
+	>
 		<CactusBarRecursion maxFlowerGroupSize="100000000"/>
+		<!-- The maxFlowerGroupSize in cactusBarWrapper determines how many bases to allow in one "small" job which will be run using the "littleMemory" -->
 		<CactusBarWrapper maxFlowerGroupSize="2000000" memory="littleMemory"/>
+		<!-- The maxFlowerGroupSize in cactusBarWrapperLarge determines how many of each large broken up to allow in one "small" job which will be run using the "littleMemory" -->
 		<CactusBarWrapperLarge maxFlowerGroupSize="2000000"/>
 		<CactusBarEndAlignerWrapper memory="littleMemory"/>
 	</bar>
-	<normal iterations="2">
+	<!-- The normal tag provides parameters to the cactus_normalisation script, which "normalises" a cactus to make all chains of maximal length. This is not used much now. -->
+	<normal 
+		iterations="0"
+	>
 		<CactusNormalRecursion maxFlowerGroupSize="100000000" maxFlowerWrapperGroupSize="10000000"/>
 		<CactusNormalWrapper/>
 	</normal>
-	<avg buildAvgs="0">
+	<!-- The avg tag is for a prototype algorithm, currently just builds trees. Not currently compatible with cactus_progressive -->
+	<avg
+		buildAvgs="0"
+	>
 		<CactusAVGRecursion maxFlowerGroupSize="100000000" maxFlowerWrapperGroupSize="10000000"/>
 		<CactusAVGWrapper/>
 	</avg>
-	<reference ignoreUnalignedGaps="1" makeScaffolds="1" matchingAlgorithm="blossom5" maxWalkForCalculatingZ="100000" minNumberOfSequencesToSupportAdjacency="1" numberOfNs="10" permutations="10" phi="1.0" reference="reference" theta="0.0001" useSimulatedAnnealing="1" wiggle="0.9999">
+	<!-- The reference tag provides parameters to cactus_reference, a method used to construct a reference genome for a given cactus database. -->
+	<!-- numberOfNs is the number of Ns to insert into an ancestral sequence when an adjacency is uncertain, think of its as the Ns in a scaffold gap -->
+	<!-- minNumberOfSequencesToSupportAdjacency is the number of sequences needed to bridge an adjacency -->
+	<!-- makeScaffolds is a boolean that enables the bridging of uncertain adjacencies in an ancestral sequence providing the larger scale problem (parent flower in cactus), bridges the path. -->
+	<!-- phi is the coefficient used to control how much weight to place on an adjacency given its phylogenetic distance from the reference node -->
+	<reference 
+		matchingAlgorithm="blossom5" 
+		reference="reference" 
+		useSimulatedAnnealing="1" 
+		theta="0.0001"
+		phi="1.0"
+		maxWalkForCalculatingZ="100000" 
+		permutations="10"
+		ignoreUnalignedGaps="1"
+		wiggle="0.9999"
+		numberOfNs="10"
+		minNumberOfSequencesToSupportAdjacency="1"
+		makeScaffolds="1"
+	>
 		<CactusReferenceRecursion maxFlowerGroupSize="100000000" maxFlowerWrapperGroupSize="2000000"/>
-		 
-		<CactusReferenceWrapper/>
-		 
-		<CactusSetReferenceCoordinatesUpWrapper/>
-		 
-		<CactusSetReferenceCoordinatesDownRecursion maxFlowerGroupSize="100000000" maxFlowerWrapperGroupSize="2000000"/>
-		 
-		<CactusSetReferenceCoordinatesDownWrapper/>
+	 	<CactusReferenceWrapper/>
+	 	<CactusSetReferenceCoordinatesUpWrapper/>
+	 	<CactusSetReferenceCoordinatesDownRecursion maxFlowerGroupSize="100000000" maxFlowerWrapperGroupSize="2000000"/>
+	 	<CactusSetReferenceCoordinatesDownWrapper/>
 	</reference>
-	<check runCheck="1">
+	<!-- The check tag provides parameters to cactus_check, a script which checks that a constructed cactus database is as expected. -->
+	<check 
+		runCheck="0"
+	>
 		<CactusCheckRecursion maxFlowerGroupSize="100000000" maxFlowerWrapperGroupSize="2000000"/>
 		<CactusCheckWrapper/>
 	</check>
-	<hal buildFasta="1" buildHal="1">
+	<!-- The hal tag controls the creation of hal and fasta files from the pipeline. -->
+	<hal
+		buildHal="1"
+		buildFasta="1"
+	>
 		<CactusHalGeneratorRecursion maxFlowerGroupSize="2000000"/>
 		<CactusHalGeneratorUpWrapper/>
 	</hal>
-	  
-	<multi_cactus>
-		<outgroup ancestor_quality_fraction="0.75" max_num_outgroups="3" strategy="greedyPreference" threshold="0"/>
-		 
-		<decomposition default_internal_node_prefix="Anc" max_parallel_subtrees="50000" self_alignment="false"/>
-		  
-	</multi_cactus>
-	    
-	<ProgressiveNext/>
-	    
-	<ProgressiveUp/>
-	    
-	<ProgressiveDown/>
-	    
-	<ProgressiveOut/>
-	    
-	<RunCactusPreprocessorThenProgressiveDown/>
-	    
-	<RunCactusPreprocessorThenProgressiveDown2/>
-	    
-	<exportHal disk="2000000000"/>
+  	<multi_cactus>
+		<outgroup 
+			strategy="greedyPreference"
+			threshold="0"
+			ancestor_quality_fraction="0.75"
+                        max_num_outgroups="3"
+		/>
+	 	<decomposition 
+	 		self_alignment="false" 
+	 		default_internal_node_prefix="Anc"
+			max_parallel_subtrees="50000"
+	 	/>
+  	</multi_cactus>
+    <ProgressiveNext/>
+    <ProgressiveUp/>
+    <ProgressiveDown/>
+    <ProgressiveOut/>
+    <RunCactusPreprocessorThenProgressiveDown/>
+    <RunCactusPreprocessorThenProgressiveDown2/>
+    <exportHal disk="2000000000"/>
 </cactusWorkflowConfig>

--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -34,15 +34,15 @@ class TestCase(unittest.TestCase):
         """ Compare halStats otuput of given file to baseline 
         """
         # this is just pasted from a successful run.  it will be used to catch serious regressions
-        ground_truth = '''Anc0, 2, 543803, 22, 0, 5169
-        Anc1, 2, 568840, 32, 7511, 33681
-        simHuman_chr6, 0, 601863, 1, 33051, 0
-        mr, 2, 611438, 17, 31652, 34064
-        simMouse_chr6, 0, 636262, 1, 34566, 0
-        simRat_chr6, 0, 647215, 1, 34080, 0
-        Anc2, 2, 576869, 49, 8024, 36376
-        simCow_chr6, 0, 602619, 1, 35306, 0
-        simDog_chr6, 0, 593897, 1, 35153, 0'''
+        ground_truth = '''Anc0, 2, 545125, 9, 0, 14471
+        Anc1, 2, 569645, 6, 16862, 54019
+        simHuman_chr6, 0, 601863, 1, 53463, 0
+        mr, 2, 611571, 3, 52338, 55582
+        simMouse_chr6, 0, 636262, 1, 56172, 0
+        simRat_chr6, 0, 647215, 1, 55687, 0
+        Anc2, 2, 577109, 15, 17350, 57130
+        simCow_chr6, 0, 602619, 1, 56309, 0
+        simDog_chr6, 0, 593897, 1, 55990, 0'''
 
         # run halStats on the evolver output
         proc = subprocess.Popen(['bin/halStats',  halPath], stdout=subprocess.PIPE)


### PR DESCRIPTION
This is a quick patch to get master branch working until #151 is more properly resolved.  It simply overwrites `cactus_config.xml` with the settings in `cactus_progressive_config.xml` in order to make sure some of the old settings in the former (such as enabling normalization) don't get activated.    