### PR TITLE
CAF tweaks

### DIFF
--- a/caf/cactus_caf.c
+++ b/caf/cactus_caf.c
@@ -348,6 +348,7 @@ int main(int argc, char *argv[]) {
     HomologyUnitType phylogenyHomologyUnitType = BLOCK;
     enum stCaf_DistanceCorrectionMethod phylogenyDistanceCorrectionMethod = JUKES_CANTOR;
     bool sortAlignments = false;
+    bool sortSecondaryAlignments = false;
     char *hgvmEventName = NULL;
 
     ///////////////////////////////////////////////////////////////////////////
@@ -500,6 +501,11 @@ int main(int argc, char *argv[]) {
                     filterFn = NULL;
                 } else {
                     st_errAbort("Could not recognize alignmentFilter option %s", optarg);
+                }
+                // by default we apply all primary filtering to secondary alignments too
+                if (secondaryFilterFn == NULL && filterFn != NULL) {
+                    secondaryFilterFn = filterFn;
+                    sortSecondaryAlignments = sortAlignments;
                 }
                 break;
             case 'v':
@@ -768,6 +774,7 @@ int main(int argc, char *argv[]) {
         cactusDisk_preCacheStrings(cactusDisk, flowers);
     }
     char *tempFile1 = NULL;
+    char *tempFile2 = NULL;
     for (int64_t i = 0; i < stList_length(flowers); i++) {
         flower = stList_get(flowers, i);
         if (!flower_builtBlocks(flower)) { // Do nothing if the flower already has defined blocks
@@ -802,7 +809,13 @@ int main(int argc, char *argv[]) {
                 }
 
                 if(secondaryAlignmentsFile != NULL) {
-                	secondaryPinchIterator = stPinchIterator_constructFromFile(secondaryAlignmentsFile);
+                    if (sortSecondaryAlignments) {
+                        tempFile2 = getTempFile();
+                        stCaf_sortCigarsFileByScoreInDescendingOrder(secondaryAlignmentsFile, tempFile2);
+                        secondaryPinchIterator = stPinchIterator_constructFromFile(tempFile2);
+                    } else {
+                        secondaryPinchIterator = stPinchIterator_constructFromFile(secondaryAlignmentsFile);
+                    }
                 }
 
             } else {
@@ -990,6 +1003,9 @@ int main(int argc, char *argv[]) {
     stList_destruct(flowers);
     if (tempFile1 != NULL) {
         st_system("rm %s", tempFile1);
+    }
+    if (tempFile2 != NULL) {
+        st_system("rm %s", tempFile2);
     }
 
     if (constraintsFile != NULL) {

--- a/caf/cactus_caf.c
+++ b/caf/cactus_caf.c
@@ -859,25 +859,27 @@ int main(int argc, char *argv[]) {
                 printf("Sequence graph statistics after annealing:\n");
                 printThreadSetStatistics(threadSet, flower, stdout);
 
-                // Check for poorly-supported blocks--those that have
-                // been transitively aligned together but with very
-                // few homologies supporting the transitive
-                // alignment. These "megablocks" can snarl up the
-                // graph so that a lot of extra gets thrown away in
-                // the first melting step.
-                stPinchThreadSetBlockIt blockIt = stPinchThreadSet_getBlockIt(threadSet);
-                stPinchBlock *block;
-                while ((block = stPinchThreadSetBlockIt_getNext(&blockIt)) != NULL) {
-                    if (stPinchBlock_getDegree(block) > minimumBlockDegreeToCheckSupport) {
-                        uint64_t supportingHomologies = stPinchBlock_getNumSupportingHomologies(block);
-                        uint64_t possibleSupportingHomologies = numPossibleSupportingHomologies(block, flower);
-                        double support = ((double) supportingHomologies) / possibleSupportingHomologies;
-                        if (support < minimumBlockHomologySupport) {
-                            fprintf(stdout, "Destroyed a megablock with degree %" PRIi64
-                                    " and %" PRIi64 " supporting homologies out of a maximum "
-                                    "of %" PRIi64 " (%lf%%).\n", stPinchBlock_getDegree(block),
-                                    supportingHomologies, possibleSupportingHomologies, support);
-                            stPinchBlock_destruct(block);
+                if (minimumBlockHomologySupport > 0) {
+                    // Check for poorly-supported blocks--those that have
+                    // been transitively aligned together but with very
+                    // few homologies supporting the transitive
+                    // alignment. These "megablocks" can snarl up the
+                    // graph so that a lot of extra gets thrown away in
+                    // the first melting step.
+                    stPinchThreadSetBlockIt blockIt = stPinchThreadSet_getBlockIt(threadSet);
+                    stPinchBlock *block;
+                    while ((block = stPinchThreadSetBlockIt_getNext(&blockIt)) != NULL) {
+                        if (stPinchBlock_getDegree(block) > minimumBlockDegreeToCheckSupport) {
+                            uint64_t supportingHomologies = stPinchBlock_getNumSupportingHomologies(block);
+                            uint64_t possibleSupportingHomologies = numPossibleSupportingHomologies(block, flower);
+                            double support = ((double) supportingHomologies) / possibleSupportingHomologies;
+                            if (support < minimumBlockHomologySupport) {
+                                fprintf(stdout, "Destroyed a megablock with degree %" PRIi64
+                                        " and %" PRIi64 " supporting homologies out of a maximum "
+                                        "of %" PRIi64 " (%lf%%).\n", stPinchBlock_getDegree(block),
+                                        supportingHomologies, possibleSupportingHomologies, support);
+                                stPinchBlock_destruct(block);
+                            }
                         }
                     }
                 }

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -74,7 +74,10 @@ def main():
                         help="The way to run the Cactus binaries", default=None)
     parser.add_argument("--nonBlastInput", action="store_true",
                         help="Input does not come from cactus-blast: Do not append ids to fasta names")
-
+    parser.add_argument("--nonBlastMegablockFilter", action="store_true",
+                        help="By default, the megablock filter is off for --nonBlastInput, as it does not play"
+                        "nicely with reference-based alignments.  This flag will turn it back on")
+    
 
     options = parser.parse_args()
 
@@ -228,6 +231,10 @@ def runCactusAfterBlastOnly(options):
             configNode = ET.parse(project.getConfigPath()).getroot()
             configWrapper = ConfigWrapper(configNode)
             configWrapper.substituteAllPredefinedConstantsWithLiterals()
+
+            if options.nonBlastInput and not options.nonBlastMegablockFilter:
+                # turn off the megablock filter as it ruins non-all-to-all alignments
+                configWrapper.disableCafMegablockFilter()
 
             workFlowArgs = CactusWorkflowArguments(options, experimentFile=experimentFile, configNode=configNode, seqIDMap = project.inputSequenceIDMap)
 

--- a/src/cactus/shared/configWrapper.py
+++ b/src/cactus/shared/configWrapper.py
@@ -212,6 +212,12 @@ class ConfigWrapper:
             replaceAllDivergenceParameters(self.xmlRoot)
         return messages
 
+    def disableCafMegablockFilter(self):
+        """Make sure the filter is off in caf """
+        cafNode = findRequiredNode(self.xmlRoot, "caf")
+        cafNode.attrib["minimumBlockHomologySupport"] = "0"
+        cafNode.attrib["minimumBlockDegreeToCheckSupport"] = "9999999999"
+
     def turnAllModesOn(self):
         """Switches on check, normalisation etc. to use when debugging/testing
         """


### PR DESCRIPTION
Some filters in caf aren't playing nicely with star tree / pangenome inputs.   So far I've found
* The megablock filter (0.05% of all possible transitive support required for blocks >= 10) basically pulls apart nearly all the blocks when giving reference-based input via star tree, as n/n^2 quickly drops below 0.05 as the number of sequences increases.  Hopefully just toggling it off will help. 
* The "singleCopy" alignment filter doesn't keep duplications out of the graph as one might expect, because it doesn't get applied to secondary alignments.  Changing the filters that previously only ran on primary alignments to run on both primary and secondary alignments.  The default filter `filterSecondariesByMultipleSpecies` remains unchanged in that it only runs on secondaries., 