### PR TITLE
GPU Repeatmasking fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ There are many different ways to install and run Cactus:
 
 #### Docker Image
 
-Cactus docker images are hosted on [quay](https://quay.io/repository/comparative-genomics-toolkit/cactus).  The image for the latest release is listed on the [Releases Page](https://github.com/ComparativeGenomicsToolkit/cactus/releases).  Here is an command line to run the included evolver mammals example with release 1.2.2
+Cactus docker images are hosted on [quay](https://quay.io/repository/comparative-genomics-toolkit/cactus).  The image for the latest release is listed on the [Releases Page](https://github.com/ComparativeGenomicsToolkit/cactus/releases).  Here is an command line to run the included evolver mammals example with release 1.2.3
 ```
 wget https://raw.githubusercontent.com/ComparativeGenomicsToolkit/cactus/master/examples/evolverMammals.txt
-docker run -v $(pwd):/data --rm -it quay.io/comparative-genomics-toolkit/cactus:v1.2.2 cactus /data/jobStore /data/evolverMammals.txt /data/evolverMammals.hal --root mr --binariesMode local
+docker run -v $(pwd):/data --rm -it quay.io/comparative-genomics-toolkit/cactus:v1.2.3 cactus /data/jobStore /data/evolverMammals.txt /data/evolverMammals.hal --root mr --binariesMode local
 
 ```
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,10 @@
+# Release 1.2.3   2020-10-05
+
+- Fix bug where `cactus_fasta_softmask_intervals.py` was expecting 1-based intervals from GPU lastz repeatmasker.
+
+hal2vg version included: [v1.0.1](https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.1/hal2vg)
+GPU Lastz version used in GPU-enabled Docker image: [8b63a0fe1c06b3511dfc4660bd0f9fb7ad7176e7](https://github.com/ComparativeGenomicsToolkit/SegAlign/commit/8b63a0fe1c06b3511dfc4660bd0f9fb7ad7176e7)
+
 # Release 1.2.2   2020-10-02
 
 - hal2vg updated to version 1.0.1

--- a/src/cactus/preprocessor/lastzRepeatMasking/cactus_lastzRepeatMask.py
+++ b/src/cactus/preprocessor/lastzRepeatMasking/cactus_lastzRepeatMask.py
@@ -163,7 +163,10 @@ class LastzRepeatMaskJob(RoundedJob):
 
         # the previous lastz command outputs a file of intervals (denoted with indices) to softmask.
         # we finish by applying these intervals to the input file, to produce the final, softmasked output.
-        args = ["--origin=one"]
+        if self.repeatMaskOptions.gpuLastz:
+            args = ["--origin=zero"]
+        else:
+            args = ["--origin=one"]
         if self.repeatMaskOptions.unmaskOutput:
             args.append("--unmask")
         args.append(maskInfo)

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -866,7 +866,7 @@ def getDockerImage():
 
 def getDockerRelease(gpu=False):
     """Get the most recent docker release."""
-    r = "quay.io/comparative-genomics-toolkit/cactus:v1.2.2"
+    r = "quay.io/comparative-genomics-toolkit/cactus:v1.2.3"
     if gpu:
         r += "-gpu"
     return r


### PR DESCRIPTION
The segalign repeat masker was [fixed up to include cactus_covered_intervals](https://github.com/gsneha26/SegAlign/issues/42#issuecomment-701865527).  But whereas cactus ran it with `--origin=one`, it seems that segalign runs it with (effectively) `--origin=zero`.  This only became apparent on a large run when `cactus_fasta_softmask_intervals.py --origin=one` crashed out on an interval that began with 0.    

Anyway, this patch should hopefully sync the options up properly.  