### PR TITLE
Docker and install fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,8 @@ before_install:
     fi
 script:
 # install toil / cactus
-  - pip install -r requirements.txt
-  - pip install -e .
+  - pip install toil==3.24.0
+  - pip install -U .
   - if [[ "$CACTUS_TEST_CHOICE" == "normal" ]]; then export MAKE_TARGET=test_nonblast; fi
   - if [[ "$CACTUS_TEST_CHOICE" == "blast" ]]; then export MAKE_TARGET=test_blast; fi
   - if [[ "$CACTUS_BINARIES_MODE" == "local" ]]; then make && PATH=`pwd`/bin:$PATH PYTHONPATH=`pwd`:`pwd`/src LD_LIBRARY_PATH=`pwd`/lib:${LD_LIBRARY_PATH} travis_wait 50 make ${MAKE_TARGET}; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,12 @@ RUN mkdir -p /home/cactus
 COPY . /home/cactus
 RUN cd /home/cactus && make -j $(nproc)
 
+# make the binaries smaller by removing debug symbols 
+RUN cd /home/cactus && strip -d bin/* 2> /dev/null || true
+
 # build cactus python3
 RUN ln -s /usr/bin/python3 /usr/bin/python
-RUN mkdir -p /wheels && cd /wheels && pip3 install -U pip && pip3 wheel /home/cactus
+RUN mkdir -p /wheels && cd /wheels && pip3 install -U pip && pip3 wheel toil[all]==3.24.0 && pip3 wheel /home/cactus
 
 # Create a thinner final Docker image in which only the binaries and necessary data exist.
 FROM ubuntu:bionic-20200112
@@ -27,8 +30,8 @@ COPY --from=builder /wheels /wheels
 
 # install the python3 binaries then clean up
 RUN pip3 install -U pip wheel setuptools && \
+    pip3 install -f /wheels toil[all]==3.24.0 && \
     pip3 install -f /wheels /tmp/cactus && \
-	 pip3 install -f /wheels /tmp/cactus/submodules/sonLib && \
     rm -rf /wheels /root/.cache/pip/* /tmp/cactus && \
     apt-get remove -y git python3-pip && \
     apt-get auto-remove -y

--- a/README.md
+++ b/README.md
@@ -47,14 +47,15 @@ You can always exit out of the virtualenv by running `deactivate`. The rest of t
 ### Install Cactus and its dependencies
 Cactus uses [Toil](http://toil.ucsc-cgl.org/) to coordinate its jobs. To install Toil into your environment, run:
 ```
-pip install --upgrade toil[all]
+pip install --upgrade setuptools pip
+pip install --upgrade toil[all]==3.24.0
 ```
 
 Note that if you are using Python 3.7, there is an issued that caused the
 Toil dependency package *http_parser* C code to fail to compile.  This is easily worked
 around by setting an environment variable before installing Toil:
 ```
-CPPFLAGS='-DPYPY_VERSION' pip install toil[all]
+CPPFLAGS='-DPYPY_VERSION' pip install toil[all]==3.24.0
 ```
 
 Finally, to install Cactus, clone it and its submodules from github and install it with pip:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,0 @@
-toil>=3.24
-networkx>=2,<3
-pytest
-decorator
-psutil
-cython
-pytest
-

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setup(
     python_requires = '>=3.6',
 
     install_requires = [
-        'toil>=3.24',
         'decorator',
         'psutil',
         'networkx>=2,<3',


### PR DESCRIPTION
* Change `Dockerfile` to install `toil[all]` instead of barebones version.  This lets, for example, it be used to read s3 job stores.
* Remove toil as a requirement in setup.py.  Having it as a requirement simplifies a single machine install, but will cause problems when using toil appliances
* Try to make docker image smaller by stripping debug symbols out of binaries
* Get rid of duplicate specification of python requirements (just keep version in setup.py)