### PR TITLE
Use built in instead of mkdir_p.

### DIFF
--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -6,7 +6,6 @@
 """
 
 import os
-import pickle
 import sys
 import shutil
 import subprocess
@@ -19,7 +18,6 @@ import time
 import signal
 import hashlib
 import tempfile
-import timeit
 import math
 import threading
 import traceback
@@ -32,13 +30,11 @@ from datetime import datetime
 from toil.lib.bioio import logger
 from toil.lib.bioio import system
 from toil.lib.bioio import getLogLevelString
-from toil.lib.misc import mkdir_p
 from toil.common import Toil
 from toil.job import Job
 from toil.realtimeLogger import RealtimeLogger
 
 from sonLib.bioio import popenCatch
-from sonLib.bioio import getTempDirectory
 
 from cactus.shared.version import cactus_commit
 
@@ -1016,7 +1012,7 @@ def singularityCommand(tool=None,
         home_dir = str(pathlib.Path.home())
         default_singularity_dir = os.path.join(home_dir, '.singularity')
         cache_dir = os.path.join(os.environ.get('SINGULARITY_CACHEDIR',  default_singularity_dir), 'toil')
-        mkdir_p(cache_dir)
+        os.makedirs(cache_dir, exist_ok=True)
 
         # hack to transform back to docker image
         if tool == 'cactus':


### PR DESCRIPTION
Changing from the custom toil function `mkdir_p()` to the equivalent built-in `os.makedirs(exist_ok=True)`.  The built-in was added in python3.2.  If python2.7 compatibility is still desired, I'll just move the function from toil here.

I attempted to refactor this on toil, but it seems cactus has a dependency on it, and @adamnovak 's cactus integration test caught it!  https://ucsc-ci.com/databiosphere/toil/-/jobs/56501

Also removed some unused imports.