### PR TITLE
Switch base docker image for gitlab CI to one with more pre-installed

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,6 @@ image: quay.io/glennhickey/cactus-ci-base:latest
 
 before_script:
   - whoami
-  - sudo apt-get -q -y update && apt-get -q -y upgrade
   - startdocker || true
   - docker info
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: quay.io/vgteam/dind
+image: quay.io/glennhickey/cactus-ci-base:latest
 
 before_script:
   - whoami

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,17 +2,7 @@ image: quay.io/glennhickey/cactus-ci-base:latest
 
 before_script:
   - whoami
-  - sudo apt-get -q -y update
-  # Cactus dependencies from Dockerfile (todo: centralize)
-  - sudo apt-get -q -y install build-essential git python3 python3-dev python3-pip zlib1g-dev wget libbz2-dev pkg-config libhdf5-dev liblzo2-dev
-  # this fails sporradically on gitlab for reasons unknown (curse), so give it a couple tries
-  - sudo apt-get -q -y install libtokyocabinet-dev || sleep 60
-  - sudo apt-get -q -y install libtokyocabinet-dev || sleep 600
-  - sudo apt-get -q -y install libtokyocabinet-dev
-  # Get cromwell dependencies
-  - sudo apt-get -q -y install default-jre wget
-  # Make sure we have some curl stuff for pycurl which we need for some Python stuff
-  - sudo apt-get -q -y install docker.io python-virtualenv libcurl4-gnutls-dev libgnutls28-dev
+  - sudo apt-get -q -y update && apt-get -q -y upgrade
   - startdocker || true
   - docker info
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN cd /home/cactus && make -j $(nproc)
 RUN cd /home/cactus && strip -d bin/* 2> /dev/null || true
 
 # build cactus python3
-RUN ln -s /usr/bin/python3 /usr/bin/python
+RUN ln -fs /usr/bin/python3 /usr/bin/python
 RUN mkdir -p /wheels && cd /wheels && python3 -m pip install -U pip && python3 -m pip wheel -r /home/cactus/toil-requirement.txt && python3 -m pip wheel /home/cactus
 
 # Create a thinner final Docker image in which only the binaries and necessary data exist.

--- a/Dockerfile.ci-base
+++ b/Dockerfile.ci-base
@@ -1,0 +1,10 @@
+# Building Cactus on Gitlab is slow and often crashes with errors like:
+# E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/m/make-dfsg/make_4.1-9.1ubuntu1_amd64.deb  Undetermined Error [IP: 91.189.88.142 80]
+# E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
+# So we try to avoid that by keeping a base image around with dependencies pre-installed that CI can use.
+
+FROM quay.io/vgteam/dind
+
+# apt dependencies for build
+RUN apt-get update && apt-get install -y build-essential git python3 python3-dev python3-pip zlib1g-dev wget libbz2-dev pkg-config libhdf5-dev liblzo2-dev libtokyocabinet-dev
+

--- a/Dockerfile.ci-base
+++ b/Dockerfile.ci-base
@@ -8,3 +8,5 @@ FROM quay.io/vgteam/dind
 # apt dependencies for build
 RUN apt-get update && apt-get install -y build-essential git python3 python3-dev python3-pip zlib1g-dev wget libbz2-dev pkg-config libhdf5-dev liblzo2-dev libtokyocabinet-dev
 
+# apt dependencies for ci
+RUN apt-get install -y default-jre wget docker.io python-virtualenv libcurl4-gnutls-dev libgnutls28-dev

--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,7 @@ ${versionPy}:
 
 evolver_test: all
 	-docker rmi -f evolvertestdocker/cactus:latest
+	sed -i -e 's/FROM.*AS builder/FROM quay.io\/glennhickey\/cactus-ci-base:latest as builder/' Dockerfile
 	docker build --network=host -t evolvertestdocker/cactus:latest . --build-arg CACTUS_COMMIT=${git_commit}
 	PYTHONPATH="" CACTUS_DOCKER_ORG=evolvertestdocker ${PYTHON} -m pytest ${pytestOpts} test/evolverTest.py
 	docker rmi -f evolvertestdocker/cactus:latest


### PR DESCRIPTION
This essentially moves the `apt` updates from the gitlab setup in `.gitlab-ci.yml` and into `Dockerfile.ci-base` which is used to create a base image for CI jobs.  

This will hopefully resolve #253, as it's been especially bad [lately](https://ucsc-ci.com/comparativegenomicstoolkit/cactus/-/jobs/56072), and should be a better fix for #224.
