### PR TITLE
Static only build of Kyoto

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ ${versionPy}:
 evolver_test: all
 	-docker rmi -f evolvertestdocker/cactus:latest
 	docker build --network=host -t evolvertestdocker/cactus:latest . --build-arg CACTUS_COMMIT=${git_commit}
-	LD_LIBRARY_PATH=${PWD}/lib:${LD_LIBARY_PATH} PYTHONPATH="" CACTUS_DOCKER_ORG=evolvertestdocker ${PYTHON} -m pytest -s ${pytestOpts} test
+	PYTHONPATH="" CACTUS_DOCKER_ORG=evolvertestdocker ${PYTHON} -m pytest -s ${pytestOpts} test
 	docker rmi -f evolvertestdocker/cactus:latest
 
 ##
@@ -139,7 +139,8 @@ clean: selfClean ${submodules:%=subclean.%}
 suball1: ${submodules1:%=suball.%}
 suball2: ${submodules2:%=suball.%}
 suball.kyoto:
-	cd submodules/kyoto && KT_OPTIONS=--disable-lua ${MAKE} PREFIX=${CWD} && ${MAKE} install
+	cd submodules/kyoto && ${MAKE} PREFIX=${CWD}
+	cd submodules/kyoto && ${MAKE} PREFIX=${CWD} install
 
 suball.sonLib: suball.kyoto
 	cd submodules/sonLib && PKG_CONFIG_PATH=${CWD}/lib/pkgconfig:${PKG_CONFIG_PATH} ${MAKE}

--- a/README.md
+++ b/README.md
@@ -82,11 +82,6 @@ HDF5 is available through most package managers (`apt-get install libhdf5-dev`) 
 export PATH := <hdf5 bin dir>:${PATH}
 ```
 
-KyotoTycoon is compiled as a submodule, but its libraries need to be available at runtime.  One way to do this is to run
-```
-export LD_LIBRARY_PATH = <path where cactus is installed>/lib:${LD_LIBRARY_PATH}
-```
-
 Once you have HDF5 installed, you should be able to compile Cactus and its dependencies by running:
 ```
 git submodule update --init


### PR DESCRIPTION
Disable building static libraries and force no lua in Kyoto.

This needs to be merged after the  submodule Kyoto build and https://github.com/ComparativeGenomicsToolkit/kyoto/pull/3

