### PR TITLE
Encode Singularity tool names before hashing

### DIFF
--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -1033,7 +1033,7 @@ def singularityCommand(tool=None,
         # Also, only sandbox directories work with user namespaces, and only user
         # namespaces work inside unprivileged Docker containers like the Toil
         # appliance.
-        sandbox_dirname = os.path.join(cache_dir, '{}.sandbox'.format(hashlib.sha256(tool).hexdigest()))
+        sandbox_dirname = os.path.join(cache_dir, '{}.sandbox'.format(hashlib.sha256(tool.encode('utf-8')).hexdigest()))
 
         if not os.path.exists(sandbox_dirname):
             # We atomically drop the sandbox at that name when we get it


### PR DESCRIPTION
Without this, in Python 3 on Toil 4.1.0, trying to run on Kubernetes with Singularity tools and an AWS job store, I get:

```
=========>
	INFO:toil.worker:---TOIL WORKER OUTPUT LOG---
	INFO:toil:Running Toil version 4.1.0-5ad5e77d98e1456b4f70f5b00e688a43cdce2ebe.
	INFO:cactus.shared.common:Work dirs: {'/var/lib/toil/node-b177fa50-1926-4fda-9b7a-da27c621b219-1b6fc4a70f8334d5f732a04b5eb3b9f0/tmpp8ei2qpl/74f32c82-213d-47db-be10-1dd8e1b8f046'}
	INFO:cactus.shared.common:Docker work dir: /var/lib/toil/node-b177fa50-1926-4fda-9b7a-da27c621b219-1b6fc4a70f8334d5f732a04b5eb3b9f0/tmpp8ei2qpl/74f32c82-213d-47db-be10-1dd8e1b8f046
	Traceback (most recent call last):
	  File "/root/venv/lib/python3.7/site-packages/toil/worker.py", line 366, in workerScript
	    job._runner(jobGraph=jobGraph, jobStore=jobStore, fileStore=fileStore, defer=defer)
	  File "/root/venv/lib/python3.7/site-packages/toil/job.py", line 1392, in _runner
	    returnValues = self._run(jobGraph, fileStore)
	  File "/root/venv/lib/python3.7/site-packages/toil/job.py", line 1329, in _run
	    return self.run(fileStore)
	  File "/root/venv/lib/python3.7/site-packages/toil/job.py", line 1533, in run
	    rValue = userFunction(*((self,) + tuple(self._args)), **self._kwargs)
	  File "/root/venv/lib/python3.7/site-packages/cactus/progressive/cactus_progressive.py", line 206, in logAssemblyStats
	    analysisString = cactus_call(parameters=["cactus_analyseAssembly", sequenceFile], check_output=True)
	  File "/root/venv/lib/python3.7/site-packages/cactus/shared/common.py", line 1205, in cactus_call
	    parameters=parameters, port=port, file_store=fileStore)
	  File "/root/venv/lib/python3.7/site-packages/cactus/shared/common.py", line 1036, in singularityCommand
	    sandbox_dirname = os.path.join(cache_dir, '{}.sandbox'.format(hashlib.sha256(tool).hexdigest()))
	TypeError: Unicode-objects must be encoded before hashing
	ERROR:toil.worker:Exiting the worker because of a failed job on host anovak-time-singlemachine-fdbm4
	WARNING:toil.jobGraph:Due to failure we are reducing the remaining retry count of job 'logAssemblyStats' c59c0aaf-d3e4-4e59-a3aa-6b86d8a8d934 with ID c59c0aaf-d3e4-4e59-a3aa-6b86d8a8d934 to 0
<=========
```