### PR TITLE
v1.1.1 patch to fix how kent tools included in releases

### DIFF
--- a/BIN-INSTALL.md
+++ b/BIN-INSTALL.md
@@ -23,6 +23,15 @@ export PATH=$(pwd)/bin:$PATH
 export PYTHONPATH=$(pwd)/lib:$PYTHONPATH
 ```
 
+Some tools required for `hal2assemblyHub.py` are not included and must be downloaded separately.
+They are `wigToBigWig faToTwoBit bedToBigBed bigBedToBed bedSort hgGcPercent`.  More information
+can be found [here](https://hgdownload.cse.ucsc.edu/admin/exe/).  Note that some may require
+a license for commercial use.  Static binaries are not available, but the following command
+should set them up successfully on many 64 bit Linux systems:
+```
+cd bin && for i in wigToBigWig faToTwoBit bedToBigBed bigBedToBed bedSort hgGcPercent; do wget -q http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/${i}; chmod ugo+x ${i}; done
+```
+
 ## Testing
 
 To test Cactus, the following will run a moderately sized alignment.  It may

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN mkdir -p /wheels && cd /wheels && python3 -m pip install -U pip && python3 -
 FROM ubuntu:bionic-20200112
 
 # apt dependencies for runtime
-RUN apt-get update && apt-get install -y --no-install-recommends git python3 python3-pip python3-distutils zlib1g libbz2-1.0 net-tools libhdf5-100 liblzo2-2 libtokyocabinet9 rsync
+RUN apt-get update && apt-get install -y --no-install-recommends git python3 python3-pip python3-distutils zlib1g libbz2-1.0 net-tools libhdf5-100 liblzo2-2 libtokyocabinet9 rsync libkrb5-3 libk5crypto3
 
 # copy temporary files for installing cactus
 COPY --from=builder /home/cactus /tmp/cactus
@@ -56,6 +56,9 @@ RUN python3 -m pip install -U pip wheel setuptools && \
     rm -rf /wheels /root/.cache/pip/* /tmp/cactus && \
     apt-get remove -y git python3-pip rsync && \
     apt-get auto-remove -y
+
+# check the linking on all our binaries (those kent tools above aren't static)
+RUN for i in /usr/local/bin/* ; do if [ -f ${i} ] && [ $(ldd ${i} | grep "not found" | wc -l) -ge 1 ]; then exit 1; fi; done
 
 # wrapper.sh is used when running using the docker image with --binariesMode docker
 RUN mkdir /opt/cactus/

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ There are many different ways to install and run Cactus:
 
 #### Docker Image
 
-Cactus docker images are hosted on [quay](https://quay.io/repository/comparative-genomics-toolkit/cactus).  The image for the latest release is listed on the [Releases Page](https://github.com/ComparativeGenomicsToolkit/cactus/releases).  Here is an command line to run the included evolver mammals example with release 1.1.0
+Cactus docker images are hosted on [quay](https://quay.io/repository/comparative-genomics-toolkit/cactus).  The image for the latest release is listed on the [Releases Page](https://github.com/ComparativeGenomicsToolkit/cactus/releases).  Here is an command line to run the included evolver mammals example with release 1.1.1
 ```
 wget https://raw.githubusercontent.com/ComparativeGenomicsToolkit/cactus/master/examples/evolverMammals.txt
-docker run -v $(pwd):/data --rm -it quay.io/comparative-genomics-toolkit/cactus:v1.1.0 cactus /data/jobStore /data/evolverMammals.txt /data/evolverMammals.hal --root mr --binariesMode local
+docker run -v $(pwd):/data --rm -it quay.io/comparative-genomics-toolkit/cactus:v1.1.1 cactus /data/jobStore /data/evolverMammals.txt /data/evolverMammals.hal --root mr --binariesMode local
 
 ```
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,13 @@
+# Release 1.1.1   2020-07-31
+
+This release fixes how Kent tools required for `hal2assemblyHub.py` were packaged in 1.1.0 (thanks @nathanweeks).  
+
+Notable Changes:
+ - The required shared libaries to run the Kent tools are added to the Docker Image
+ - The same Kent tools are removed from the binary release.  They were included under the assumption that they were statically built and fully standalone, but they are not.  Instead, instrucitons are provided to guide interested users to installing them on their own. 
+
+GPU Lastz version used in GPU-enabled Docker image: [3e14c3b8ceeb139b3b929b5993d96d8e5d3ef9fa](https://github.com/ComparativeGenomicsToolkit/SegAlign/commit/3e14c3b8ceeb139b3b929b5993d96d8e5d3ef9fa)
+
 # Release 1.1.0   2020-07-30
 
 This release contains some important bug fixes, as well as major improvements to `cactus-prepare` functionality.

--- a/build-tools/makeBinRelease
+++ b/build-tools/makeBinRelease
@@ -49,8 +49,6 @@ rsync -avm --include='*.py' -f 'hide,! */' ./submodules/hal ${binPackageDir}/lib
 # need .git dir for pip install -U ., but don't need everything
 cp -r .git ${binPackageDir}
 rm -rf ${binPackageDir}/.git/modules
-# install (opensource) kent tools needed by hal2assemblyhub.py
-pushd ${binPackageDir}/bin && for i in wigToBigWig faToTwoBit bedToBigBed bigBedToBed; do wget -q http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/${i}; chmod ugo+x ${i}; done && popd
 # remove test executables
 rm -f ${binPackageDir}/bin/*test ${binPackageDir}/bin/*tests ${binPackageDir}/bin/*Test ${binPackageDir}/bin/*Tests
 # make binaries smaller

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -844,7 +844,7 @@ def getDockerImage():
 
 def getDockerRelease(gpu=False):
     """Get the most recent docker release."""
-    r = "quay.io/comparative-genomics-toolkit/cactus:v1.1.0"
+    r = "quay.io/comparative-genomics-toolkit/cactus:v1.1.1"
     if gpu:
         r += "-gpu"
     return r


### PR DESCRIPTION
#291 pointed out that the Kent tools that were included in the release are, despite being billed as "standalone", not in fact statically built.  As a result just copying them into the docker image left them unusable.  

The remedy here is:
* installing the required shared libraries in the Docker image (following the suggestion in #291 -- thanks @nathanweeks !)
* removing the Kent binaries from the static binary release of Cactus.  They are replaced with a blurb in the install instructions guiding the user how to install them themselves.

This has been enough trouble that I think it's worth making an assembly hub via Docker within the CI tests.  Still no phylop hal support but baby steps...