### PR TITLE
Add hal python tools to cactus docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic-20200112 AS builder
 
 # apt dependencies for build
-RUN apt-get update && apt-get install -y build-essential git python3 python3-dev python3-pip zlib1g-dev wget libbz2-dev pkg-config libhdf5-dev liblzo2-dev libtokyocabinet-dev
+RUN apt-get update && apt-get install -y build-essential git python3 python3-dev python3-pip zlib1g-dev wget libbz2-dev pkg-config libhdf5-dev liblzo2-dev libtokyocabinet-dev wget
 
 # build cactus binaries
 RUN mkdir -p /home/cactus
@@ -16,6 +16,12 @@ RUN find /home/cactus -name include.local.mk -exec rm -f {} \;
 RUN cd /home/cactus && make clean -j $(nproc)
 RUN cd /home/cactus && make -j $(nproc)
 
+# download kent binaries used by hal for assembly hubs
+# bedSort and hgGcPercent are part of a more restricted licence: https://hgdownload.cse.ucsc.edu/admin/exe/
+# if you agree to it, add them by replacing the following line with this one:
+# RUN cd /home/cactus/bin && for i in wigToBigWig faToTwoBit bedToBigBed bigBedToBed bedSort hgGcPercent; do wget -q http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/${i}; chmod ugo+x ${i}; done
+RUN cd /home/cactus/bin && for i in wigToBigWig faToTwoBit bedToBigBed bigBedToBed; do wget -q http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/${i}; chmod ugo+x ${i}; done
+
 # make the binaries smaller by removing debug symbols 
 RUN cd /home/cactus && strip -d bin/* 2> /dev/null || true
 
@@ -27,7 +33,7 @@ RUN mkdir -p /wheels && cd /wheels && python3 -m pip install -U pip && python3 -
 FROM ubuntu:bionic-20200112
 
 # apt dependencies for runtime
-RUN apt-get update && apt-get install -y --no-install-recommends git python3 python3-pip python3-distutils zlib1g libbz2-1.0 net-tools libhdf5-100 liblzo2-2 libtokyocabinet9
+RUN apt-get update && apt-get install -y --no-install-recommends git python3 python3-pip python3-distutils zlib1g libbz2-1.0 net-tools libhdf5-100 liblzo2-2 libtokyocabinet9 rsync
 
 # copy temporary files for installing cactus
 COPY --from=builder /home/cactus /tmp/cactus
@@ -36,12 +42,16 @@ COPY --from=builder /wheels /wheels
 # install the cactus binaries
 RUN cd /tmp/cactus && cp -rP bin /usr/local/
 
+# install the hal python modules
+RUN rsync -avm --include='*.py' -f 'hide,! */' /tmp/cactus/submodules/hal /usr/local/lib
+ENV PYTHONPATH /usr/local/lib:${PYTHONPATH}
+
 # install the python3 binaries then clean up
 RUN python3 -m pip install -U pip wheel setuptools && \
     python3 -m pip install -f /wheels -r /tmp/cactus/toil-requirement.txt && \
     python3 -m pip install -f /wheels /tmp/cactus && \
     rm -rf /wheels /root/.cache/pip/* /tmp/cactus && \
-    apt-get remove -y git python3-pip && \
+    apt-get remove -y git python3-pip rsync && \
     apt-get auto-remove -y
 
 # wrapper.sh is used when running using the docker image with --binariesMode docker

--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ and added to the PATH with
 export PATH=$(pwd)/bin:$PATH
 ```
 
+To use HAL python scripts such as `hal2mafMP.py`, add the submodules directory to the PYTHONPATH with
+```
+export PYTHONPATH=$(pwd)/submodules:$PYTHONPATH
+```
+
 #### Python Install With Docker Binaries
 
 Cactus can be setup and used in a virtual environment as in the [previous section](#build-from-source), without compiling the binaries.  When used like this (which will happen automatically when running `cactus` without the appropriate binaries in the `PATH` environment variable), a Docker image will be automatically pulled to run commands as needed.  The main use case for this is running with Toils AWS provisioner as [described here](doc/running-in-aws.md).

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,8 @@ setup(
         'psutil',
         'networkx>=2,<3',
         'cython',
-        'pytest'],
+        'pytest',
+        'biopython'], # cactus doesn't really need it, but some hal tools do
 
     cmdclass = {
         'install': PostInstallCommand,

--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -89,7 +89,7 @@ class TestCase(unittest.TestCase):
             cw_opts.write('}\n')
 
         # download cromwell
-        subprocess.check_call(['wget', 'https://github.com/broadinstitute/cromwell/releases/download/49/cromwell-49.jar'],
+        subprocess.check_call(['wget', '-q', 'https://github.com/broadinstitute/cromwell/releases/download/49/cromwell-49.jar'],
                               cwd=self.tempDir)
 
         # run cactus-prepare and write the output to a wdl file


### PR DESCRIPTION
https://github.com/ComparativeGenomicsToolkit/hal/issues/108#issuecomment-620814684 points out that hal python tools aren't runnable in the cactus docker image. 

This PR ought to fix that.  As discussed in #225, something similar needs to be done with the binary release package.  

Don't like that there are a few duplicated hal scripts in the image (in particular, those from cactus's binary directory), but can live with it for now.   