### PR TITLE
Patch 0-length branch problem in cactus_reference

### DIFF
--- a/reference/impl/buildReference.c
+++ b/reference/impl/buildReference.c
@@ -231,11 +231,14 @@ static void getEventWeightingP(Event *pEvent, Event *event,
     }
     if(stSet_search(chosenEvents, event) != NULL) { //Defines a leaf event that is not the reference, which we need to give a score for
         assert(adjustedPathLength <= pathLength);
-        assert(exp(-phi * pathLength) <= 1.0);
-        assert(exp(-phi * pathLength) >= 0.0);
-        double score = exp(-phi * pathLength) * adjustedPathLength/pathLength;
+        double score = exp(-phi * pathLength);
         assert(score <= 1.0);
         assert(score >= 0.0);
+        if (pathLength > 0.0) {
+            score *= adjustedPathLength/pathLength;
+            assert(score <= 1.0);
+            assert(score >= 0.0);
+        }
         // fprintf(stdout, "Chose weight %lf for event %s (multiplicity %" PRIi64 "). Adj path length %lf, path length %lf.\n", score, event_getHeader(event), stIntTuple_get(stHash_search(branchesToMultiplicity, event), 0), adjustedPathLength, pathLength);
         stHash_insert(eventToWeights, event, stDoubleTuple_construct(1, score));
     }

--- a/setup/cactus_setup.c
+++ b/setup/cactus_setup.c
@@ -51,6 +51,10 @@ void checkBranchLengthsAreDefined(stTree *tree) {
     if (isinf(stTree_getBranchLength(tree))) {
         st_errAbort("Got a non defined branch length in the input tree: %s.\n", stTree_getNewickTreeString(tree));
     }
+    if (stTree_getBranchLength(tree) == 0.0) {
+        stTree_setBranchLength(tree, DBL_MIN);
+        st_logCritical("0-length branch found for %s. Resetting to very small value\n", stTree_getLabel(tree)); 
+    }
     for (int64_t i = 0; i < stTree_getChildNumber(tree); i++) {
         checkBranchLengthsAreDefined(stTree_getChild(tree, i));
     }


### PR DESCRIPTION
`cactus_reference` was [dividing by 0](https://github.com/ComparativeGenomicsToolkit/cactus/issues/181#issuecomment-625489666) in the presence of 0-length branches, and the resulting `nan`s caused it to loop forever.  

This PR fixes that particular division and, just to be sure, changes `cactus_setup` to add a little epsilon to 0-length branches to make sure they never end up in the cactus disk. 

Should resolve #181 