### PR TITLE
Turn on asserts in C code

### DIFF
--- a/include.mk
+++ b/include.mk
@@ -34,6 +34,10 @@ sonLibDir=${sonLibRootDir}/lib
 
 include ${sonLibRootDir}/include.mk
 
+#Turn asserts back on in spite of sonLib
+#https://github.com/ComparativeGenomicsToolkit/cactus/issues/235
+CFLAGS += -UNDEBUG
+
 dataSetsPath=/Users/benedictpaten/Dropbox/Documents/work/myPapers/genomeCactusPaper/dataSets
 
 inclDirs = api/inc bar/inc caf/inc hal/inc reference/inc submodules/sonLib/C/inc \


### PR DESCRIPTION
Cactus is full of asserts, but they are switched off by default.  This PR turns them on: 
* Mostly because I'm bitter about #181 taking so long to reproduce and fix (#234).  Having the asserts switched on would have produced a semi useful error log rather than running indefinitely. 
* There are a few new features in development, and I think having asserts on will be especially valuable as we integrate them

I ran a little benchmark on 3 250Mb insect genomes (plus another 3 outgroups) on a dedicated 64 core machine.
Without asserts
```
real    391m9.762s
user    12474m44.832s
sys     569m36.468s
```
With asserts
```
real    402m2.147s
user    12580m36.629s
sys     573m7.268s
```
A couple percent difference seems reasonable.  Can reevaluate if it seems to cause disproportionately more trouble on mammalian genomes. 
