### PR TITLE
Fix memory leak in cactus_convertAlignmentsToInternalNames

### DIFF
--- a/blast/cactus_convertAlignmentsToInternalNames.c
+++ b/blast/cactus_convertAlignmentsToInternalNames.c
@@ -217,6 +217,7 @@ int main(int argc, char *argv[])
             convertHeadersToNames(pA, headerToName);
             checkPairwiseAlignment(pA);
             cigarWrite(outputFile, pA, TRUE);
+            destructPairwiseAlignment(pA);
         }
     }
 


### PR DESCRIPTION
And here's `cactus_convertAlignmentsToInternalNames` of all things about to bring down a big toil run due to running out of memory:
```
  8621 root      20   0  229.0g 229.0g    428 R  99.3  95.4  55:50.01 cactus_convertAlignmentsToInternalNames tmpws3w08gd.tmp tmpxthgv3k_.tmp --cactusDisk <st_kv_database_conf type="kyoto_tycoon"> ...<kyoto_tycoon database_dir="fakepath" host="172.31.26.9+ 
```