### PR TITLE
Reorganize Installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,40 @@ Cactus uses many different algorithms and individual code contributions, princip
 ### System requirements
 We regularly test on Ubuntu 18.04 (Bionic) and to a more limited degree on Mac OS X (using Docker).
 
+Cactus requires Python 3.
+
 Cactus uses substantial resources. For primate-sized genomes (3 gigabases each), you should expect Cactus to use approximately 120 CPU-days of compute per genome, with about 120 GB of RAM used at peak. The requirements scale roughly quadratically, so aligning two 1-megabase bacterial genomes takes only 1.5 CPU-hours and 14 GB RAM.
 
 Note that to run even the very small evolverMammals example, you will need 2 CPUs and 12 GB RAM. The actual resource requirements are much less, but the individual jobs have resource estimates based on much larger alignments, so the jobs will refuse to run unless there are enough resources to meet their estimates.
 
-### Virtual environment
-To avoid problems with conflicting versions of dependencies on your system, we strongly recommend installing Cactus inside a Python 3 [virtual environment](https://virtualenv.pypa.io/en/stable/).
+IMPORTANT:  It is highly recommend that one **not** run Cactus using the Toil Grid Engine-like batch systems (GridEngine, HTCondor, LSF, SLURM, or Torque).  Cactus creates a very large number of small jobs, which can overwhelm these systems.
 
-Python 2 is no longer supported by Cactus.
+### Installation Overview
 
-To install the `virtualenv` command, if you don't have it already, run:
+There are many different ways to install and run Cactus:
+* [Docker Image](#docker-image)
+* [Precompiled Binaries](#precompiled-binaries)
+* [Build From Source](#build-from-source)
+* [Python Install with Docker Binaries](#python-install-with-docker-binaries)
+
+#### Docker Image
+
+Cactus docker images are hosted on [quay](https://quay.io/repository/comparative-genomics-toolkit/cactus).  The image for the latest release is listed on the [Releases Page](https://github.com/ComparativeGenomicsToolkit/cactus/releases).  Here is an command line to run the included evolver mammals example with release 1.0.0
+```
+wget https://raw.githubusercontent.com/ComparativeGenomicsToolkit/cactus/master/examples/evolverMammals.txt
+docker run -v $(pwd):/data --rm -it quay.io/comparative-genomics-toolkit/cactus:v1.0.0 cactus /data/jobStore /data/evolverMammals.txt /data/evolverMammals.hal --root mr --binariesMode local
+
+```
+
+#### Precompiled Binaries
+
+Precompiled binaries can be found on the [Releases Page](https://github.com/ComparativeGenomicsToolkit/cactus/releases).  Download by clicking the `cactus-bin-vx.x.x.tar.gz` and install following the instructions in the `BIN-INSTALL.md` link.
+
+#### Build From Source
+
+##### Install the Cactus Python package and its dependencies
+
+To avoid problems with conflicting versions of dependencies on your system, we strongly recommend installing Cactus inside a Python 3 [virtual environment](https://virtualenv.pypa.io/en/stable/). To install the `virtualenv` command, if you don't have it already, run:
 ```
 python3 -m pip install virtualenv
 ```
@@ -42,61 +66,51 @@ Then, to enter the virtualenv, run:
 source cactus_env/bin/activate
 ```
 
-You can always exit out of the virtualenv by running `deactivate`. The rest of the README assumes you're running inside a virtual environment.
+You can always exit out of the virtualenv by running `deactivate`.
 
-### Install Cactus and its dependencies
-Cactus uses [Toil](http://toil.ucsc-cgl.org/) to coordinate its jobs. To install Toil into your environment, run:
-```
-pip install --upgrade setuptools pip
-pip install --upgrade -r toil-requirement.txt
-```
 
-Note that if you are using Python 3.7, there is an issued that caused the
-Toil dependency package *http_parser* C code to fail to compile.  This is easily worked
-around by setting an environment variable before installing Toil:
-```
-CPPFLAGS='-DPYPY_VERSION' pip install -r toil-requirement.txt
-```
-
-Finally, to install Cactus, clone it and its submodules from github and install it with pip:
+To install Cactus in Python, clone it and **its submodules with --recursive** from github and install it with pip:
 ```
 git clone https://github.com/ComparativeGenomicsToolkit/cactus.git --recursive
 cd cactus
+pip install --upgrade setuptools pip
+pip install --upgrade -r toil-requirement.txt
 pip install --upgrade .
 ```
-IMPORTANT:  The `--recursive` option is required to download submodules.  If you omit it, you will need to run `git submodule update --init` from the `cactus/` directory before installing.
 
-IMPORTANT:  It is highly recommend that one **not** run Cactus using the Toil Grid Engine-like batch systems (GridEngine, HTCondor, LSF, SLURM, or Torque).  Cactus creates a very large number of small jobs, which can overwhelm these systems.
+##### Build the Cactus Binaries
 
-### Install Docker or Singularity
-By default, Cactus uses Docker to run its compiled components. It can instead use Singularity to run its binaries, or use a locally installed copy. To select a different way of running the binaries, you can use the `--binariesMode singularity` or `--binariesMode local` options.
+Several binaries are required to run Cactus.  They can be built as follows:
 
-Note, you must use Singularity 2.3 - 2.6 or Singularity 3.1.0+. Singularity 3 versions below 3.1.0 are incompatible with cactus (see [issue #55](https://github.com/ComparativeGenomicsToolkit/cactus/issues/55) and [issue #60](https://github.com/ComparativeGenomicsToolkit/cactus/issues/60)).
-
-### Compile Cactus executables (if not using Docker/Singularity)
-By default Cactus uses containers to distribute its binaries, because compiling its dependencies can sometimes be a pain. If you can use Docker or Singularity, *which we highly recommend*, you can skip this section since all that needs to be installed in that case is the Python workflow as described above. However, in some environments (e.g. HPC clusters) you won't be able to use Docker or Singularity, so you will have to compile the binaries and install a few dependencies. Looking at the [Dockerfile](Dockerfile) itself can serve as a guide for building on Ubuntu. 
-
-HDF5 is a compile-time dependency.
-Compile time settings can be overridden by creating a make include file 
+Compile time settings can be overridden by creating a make include file in the top level cactus directory.  
 ```
-include.local.mk
+cactus/include.local.mk
 ```
-in the top level cactus directory.
 
-HDF5 is available through most package managers (`apt-get install libhdf5-dev`) or can be manual installed from source files at [The HDF Group](https://www.hdfgroup.org/).   HDF5 should be configured with the `--enable-cxx` option. If you've installed it in a non-standard location, have the `h5c++` command in your `PATH` or add this to `include.local.mk`:
+Cactus has several dependencies that need to be installed on the system, including HDF5. HDF5 is available through most package managers (`apt-get install libhdf5-dev`) or can be manual installed from source files at [The HDF Group](https://www.hdfgroup.org/).   HDF5 should be configured with the `--enable-cxx` option. If you've installed it in a non-standard location, have the `h5c++` command in your `PATH` or add this to `include.local.mk`:
 ```
 export PATH := <hdf5 bin dir>:${PATH}
 ```
 
-Once you have HDF5 installed, you should be able to compile Cactus and its dependencies by running:
+You can use the the [Dockerfile](Dockerfile) as a guide to see how all dependencies are installed with `apt` on Ubuntu.
+
+In the top level cactus directory.  The binaries can then be built with
 ```
-git submodule update --init
-make
+make -j $(nproc)
+```
+and added to the PATH with
+```
+export PATH=$(pwd)/bin:$PATH
 ```
 
-To run using these local executables, you will need to provide the `--binariesMode local` option to all `cactus` commands and add the `bin` directory to your PATH.
-## System/cluster requirements
-Cactus will take about 20 CPU-hours per bacterial-sized (~4 megabase) genome, about 20 CPU-days per nematode-sized (~100 megabase) genome, and about 120 CPU-days per mammalian-sized (~3 gigabase) genome. You will need at least one machine with very large amounts of RAM (150+ GB) to run mammalian-sized genomes. The requirements will vary a bit depending on how closely related your genomes are, so these are only rough estimates.
+#### Python Install With Docker Binaries
+
+Cactus can be setup and used in a virtual environment as in the [previous section](#build-from-source), without compiling the binaries.  When used like this (which will happen automatically when running `cactus` without the appropriate binaries in the `PATH` environment variable), a Docker image will be automatically pulled to run commands as needed.  The main use case for this is running with Toils AWS provisioner as [described here](doc/running-in-aws.md).
+
+Singularity binaries can be used in place of docker binaries with the `--binariesMode singularity` flag.  Note, you must use Singularity 2.3 - 2.6 or Singularity 3.1.0+. Singularity 3 versions below 3.1.0 are incompatible with cactus (see [issue #55](https://github.com/ComparativeGenomicsToolkit/cactus/issues/55) and [issue #60](https://github.com/ComparativeGenomicsToolkit/cactus/issues/60)).
+
+The `--binariesMode local` flag can be used to force `cactus` to run local binaries -- this is the default behavior if they are found. 
+
 ## Running
 To run Cactus, the basic format is:
 ```
@@ -112,23 +126,6 @@ cactus jobStore examples/evolverMammals.txt examples/evolverMammals.hal --root m
 
 Within an hour at most (on modern computers), you should have a [HAL](https://github.com/ComparativeGenomicsToolkit/hal) file which relates simulated mouse and rat genomes.
 
-### Choosing how to run the Cactus binaries (Docker/Singularity/local)
-
-If Docker is installed, and no local binaries are found, Cacus will use Docker to run its compiled components.  To do this it will attempt to find the image with the tag matching the current git commit from https://quay.io/repository/comparative-genomics-toolkit/cactus?tab=tags and run it as needed.
-
-To run the binaries locally, build them with `make` and add cactus's bin directory to your `PATH`.  Cactus will use them automatically if found:
-```
-export PATH=$(pwd)/bin:$PATH
-```
-
-The `--binariesMode` option can force Cactus to use either `local`, `docker` or `singularity` binaries. 
-
-You can also run Cactus directly from Docker the docker image (as opposed to using it only for compiled binaries).  To do this you do not need to clone the cactus repo, install toil, make a virtualenv or anything else.  Simply run as follows (note this example assumes the `cactus/examples` folder from the git repo is available:
-```
-docker run -v $(pwd)/examples:/data/examples --rm -it quay.io/comparative-genomics-toolkit/cactus:latest cactus jobStore /data/examples/evolverMammals.txt /data/examples/evolverMammals.hal --root mr --binariesMode local
-
-**Note** We don't currently have a system of tagging and releasing docker images.  Unfortunately, the latest tag may point to a development branch.  
-```
 
 ### seqFile: the input file
 The input file, called a "seqFile", is just a text file containing the locations of the input sequences as well as their phylogenetic tree. The tree will be used to progressively decompose the alignment by iteratively aligning sibling genomes to estimate their parents in a bottom-up fashion. Polytomies in the tree are allowed, though the amount of computation required for a sub-alignment rises quadratically with the degree of the polytomy.  Cactus uses the predicted branch lengths from the tree to determine appropriate pairwise alignment parameters, allowing closely related species to be aligned more quickly with no loss in accuracy. The file is formatted as follows:
@@ -162,10 +159,10 @@ Example:
      *chimp /data/genomes/chimp/
      *gorilla /data/genomes/gorilla/gorilla.fa
      orang /cluster/home/data/orang/
-### Running locally
-There isn't much to configure if running locally. Most importantly, if on a shared system, you can adjust the maximum number of processors used with `--maxCores <N>` (by default, Cactus will use all cores).
+
 ### Running on a cluster
 Cactus (through Toil) supports many batch systems, including LSF, SLURM, GridEngine, Parasol, and Torque. To run on a cluster, simply add `--batchSystem <batchSystem>`, e.g. `--batchSystem gridEngine`. If your batch system needs additional configuration, Toil exposes some [environment variables](http://toil.readthedocs.io/en/3.10.1/developingWorkflows/batchSystem.html#batch-system-enivronmental-variables) that can help.
+
 ### Running on the cloud
 Cactus supports running on AWS, Azure, and Google Cloud Platform using [Toil's autoscaling features](https://toil.readthedocs.io/en/latest/running/cloud/cloud.html). For more details on running in AWS, check out [these instructions](doc/running-in-aws.md) (other clouds are similar).
 

--- a/doc/running-in-aws.md
+++ b/doc/running-in-aws.md
@@ -15,12 +15,12 @@ By default, AWS will restrict you to running only a few small instances at a tim
 ## Installing Cactus on your local machine
 Follow the steps in the README, making sure to install toil with its extra AWS support:
 ```
-git clone https://github.com/comparativegenomicstoolkit/cactus.git
+git clone https://github.com/comparativegenomicstoolkit/cactus.git --recursive
 cd cactus
-virtualenv venv
+virtualenv -p python 3.6 venv
 source venv/bin/activate
+pip install -r toil-requirement.txt
 pip install --upgrade .
-pip install --upgrade toil[aws]
 ```
 ## Estimating the maximum number of worker instances you'll need
 The cluster will automatically scale up and down, but you'll want to set a maximum number of nodes so the scaler doesn't get overly aggressive and waste money, or go over your AWS limits. We typically use `c4.8xlarge` on the spot market for most jobs, and `r4.8xlarge` on-demand for database jobs. Here are some very rough estimates of what we typically use for the maximum of each type (round up):
@@ -63,7 +63,7 @@ Install Cactus in a virtual environment on the leader:
 ```
 apt update
 apt install -y git tmux
-virtualenv --system-site-packages venv
+virtualenv --system-site-packages -p python3.6 venv
 source venv/bin/activate
 git clone https://github.com/comparativegenomicstoolkit/cactus.git
 cd cactus


### PR DESCRIPTION
Now that we're making releases, emphasize using them in the README.  Also fix bug in installation instructions where `toil-requirements.txt` was used before it was cloned.  

Should resolve #227.