### PR TITLE
Option to only decompose preprocessing in cactus-prepare

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ There isn't much to configure if running locally. Most importantly, if on a shar
 Cactus (through Toil) supports many batch systems, including LSF, SLURM, GridEngine, Parasol, and Torque. To run on a cluster, simply add `--batchSystem <batchSystem>`, e.g. `--batchSystem gridEngine`. If your batch system needs additional configuration, Toil exposes some [environment variables](http://toil.readthedocs.io/en/3.10.1/developingWorkflows/batchSystem.html#batch-system-enivronmental-variables) that can help.
 ### Running on the cloud
 Cactus supports running on AWS, Azure, and Google Cloud Platform using [Toil's autoscaling features](https://toil.readthedocs.io/en/latest/running/cloud/cloud.html). For more details on running in AWS, check out [these instructions](doc/running-in-aws.md) (other clouds are similar).
+
 ### Running step by step (experimental)
 Breaking Cactus up into smaller jobs can be practical, both for development and debugging, and managing larger workflows.  Here is an example of how to break the Evolver Mammals example up into three steps: 1) Preprocessing 2) Blast 3) Multiple Aligment:
 ```
@@ -164,6 +165,14 @@ cactus-prepare examples/evolverMammals.txt steps-output steps-output/evovlerMamm
 ```
 
 It will print the sequence of commands to run the alignment step-by-step.  Blocks of commands within each alignment run can be run in parallel
+
+`cactus-prepare` can also be used to simplify preprocessing sequences without decomposing the remaining workflow:
+
+```
+cactus-prepare examples/evolverMammals.txt steps-output steps-output/evovlerMammals.txt steps-output/evolverMammals.hal --jobStore jobstore --preprocessOnly
+```
+
+Note that the `--preprocessBatchSize` option can be used to determine the size of each `cactus-preprocess` job.
 
 ## Using the output
 Cactus outputs its alignments in the [HAL](https://github.com/ComparativeGenomicsToolkit/hal) format. This format represents the alignment in a reference-free, indexed way, but isn't readable by many tools. To export a MAF (which by its nature is usually reference-based), you can use the `hal2maf` tool to export the alignment from any particular genome: `hal2maf <hal> --refGenome <reference> <maf>`.

--- a/src/cactus/shared/configWrapper.py
+++ b/src/cactus/shared/configWrapper.py
@@ -224,3 +224,10 @@ class ConfigWrapper:
         for node in self.xmlRoot.findall("preprocessor"):
             if 'checkAssemblyHub' in node.attrib:
                 node.attrib['checkAssemblyHub'] = '0'
+
+    def removePreprocessors(self):
+        """Remove all preprocessor elements """
+        for node in self.xmlRoot.findall("preprocessor"):
+            self.xmlRoot.remove(node)
+
+        


### PR DESCRIPTION
When running cactus more than once on the same inputs, which happens frequently for numerous reasons, it helps a lot to not redo the preprocessing.  `cactus-prepare` is modified here to simplify this.

For example
```
cactus-prepare examples/evolverMammals.txt steps-output steps-output/evovlerMammals.txt steps-output/evolverMammals.hal --jobStore jobstore --preprocessOnly --preprocessBatchSize 10
```
gives this output.  The first command can be run once to preprocess the sequences and put their outputs into the output directory.  The second command will run `cactus` on this input without re-preprocessing
```

## Preprocessor
cactus-preprocess jobstore examples/evolverMammals.txt steps-output/evovlerMammals.txt --inputNames simHuman_chr6 simCow_chr6 simDog_chr6 simMouse_chr6 simRat_chr6 --realTimeLogging --logInfo

## Cactus
cactus jobstore steps-output/evovlerMammals.txt steps-output/evolverMammals.hal --realTimeLogging --logInfo --configFile steps-output/config.xml
```
