### PR TITLE
Faster CAF

### DIFF
--- a/caf/impl/filtering.c
+++ b/caf/impl/filtering.c
@@ -119,10 +119,15 @@ static bool containsMoreThanOneEvent(stPinchSegment *segment, Flower *flower) {
         return false;
     } else {
         stPinchBlock *block = stPinchSegment_getBlock(segment);
+        // we use this flag to bypass the loop below, which can be quite costly in practice
+        if (stPinchBlock_getFilterFlag(block)) {
+            return true;
+        }
         Event *event = stCaf_getEvent(segment, flower);
         stPinchBlockIt it = stPinchBlock_getSegmentIterator(block);
         while ((segment = stPinchBlockIt_getNext(&it)) != NULL) {
             if (stCaf_getEvent(segment, flower) != event) {
+                stPinchBlock_setFilterFlag(block, true);
                 return true;
             }
         }


### PR DESCRIPTION
This is a little hack to speed up `containsMoreThanOneEvent()` by caching its results inside  `stPinchBlock`s.  It resolves #272 where `cactus_caf` could take extremely long on some outputs.  

I have a test running to make sure it behaves exactly the same as the old logic on the data mentioned in that issue, and won't merge until that passes.  