### PR TITLE
Apply toil overrides consistently for all cactus-* scripts

### DIFF
--- a/src/cactus/blast/cactus_blast.py
+++ b/src/cactus/blast/cactus_blast.py
@@ -27,6 +27,7 @@ from cactus.pipeline.cactus_workflow import addCactusWorkflowOptions
 from cactus.pipeline.cactus_workflow import CactusTrimmingBlastPhase
 from cactus.shared.common import makeURL
 from cactus.shared.common import enableDumpStack
+from cactus.shared.common import cactus_override_toil_options
 
 from toil.job import Job
 from toil.common import Toil
@@ -80,21 +81,8 @@ def main():
            len(options.pathOverrideNames) != len(options.pathOverrides):
             raise RuntimeError('same number of values must be passed to --pathOverrides and --pathOverrideNames')
 
-    options.database = 'kyoto_tycoon'
-
     # Mess with some toil options to create useful defaults.
-
-    # Caching generally slows down the cactus workflow, plus some
-    # methods like readGlobalFileStream don't support forced
-    # reads directly from the job store rather than from cache.
-    options.disableCaching = True
-    # Job chaining breaks service termination timing, causing unused
-    # databases to accumulate and waste memory for no reason.
-    options.disableChaining = True
-    if options.retryCount is None:
-        # If the user didn't specify a retryCount value, make it 5
-        # instead of Toil's default (1).
-        options.retryCount = 5
+    cactus_override_toil_options(options)
 
     start_time = timeit.default_timer()
     runCactusBlastOnly(options)

--- a/src/cactus/preprocessor/cactus_preprocessor.py
+++ b/src/cactus/preprocessor/cactus_preprocessor.py
@@ -31,6 +31,7 @@ from cactus.shared.common import enableDumpStack
 from toil.lib.bioio import setLoggingFromOptions
 from toil.realtimeLogger import RealtimeLogger
 
+from cactus.shared.common import cactus_override_toil_options
 from cactus.preprocessor.checkUniqueHeaders import checkUniqueHeaders
 from cactus.preprocessor.lastzRepeatMasking.cactus_lastzRepeatMask import LastzRepeatMaskJob
 from cactus.preprocessor.lastzRepeatMasking.cactus_lastzRepeatMask import RepeatMaskOptions
@@ -319,6 +320,9 @@ def main():
     setupBinaries(options)
     setLoggingFromOptions(options)
     enableDumpStack()
+
+    # Mess with some toil options to create useful defaults.
+    cactus_override_toil_options(options)
 
     # we have two modes: operate directly on paths or rely on the seqfiles.  they cannot be mixed
     if options.inSeqFile or options.outSeqFile:

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -31,8 +31,9 @@ from cactus.pipeline.cactus_workflow import prependUniqueIDs
 from cactus.blast.blast import calculateCoverage
 from cactus.shared.common import makeURL
 from cactus.shared.common import enableDumpStack
-from toil.realtimeLogger import RealtimeLogger
+from cactus.shared.common import cactus_override_toil_options
 
+from toil.realtimeLogger import RealtimeLogger
 from toil.job import Job
 from toil.common import Toil
 from toil.lib.bioio import logger
@@ -105,18 +106,7 @@ def main():
     options.buildFasta = True
 
     # Mess with some toil options to create useful defaults.
-
-    # Caching generally slows down the cactus workflow, plus some
-    # methods like readGlobalFileStream don't support forced
-    # reads directly from the job store rather than from cache.
-    options.disableCaching = True
-    # Job chaining breaks service termination timing, causing unused
-    # databases to accumulate and waste memory for no reason.
-    options.disableChaining = True
-    if options.retryCount is None:
-        # If the user didn't specify a retryCount value, make it 5
-        # instead of Toil's default (1).
-        options.retryCount = 5
+    cactus_override_toil_options(options)
 
     start_time = timeit.default_timer()
     runCactusAfterBlastOnly(options)


### PR DESCRIPTION
Got this when finishing bar on the 55-way minimap2 alignments
```
Deadlock encountered: The workflow is service deadlocked - all 1 running jobs have been the same active services for at least 60 seconds
``` 
This is because the hack to override deadlockWait that's in `cactus` somehow never made it to `cactus-align`.  This PR makes sure the same overrides (including setting the deadlockWait to 3600) that are in `cactus` are also in `cactus-blast`, `cactus-align`, etc. 