### PR TITLE
have cactus_call report if subprocess signaled or exited

### DIFF
--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -1171,7 +1171,7 @@ def cactus_call(tool=None,
         tool = "cactus"
 
     entrypoint = None
-    if len(parameters) > 0 and type(parameters[0]) is list:
+    if (len(parameters) > 0) and isinstance(parameters[0], list):
         # We have a list of lists, which is the convention for commands piped into one another.
         flattened = [i for sublist in parameters for i in sublist]
         chain_params = [' '.join(p) for p in [list(map(pipes.quote, q)) for q in parameters]]


### PR DESCRIPTION
real commit is 56bc5d7 distinguish between signals and exit non-zero when reporting cactus
program failures

however, due to accidentally being pushed to master and then reverted, it doesn't show up in the pull request diff.