### PR TITLE
Get cactus-prepare ready for gpu release

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,16 @@
+# Release 1.1.0   ???
+
+This release contains some important bug fixes, as well as major improvements to `cactus-prepare` functionality.
+
+Notable Changes:
+ - `cactus-prepare` improvements including:
+    - WDL / Terra support
+	 - GPU lastz support
+	 - bug fixes
+- Upgrade to Toil 4.1.0
+- Fix bug causing `cactus-reference` to run forever in presence of 0-length branches
+- Major speed improvement for `cactus-caf` by fixing secondary alignment filter.
+- Include HAL python tools in Docker images
 
 # Release 1.0.0   2020-04-19
 

--- a/src/cactus/progressive/cactus_prepare.py
+++ b/src/cactus/progressive/cactus_prepare.py
@@ -18,7 +18,7 @@ from cactus.progressive.seqFile import SeqFile
 from cactus.progressive.multiCactusTree import MultiCactusTree
 from cactus.shared.common import cactusRootPath
 from cactus.shared.common import enableDumpStack
-from cactus.shared.common import getDockerImage
+from cactus.shared.common import getDockerImage, getDockerRelease
 from cactus.progressive.multiCactusProject import MultiCactusProject
 from cactus.shared.experimentWrapper import ExperimentWrapper
 from cactus.shared.configWrapper import ConfigWrapper
@@ -137,11 +137,6 @@ def main():
             options.alignDisk = options.defaultDisk
         if not options.halAppendDisk:
             options.halAppendDisk = options.defaultDisk
-
-    # todo: we need a gpu-cactus release, then we need cactus-prepare to default to this or the docs to make it very clear
-    # how to point to it.  
-    if options.gpu:
-        sys.stderr.write("Warning: --gpu option not yet supported in official release. User must verify Cactus Docker image is accelerated\n")
 
     # https://cromwell.readthedocs.io/en/stable/RuntimeAttributes/#gpucount-gputype-and-nvidiadriverversion
     # note: k80 not included as WGA_GPU doesn't run on it.  
@@ -286,14 +281,8 @@ def cactusPrepare(options, project):
             # realigning doesn't mix well with lastz so we make sure it's off
             # https://github.com/ComparativeGenomicsToolkit/cactus/issues/271
             cafNode.attrib["realign"] = "0"
-        options.configFile = os.path.join(options.outDir, 'config.xml')
+        options.configFile = os.path.join(options.outDir, 'config-prepared.xml')
         sys.stderr.write("configuration saved in {}\n".format(options.configFile))
-        config.writeXML(options.configFile)
-
-    if options.gpu:
-        cafNode = findRequiredNode(config.xmlRoot, "caf")
-        cafNode.attrib["gpuLastz"] = "true"
-        options.configFile = os.path.join(options.outDir, 'config.xml')
         config.writeXML(options.configFile)
         
     # pass through the config file to the options
@@ -598,7 +587,6 @@ def wdl_task_blast(options):
                                                                               wdl_disk(options, 'blast')[1])
     s += '\n    }\n'
     s += '    runtime {\n'
-    s += '        docker: \"{}\"\n'.format(options.dockerImage)
     s += '        preemptible: {}\n'.format(options.blastPreemptible)
     if options.blastCores:
         s += '        cpu: {}\n'.format(options.blastCores)
@@ -611,8 +599,10 @@ def wdl_task_blast(options):
         s += '        gpuCount: {}\n'.format(options.gpuCount)
         s += '        bootDiskSizeGb: 20\n'
         s += '        nvidiaDriverVersion: \"{}\"\n'.format(options.nvidiaDriver)
+        s += '        docker: \"{}\"\n'.format(getDockerRelease(gpu=True))
         s += '        zones: \"{}\"\n'.format(options.gpuZone)
     else:
+        s += '        docker: \"{}\"\n'.format(options.dockerImage)
         s += '        zones: \"{}\"\n'.format(options.zone)
     s += '    }\n'
     s += '    output {\n        Array[File] out_files=glob(\"${out_name}*\")\n    }\n'

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -846,6 +846,13 @@ def getDockerImage():
     """Get fully specified Docker image name."""
     return "%s/cactus:%s" % (getDockerOrg(), getDockerTag())
 
+def getDockerRelease(gpu=False):
+    """Get the most recent docker release."""
+    r = "quay.io/comparative-genomics-toolkit/cactus:v1.0.0"
+    if gpu:
+        r += "-gpu"
+    return r
+
 def maxMemUsageOfContainer(containerInfo):
     """Return the max RSS usage (in bytes) of a container, or None if something failed."""
     if containerInfo['id'] is None:


### PR DESCRIPTION
I'll update the wiki, but this will necessitate that `getDockerRelease()` in common.py gets updated just before each release.  