### PR TITLE
Fix cactus-blast/align interface to better accept non-cactus input

### DIFF
--- a/src/cactus/blast/cactus_blast.py
+++ b/src/cactus/blast/cactus_blast.py
@@ -166,7 +166,6 @@ def runCactusBlastOnly(options):
 
         # export the alignments
         toil.exportFile(outWorkFlowArgs.alignmentsID, makeURL(options.outputFile))
-        outWorkFlowArgs.experimentWrapper.writeXML(options.outputFile + '.exp.xml')
         # optional secondary alignments
         if outWorkFlowArgs.secondaryAlignmentsID:
             toil.exportFile(outWorkFlowArgs.secondaryAlignmentsID, makeURL(options.outputFile) + '.secondary')

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -68,6 +68,8 @@ def main():
                         "rather than pulling one from quay.io")
     parser.add_argument("--binariesMode", choices=["docker", "local", "singularity"],
                         help="The way to run the Cactus binaries", default=None)
+    parser.add_argument("--nonBlastInput", action="store_true",
+                        help="Input does not come from cactus-blast: Do not append ids to fasta names")
 
     options = parser.parse_args()
 
@@ -140,17 +142,18 @@ def runCactusAfterBlastOnly(options):
 
             # import the outgroups
             outgroupIDs = []
-            cactus_blast_input = True
+            cactus_blast_input = not options.nonBlastInput
             for i, outgroup in enumerate(outgroups):
                 try:
                     outgroupID = toil.importFile(makeURL(options.blastOutput) + '.og_fragment_{}'.format(i))
                     outgroupIDs.append(outgroupID)
                     experiment.setSequenceID(outgroup, outgroupID)
                 except:
+                    if cactus_blast_input:
+                        raise
                     # we assume that input is not coming from cactus blast, so we'll treat output
                     # sequences normally and not go looking for fragments
                     outgroupIDs = []
-                    cactus_blast_input = False
                     break
 
             #import the sequences (that we need to align for the given event, ie leaves and outgroups)


### PR DESCRIPTION
`--nonBlastInput` added to `cactus-align` to tell it not to add `id=0|` prefixes to fasta sequence names in order to match with the cigar.  Previously, this was toggled automatically in a confusing way. 

There's still work to be done with regards to outgroup alignments coming from other pipelines, but will hash that out when we have an example.  

@Robin-Rounthwaite This seems to work on a trivial example:

seq.txt
```
(simMouse_chr6:0.084509,simRat_chr6:0.091589);

simMouse_chr6 http://s3-us-west-2.amazonaws.com/jcarmstr-misc/testRegions/evolverMammals/simMouse.chr6
simRat_chr6 http://s3-us-west-2.amazonaws.com/jcarmstr-misc/testRegions/evolverMammals/simRat.chr6
```
prepare
```
rm -rf js ; cactus-prepare seq.txt ./test ./test/seq.txt ./test/out.hal --jobStore js
## Preprocessor
cactus-preprocess js seq.txt ./test/seq.txt --inputNames simMouse_chr6 simRat_chr6 --realTimeLogging --logInfo

## Alignment

### Round 0
cactus-blast js ./test/seq.txt ./test/Anc0.cigar --root Anc0 --realTimeLogging --logInfo
cactus-align js ./test/seq.txt ./test/Anc0.cigar ./test/out.hal --root Anc0 --realTimeLogging --logInfo
hal2fasta ./test/out.hal Anc0 --hdf5InMemory > ./test/Anc0.fa
```
Then run the first two commands
```
cactus-preprocess js seq.txt ./test/seq.txt --inputNames simMouse_chr6 simRat_chr6 --realTimeLogging --logInfo
cactus-blast js ./test/seq.txt ./test/Anc0.cigar --root Anc0 --realTimeLogging --logInfo
```
Remove all the id prefixes to pretend the cigars came from your pipeline and not `cactus-blast`
```
sed -i -e 's/id=[0,1]|//g' test/Anc0.cigar*
```
Run cactus-align with the `--nonBlastInput` option
```
cactus-align js ./test/seq.txt ./test/Anc0.cigar ./test/out.hal --root Anc0 --realTimeLogging --logInfo --nonBlastInput
```
should work.  