### PR TITLE
WIP: Partial Order Alignment (POA) option for cactus_bar

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "submodules/kyoto"]
 	path = submodules/kyoto
 	url = https://github.com/ComparativeGenomicsToolkit/kyoto.git
+[submodule "submodules/abPOA"]
+	path = submodules/abPOA
+	url = https://github.com/yangao07/abPOA.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,9 @@ RUN mkdir /opt/cactus/
 COPY runtime/wrapper.sh /opt/cactus/
 RUN chmod 777 /opt/cactus/wrapper.sh
 
+# log the memory usage (with --realTimeLogging) for local commands
+ENV CACTUS_LOG_MEMORY 1
+
 # remember where we came from
 ARG CACTUS_COMMIT
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic-20200112 AS builder
+FROM quay.io/glennhickey/cactus-ci-base:latest as builder
 
 # apt dependencies for build
 RUN apt-get update && apt-get install -y build-essential git python3 python3-dev python3-pip zlib1g-dev wget libbz2-dev pkg-config libhdf5-dev liblzo2-dev libtokyocabinet-dev wget
@@ -39,7 +39,7 @@ RUN mkdir -p /wheels && cd /wheels && python3 -m pip install -U pip && python3 -
 FROM ubuntu:bionic-20200112
 
 # apt dependencies for runtime
-RUN apt-get update && apt-get install -y --no-install-recommends git python3 python3-pip python3-distutils zlib1g libbz2-1.0 net-tools libhdf5-100 liblzo2-2 libtokyocabinet9 rsync libkrb5-3 libk5crypto3
+RUN apt-get update && apt-get install -y --no-install-recommends git python3 python3-pip python3-distutils zlib1g libbz2-1.0 net-tools libhdf5-100 liblzo2-2 libtokyocabinet9 rsync libkrb5-3 libk5crypto3 time
 
 # copy temporary files for installing cactus
 COPY --from=builder /home/cactus /tmp/cactus

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN cd /home/cactus/bin && for i in wigToBigWig faToTwoBit bedToBigBed bigBedToB
 RUN cd /home/cactus/bin && ../build-tools/downloadHal2vg
 
 # remove test executables
-RUN cd /home/cactus && rm -f ${binPackageDir}/bin/*test ${binPackageDir}/bin/*tests ${binPackageDir}/bin/*Test ${binPackageDir}/bin/*Tests
+RUN cd /home/cactus && rm -f ${binPackageDir}/bin/*test ${binPackageDir}/bin/*tests ${binPackageDir}/bin/*Test ${binPackageDir}/bin/*Tests ${binPackageDir}/bin/cactus_runEndAlignment
 
 # make the binaries smaller by removing debug symbols 
 RUN cd /home/cactus && strip -d bin/* 2> /dev/null || true

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ evolver_test: all bin/mafComparator
 	PYTHONPATH="" CACTUS_DOCKER_ORG=evolvertestdocker CACTUS_USE_LATEST=1 ${PYTHON} -m pytest ${pytestOpts} test/evolverTest.py
 	docker rmi -f evolvertestdocker/cactus:latest
 
-evolver_test_local: all
+evolver_test_local: all bin/mafComparator
 	CACTUS_BINARIES_MODE=local CACTUS_DOCKER_MODE=0 ${PYTHON} -m pytest ${pytestOpts} test/evolverTest.py::TestCase::testEvolverLocal
 
 ##

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ evolver_test_local: all bin/mafComparator
 	CACTUS_BINARIES_MODE=local CACTUS_DOCKER_MODE=0 ${PYTHON} -m pytest ${pytestOpts} test/evolverTest.py::TestCase::testEvolverLocal
 
 evolver_test_poa_local: all bin/mafComparator
-	CACTUS_BINARIES_MODE=local CACTUS_DOCKER_MODE=0 ${PYTHON} -m pytest ${pytestOpts} test/evolverTest.py::TestCase::testEvolverPOALocal
+	CACTUS_BINARIES_MODE=local CACTUS_DOCKER_MODE=0 ${PYTHON} -m pytest ${pytestOpts} -s test/evolverTest.py::TestCase::testEvolverPOALocal
 
 
 ##

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@ rootPath = .
 
 include ${rootPath}/include.mk
 
-modules = api setup blastLib caf bar blast normalisation hal phylogeny reference faces check pipeline preprocessor hal dbTest
+modules = api setup blastLib caf bar blast normalisation hal phylogeny reference faces check pipeline preprocessor dbTest
 
 # submodules are in multiple pass to handle dependencies cactus2hal being dependent on
 # both cactus and sonLib
-submodules1 = kyoto sonLib cPecan hal matchingAndOrdering pinchesAndCacti
+submodules1 = kyoto sonLib cPecan hal matchingAndOrdering pinchesAndCacti abPOA
 submodules2 = cactus2hal
 submodules = ${submodules1} ${submodules2}
 
@@ -189,6 +189,11 @@ suball.hal: suball.sonLib
 	mkdir -p bin
 	-ln -f submodules/hal/bin/* bin/
 	-ln -f submodules/hal/lib/libHal.a submodules/hal/lib/halLib.a
+
+suball.abPOA:
+	cd submodules/abPOA && ${MAKE}
+	ln -f submodules/abPOA/lib/*.a ${LIBDIR}
+	ln -f submodules/abPOA/include/*.h ${INCLDIR}
 
 subclean.%:
 	cd submodules/$* && ${MAKE} clean

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,8 @@ bin/mafComparator:
 	cd submodules && git clone https://github.com/dentearl/mafTools.git && cd mafTools && git checkout 82077ac39c9966ac8fb8efe9796fbcfb7da55477
 	cd submodules/mafTools && sed -i -e 's/-Werror//g' inc/common.mk lib/Makefile && sed -i -e 's/mafExtractor//g' Makefile && make
 	cp submodules/mafTools/bin/mafComparator bin/
-	cd ${CWD}/test && wget -q https://raw.githubusercontent.com/UCSantaCruzComputationalGenomicsLab/cactusTestData/master/evolver/mammals/loci1/all.maf -O all.maf
+	cd ${CWD}/test && wget -q https://raw.githubusercontent.com/UCSantaCruzComputationalGenomicsLab/cactusTestData/master/evolver/mammals/loci1/all.maf -O mammals-truth.maf
+	cd ${CWD}/test && wget -q https://raw.githubusercontent.com/UCSantaCruzComputationalGenomicsLab/cactusTestData/master/evolver/primates/loci1/all.maf -O primates-truth.maf
 
 evolver_test: all bin/mafComparator
 	-docker rmi -f evolvertestdocker/cactus:latest

--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,10 @@ evolver_test: all bin/mafComparator
 evolver_test_local: all bin/mafComparator
 	CACTUS_BINARIES_MODE=local CACTUS_DOCKER_MODE=0 ${PYTHON} -m pytest ${pytestOpts} test/evolverTest.py::TestCase::testEvolverLocal
 
+evolver_test_poa_local: all bin/mafComparator
+	CACTUS_BINARIES_MODE=local CACTUS_DOCKER_MODE=0 ${PYTHON} -m pytest ${pytestOpts} test/evolverTest.py::TestCase::testEvolverPOALocal
+
+
 ##
 # clean targets
 ##

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,14 @@ test_nonblast: ${testModules:%=%_runtest_nonblast}
 ${versionPy}:
 	echo "cactus_commit = '${git_commit}'" >$@
 
-evolver_test: all
+bin/mafComparator:
+	rm -rf submodules/mafTools
+	cd submodules && git clone https://github.com/dentearl/mafTools.git && cd mafTools && git checkout 82077ac39c9966ac8fb8efe9796fbcfb7da55477
+	cd submodules/mafTools && sed -i 's/-Werror//g' inc/common.mk lib/Makefile && sed -i 's/mafExtractor//g' Makefile && make
+	cp submodules/mafTools/bin/mafComparator bin/
+	cd ${CWD}/test && wget -q https://raw.githubusercontent.com/UCSantaCruzComputationalGenomicsLab/cactusTestData/master/evolver/mammals/loci1/all.maf -O all.maf
+
+evolver_test: all bin/mafComparator
 	-docker rmi -f evolvertestdocker/cactus:latest
 	sed -i -e 's/FROM.*AS builder/FROM quay.io\/glennhickey\/cactus-ci-base:latest as builder/' Dockerfile
 	docker build --network=host -t evolvertestdocker/cactus:latest . --build-arg CACTUS_COMMIT=${git_commit}

--- a/bar/Makefile
+++ b/bar/Makefile
@@ -3,7 +3,7 @@ include ${rootPath}/include.mk
 
 libSources = impl/*.c
 libHeaders = inc/*.h
-libTests = tests/adjacencySequencesTest.c tests/allTests.c tests/endAlignerTest.c tests/flowerAlignerTest.c tests/flowersShared.h tests/rescueTest.c
+libTests = tests/adjacencySequencesTest.c tests/allTests.c tests/endAlignerTest.c tests/flowerAlignerTest.c tests/rescueTest.c
 libRunEndAlignment = tests/runEndAlignment.c
 
 #${LIBDIR}/stCaf.a

--- a/bar/Makefile
+++ b/bar/Makefile
@@ -3,7 +3,9 @@ include ${rootPath}/include.mk
 
 libSources = impl/*.c
 libHeaders = inc/*.h
-libTests = tests/*.c
+libTests = tests/adjacencySequencesTest.c tests/allTests.c tests/endAlignerTest.c tests/flowerAlignerTest.c tests/flowersShared.h tests/rescueTest.c
+libRunEndAlignment = tests/runEndAlignment.c
+
 #${LIBDIR}/stCaf.a
 commonBarLibs =  ${LIBDIR}/stCaf.a ${sonLibDir}/stPinchesAndCacti.a ${LIBDIR}/cactusLib.a ${sonLibDir}/3EdgeConnected.a ${sonLibDir}/cPecanLib.a  
 stBarDependencies =  ${commonBarLibs} ${LIBDEPENDS}
@@ -12,7 +14,7 @@ LDLIBS += ${commonBarLibs} ${sonLibDir}/sonLib.a ${databaseLibs} -lm
 all: all_libs all_progs
 all_libs: ${LIBDIR}/cactusBarLib.a
 all_progs: all_libs
-	${MAKE} ${BINDIR}/cactus_bar ${BINDIR}/cactus_barTests
+	${MAKE} ${BINDIR}/cactus_bar ${BINDIR}/cactus_barTests ${BINDIR}/cactus_runEndAlignment
 
 clean : 
 	rm -f ${BINDIR}/cactus_barTests  ${LIBDIR}/cactusBarLib.a *.o
@@ -22,6 +24,9 @@ ${BINDIR}/cactus_bar : cactus_bar.c  ${LIBDIR}/cactusBarLib.a ${stBarDependencie
 
 ${BINDIR}/cactus_barTests : ${libTests} tests/*.h ${LIBDIR}/cactusBarLib.a ${stBarDependencies}
 	${CC} ${CPPFLAGS} ${CFLAGS} ${LDFLAGS} -Wno-error -o ${BINDIR}/cactus_barTests ${libTests} ${LIBDIR}/cactusBarLib.a ${LDLIBS}
+
+${BINDIR}/cactus_runEndAlignment : ${libRunEndAlignment} ${LIBDIR}/cactusBarLib.a ${stBarDependencies}
+	${CC} ${CPPFLAGS} ${CFLAGS} ${LDFLAGS} -Wno-error -o ${BINDIR}/cactus_runEndAlignment ${libRunEndAlignment} ${LIBDIR}/cactusBarLib.a ${LDLIBS}
 
 ${LIBDIR}/cactusBarLib.a : ${libSources} ${libHeaders}
 	${CC} ${CPPFLAGS} ${CFLAGS} -c ${libSources} 

--- a/bar/cactus_bar.c
+++ b/bar/cactus_bar.c
@@ -70,6 +70,8 @@ void usage() {
 
     fprintf(stderr, "-M --minimumCoverageToRescue : Unaligned segments must have at least this proportion of their bases covered by an outgroup to be rescued.\n");
 
+    fprintf(stderr, "-P --partialOrderAlignment : Use partial order aligner instead of Pecan for multiple alignment subproblems.\n");
+
     fprintf(stderr, "-h --help : Print this help screen\n");
 }
 
@@ -111,6 +113,8 @@ int main(int argc, char *argv[]) {
     char *ingroupCoverageFilePath = NULL;
     int64_t minimumSizeToRescue = 1;
     double minimumCoverageToRescue = 0.0;
+    // toggle from pecan to abpoa for multiple alignment
+    bool poaMode = false;
 
     PairwiseAlignmentParameters *pairwiseAlignmentBandingParameters = pairwiseAlignmentBandingParameters_construct();
 
@@ -140,11 +144,12 @@ int main(int argc, char *argv[]) {
                         {"minimumSizeToRescue", required_argument, 0, 'K'},
                         {"minimumCoverageToRescue", required_argument, 0, 'M'},
                         { "minimumNumberOfSpecies", required_argument, 0, 'N' },
+                        {"partialOrderAlignment", no_argument, 0, 'P'},                        
                         { 0, 0, 0, 0 } };
 
         int option_index = 0;
 
-        int key = getopt_long(argc, argv, "a:b:hi:j:kl:o:p:q:r:t:u:wy:A:B:D:E:FGI:J:K:L:M:N:", long_options, &option_index);
+        int key = getopt_long(argc, argv, "a:b:hi:j:kl:o:p:q:r:t:u:wy:A:B:D:E:FGI:J:K:L:M:N:P", long_options, &option_index);
 
         if (key == -1) {
             break;
@@ -265,6 +270,9 @@ int main(int argc, char *argv[]) {
                     st_errAbort("Error parsing minimumNumberOfSpecies parameter");
                 }
                 break;
+            case 'P':
+                poaMode = true;
+                break;
             default:
                 usage();
                 return 1;
@@ -319,7 +327,7 @@ int main(int argc, char *argv[]) {
                 st_errAbort("The end %" PRIi64 " was not found in the flower\n", *((Name *)stList_get(names, i)));
             }
             stSortedSet *endAlignment = makeEndAlignment(sM, end, spanningTrees, maximumLength, useProgressiveMerging,
-                            matchGamma, pairwiseAlignmentBandingParameters);
+                                                         matchGamma, pairwiseAlignmentBandingParameters, poaMode);
             writeEndAlignmentToDisk(end, endAlignment, fileHandle);
             stSortedSet_destruct(endAlignment);
         }

--- a/bar/cactus_bar.c
+++ b/bar/cactus_bar.c
@@ -380,7 +380,7 @@ int main(int argc, char *argv[]) {
             st_logInfo("Processing a flower\n");
 
             stSortedSet *alignedPairs = makeFlowerAlignment3(sM, flower, listOfEndAlignmentFiles, spanningTrees, maximumLength,
-                    useProgressiveMerging, matchGamma, pairwiseAlignmentBandingParameters, pruneOutStubAlignments);
+                    useProgressiveMerging, matchGamma, pairwiseAlignmentBandingParameters, pruneOutStubAlignments, poaMode);
             st_logInfo("Created the alignment: %" PRIi64 " pairs\n", stSortedSet_size(alignedPairs));
             stPinchIterator *pinchIterator = stPinchIterator_constructFromAlignedPairs(alignedPairs, getNextAlignedPairAlignment);
 

--- a/bar/impl/endAligner.c
+++ b/bar/impl/endAligner.c
@@ -96,12 +96,10 @@ stSortedSet *makeEndAlignment(StateMachine *sM, End *end, int64_t spanningTrees,
         stListIterator *it = stList_getIterator(mA->alignedPairs);
         stIntTuple* alignedPair;
         while ((alignedPair = stList_getNext(it)) != NULL) {
-            stList_append(mA->chosenPairwiseAlignments, stIntTuple_construct5(
+            stList_append(mA->chosenPairwiseAlignments, stIntTuple_construct3(
                               stIntTuple_get(alignedPair, 0),
                               stIntTuple_get(alignedPair, 1),
-                              stIntTuple_get(alignedPair, 2),
-                              stIntTuple_get(alignedPair, 3),
-                              stIntTuple_get(alignedPair, 4)));
+                              stIntTuple_get(alignedPair, 3)));
         }
     } else {
         mA = makeAlignment(sM, seqFrags, spanningTrees, 100000000, useProgressiveMerging, gapGamma, pairwiseAlignmentBandingParameters);

--- a/bar/impl/flowerAligner.c
+++ b/bar/impl/flowerAligner.c
@@ -523,7 +523,8 @@ static stSortedSet *getEndsToAlign(Flower *flower, int64_t maxSequenceLength) {
 
 static void computeMissingEndAlignments(StateMachine *sM, Flower *flower, stHash *endAlignments, int64_t spanningTrees,
         int64_t maxSequenceLength, bool useProgressiveMerging, float gapGamma,
-        PairwiseAlignmentParameters *pairwiseAlignmentBandingParameters) {
+        PairwiseAlignmentParameters *pairwiseAlignmentBandingParameters,
+        bool poa) {
     /*
      * Creates end alignments for the ends that
      * do not have an alignment in the "endAlignments" hash, only creating
@@ -553,10 +554,10 @@ static void computeMissingEndAlignments(StateMachine *sM, Flower *flower, stHash
 
 stSortedSet *makeFlowerAlignment(StateMachine *sM, Flower *flower, int64_t spanningTrees, int64_t maxSequenceLength,
         bool useProgressiveMerging, float gapGamma,
-        PairwiseAlignmentParameters *pairwiseAlignmentBandingParameters, bool pruneOutStubAlignments) {
+        PairwiseAlignmentParameters *pairwiseAlignmentBandingParameters, bool pruneOutStubAlignments, bool poa) {
     stHash *endAlignments = stHash_construct2(NULL, (void(*)(void *)) stSortedSet_destruct);
     computeMissingEndAlignments(sM, flower, endAlignments, spanningTrees, maxSequenceLength,
-            useProgressiveMerging, gapGamma, pairwiseAlignmentBandingParameters);
+            useProgressiveMerging, gapGamma, pairwiseAlignmentBandingParameters, poa);
     return makeFlowerAlignment2(flower, endAlignments, pruneOutStubAlignments);
 }
 
@@ -578,13 +579,13 @@ static void loadEndAlignments(Flower *flower, stHash *endAlignments, stList *lis
 
 stSortedSet *makeFlowerAlignment3(StateMachine *sM, Flower *flower, stList *listOfEndAlignmentFiles, int64_t spanningTrees,
         int64_t maxSequenceLength, bool useProgressiveMerging, float gapGamma,
-        PairwiseAlignmentParameters *pairwiseAlignmentBandingParameters, bool pruneOutStubAlignments) {
+        PairwiseAlignmentParameters *pairwiseAlignmentBandingParameters, bool pruneOutStubAlignments, bool poa) {
     stHash *endAlignments = stHash_construct2(NULL, (void(*)(void *)) stSortedSet_destruct);
     if(listOfEndAlignmentFiles != NULL) {
         loadEndAlignments(flower, endAlignments, listOfEndAlignmentFiles);
     }
     computeMissingEndAlignments(sM, flower, endAlignments, spanningTrees, maxSequenceLength,
-            useProgressiveMerging, gapGamma, pairwiseAlignmentBandingParameters);
+            useProgressiveMerging, gapGamma, pairwiseAlignmentBandingParameters, poa);
     return makeFlowerAlignment2(flower, endAlignments, pruneOutStubAlignments);
 }
 

--- a/bar/impl/flowerAligner.c
+++ b/bar/impl/flowerAligner.c
@@ -541,7 +541,7 @@ static void computeMissingEndAlignments(StateMachine *sM, Flower *flower, stHash
                         end,
                         makeEndAlignment(sM, end, spanningTrees, maxSequenceLength,
                                 useProgressiveMerging, gapGamma,
-                                pairwiseAlignmentBandingParameters));
+                                pairwiseAlignmentBandingParameters, false));
             } else {
                 stHash_insert(endAlignments, end, stSortedSet_construct());
             }

--- a/bar/impl/flowerAligner.c
+++ b/bar/impl/flowerAligner.c
@@ -542,7 +542,7 @@ static void computeMissingEndAlignments(StateMachine *sM, Flower *flower, stHash
                         end,
                         makeEndAlignment(sM, end, spanningTrees, maxSequenceLength,
                                 useProgressiveMerging, gapGamma,
-                                pairwiseAlignmentBandingParameters, false));
+                                pairwiseAlignmentBandingParameters, poa));
             } else {
                 stHash_insert(endAlignments, end, stSortedSet_construct());
             }

--- a/bar/impl/poaAligner.c
+++ b/bar/impl/poaAligner.c
@@ -124,6 +124,9 @@ MultipleAlignment *makePartialOrderAlignment(StateMachine *sM, stList *seqFrags,
     free(seq_lens);
     abpoa_free(ab, abpt);
     abpoa_free_para(abpt); 
+
+    // in debug mode, cactus uses the dreaded -Wall -Werror combo.  This line is a hack to allow compilition with these flags
+    if (false) SIMDMalloc(0, 0);
     
     return mA;
 }

--- a/bar/impl/poaAligner.c
+++ b/bar/impl/poaAligner.c
@@ -1,0 +1,189 @@
+/*
+ * This is designed as a drop-in replacement for the multiple aligner from pecan that gets used in the end aligner. 
+ * The idea is that this will scale better for larger numbers of input samples, which seems to blow up the memory
+ * in pecan.  
+ *
+ * Released under the MIT license, see LICENSE.txt
+ */
+
+#include "endAligner.h"
+#include "multipleAligner.h"
+#include "abpoa.h"
+#include "poaAligner.h"
+#include "adjacencySequences.h"
+#include "pairwiseAligner.h"
+
+// AaCcGgTtNn ==> 0,1,2,3,4
+static unsigned char nst_nt4_table[256] = {
+    4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4, 
+    4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4, 
+    4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 5 /*'-'*/, 4, 4,
+    4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4, 
+    4, 0, 4, 1,  4, 4, 4, 2,  4, 4, 4, 4,  4, 4, 4, 4, 
+    4, 4, 4, 4,  3, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4, 
+    4, 0, 4, 1,  4, 4, 4, 2,  4, 4, 4, 4,  4, 4, 4, 4, 
+    4, 4, 4, 4,  3, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4, 
+    4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4, 
+    4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4, 
+    4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4, 
+    4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4, 
+    4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4, 
+    4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4, 
+    4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4, 
+    4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4
+};
+
+MultipleAlignment *makePartialOrderAlignment(StateMachine *sM, stList *seqFrags,
+                                             int64_t spanningTrees, int64_t maxPairsToConsider,
+                                             bool useProgressiveMerging,
+                                             float matchGamma,
+                                             PairwiseAlignmentParameters *pairwiseAlignmentBandingParameters) {
+
+    // transorm the input for abpoa, using its example.c as a guide
+    int64_t n_seqs = stList_length(seqFrags);
+    
+    // collect sequence length, trasform ACGT to 0123
+    int *seq_lens = (int*)malloc(sizeof(int) * n_seqs);
+    uint8_t **bseqs = (uint8_t**)malloc(sizeof(uint8_t*) * n_seqs);
+
+    stListIterator *it = stList_getIterator(seqFrags);
+    SeqFrag* frag;
+    int i = 0;
+    int j = 0;    
+    while ((frag = stList_getNext(it)) != NULL) {
+        fprintf(stderr, "frag = %s\n", frag->seq);
+        seq_lens[i] = frag->length;
+        bseqs[i] = (uint8_t*)malloc(sizeof(uint8_t) * frag->length);
+        for (j = 0; j < frag->length; ++j) {
+            // todo: support iupac characters!
+            bseqs[i][j] = nst_nt4_table[(int)frag->seq[j]];
+        }
+        ++i;
+    }
+
+    // initialize variables
+    abpoa_t *ab = abpoa_init();
+    abpoa_para_t *abpt = abpoa_init_para();
+
+    // alignment parameters
+    // abpt->align_mode = 0; // 0:global alignment, 1:extension
+    // abpt->match = 2;      // match score
+    // abpt->mismatch = 4;   // mismatch penalty
+    // abpt->gap_mode = ABPOA_CONVEX_GAP; // gap penalty mode
+    // abpt->gap_open1 = 4;  // gap open penalty #1
+    // abpt->gap_ext1 = 2;   // gap extension penalty #1
+    // abpt->gap_open2 = 24; // gap open penalty #2
+    // abpt->gap_ext2 = 1;   // gap extension penalty #2
+                             // gap_penalty = min{gap_open1 + gap_len * gap_ext1, gap_open2 + gap_len * gap_ext2}
+    // abpt->bw = 10;        // extra band used in adaptive banded DP
+    // abpt->bf = 0.01; 
+     
+    // output options
+    abpt->out_msa = 1; // generate Row-Column multiple sequence alignment(RC-MSA), set 0 to disable
+    abpt->out_cons = 0; // generate consensus sequence, set 0 to disable
+
+    abpoa_post_set_para(abpt);
+
+    // variables to store result
+    uint8_t **cons_seq; int **cons_cov, *cons_l, cons_n=0;
+    uint8_t **msa_seq; int msa_l=0;
+
+    // perform abpoa-msa
+    abpoa_msa(ab, abpt, n_seqs, NULL, seq_lens, bseqs, NULL, &cons_seq, &cons_cov, &cons_l, &cons_n, &msa_seq, &msa_l);
+
+    // print
+    fprintf(stdout, "=== output to variables ===\n");
+    for (i = 0; i < cons_n; ++i) {
+        fprintf(stdout, ">Consensus_sequence\n");
+        for (j = 0; j < cons_l[i]; ++j)
+            fprintf(stdout, "%c", "ACGTN"[cons_seq[i][j]]);
+        fprintf(stdout, "\n");
+    }
+
+    // todo: score
+    MultipleAlignment* mA = poaMatrixToMultipleAlignment(msa_seq, n_seqs, msa_l, 0, seqFrags);
+        
+    // clean up
+    if (cons_n) {
+        for (i = 0; i < cons_n; ++i) {
+            free(cons_seq[i]); free(cons_cov[i]);
+        }
+        free(cons_seq); free(cons_cov); free(cons_l);
+    }
+    if (msa_l) {
+        for (i = 0; i < n_seqs; ++i) {
+            free(msa_seq[i]);
+        }
+        free(msa_seq);
+    }
+
+    for (i = 0; i < n_seqs; ++i) {
+        free(bseqs[i]);
+    }
+    
+    free(bseqs);
+    free(seq_lens);
+    abpoa_free(ab, abpt);
+    abpoa_free_para(abpt); 
+    
+    return mA;
+}
+
+static inline char toBase(uint8_t n) {
+    return "ACGTN-"[n];
+}
+
+MultipleAlignment *poaMatrixToMultipleAlignment(uint8_t** msaSeq, int numSeqs, int msaWidth, int score, stList* seqFrags) {
+
+    fprintf(stdout, ">Multiple_sequence_alignment\n");
+    for (int i = 0; i < numSeqs; ++i) {
+        for (int j = 0; j < msaWidth; ++j) {
+            fprintf(stdout, "%c", toBase(msaSeq[i][j]));
+        }
+        fprintf(stdout, "\n");
+    }
+
+    // this is a big waste of memory
+    // todo: can we go lower into the poa api to avoid, or perhaps just use an interval index
+    int32_t** offsets = st_calloc(numSeqs, sizeof(int32_t*));
+    for (int i = 0; i < numSeqs; ++i) {
+        offsets[i] = st_calloc(msaWidth, sizeof(int32_t));
+    }
+    for (int i = 0; i < numSeqs; ++i) {
+        int32_t offset = 0;
+        for (int j = 0; j < msaWidth; ++j) {
+            offsets[i][j] = offset;
+            if (toBase(msaSeq[i][j]) != '-') {
+                ++offset;
+            }
+        }
+        int64_t seqLength = ((SeqFrag*)stList_get(seqFrags, i))->length;
+        assert(offset >= seqLength);
+    }
+    
+    MultipleAlignment *mA = st_calloc(1, sizeof(MultipleAlignment));
+
+    //pairwise alignment pairs, with sequence indices
+    mA->alignedPairs = stList_construct3(0, (void(*)(void *)) stIntTuple_destruct); //pairwise alignment pairs, with sequence indices
+
+    for (int column = 0; column < msaWidth; ++column) {
+        int anchor = -1;
+        for (int seqIdx = 0; seqIdx < numSeqs; ++seqIdx) {
+            if (toBase(msaSeq[seqIdx][column]) != 'N' && toBase(msaSeq[seqIdx][column]) != '-') {
+                if (anchor == -1) {
+                    anchor = seqIdx;
+                } else if (anchor >= 0) {
+                    stList_append(mA->alignedPairs, stIntTuple_construct5(
+                                      score,
+                                      anchor,
+                                      offsets[anchor][column],
+                                      seqIdx,
+                                      offsets[seqIdx][column]));
+                }
+            }
+        }
+    }
+    return mA;
+    
+}
+

--- a/bar/impl/poaAligner.c
+++ b/bar/impl/poaAligner.c
@@ -109,6 +109,8 @@ MultipleAlignment *makePartialOrderAlignment(StateMachine *sM, stList *seqFrags,
     MultipleAlignment *mA = st_calloc(1, sizeof(MultipleAlignment));
             
     mA->alignedPairs = poaMatrixToAlignedPairs(msa_seq, n_seqs, msa_l, 0, seqFrags);
+
+    mA->columns = makeColumns(seqFrags);
         
     // clean up
     for (i = 0; i < n_seqs; ++i) {
@@ -132,7 +134,7 @@ MultipleAlignment *makePartialOrderAlignment(StateMachine *sM, stList *seqFrags,
 }
 
 stList *poaMatrixToAlignedPairs(uint8_t** msaSeq, int numSeqs, int msaWidth, int score, stList* seqFrags) {
-
+/*
     fprintf(stdout, ">Multiple_sequence_alignment\n");
     for (int i = 0; i < numSeqs; ++i) {
         for (int j = 0; j < msaWidth; ++j) {
@@ -140,7 +142,7 @@ stList *poaMatrixToAlignedPairs(uint8_t** msaSeq, int numSeqs, int msaWidth, int
         }
         fprintf(stdout, "\n");
     }
-
+*/
     // this is a big waste of memory
     // todo: can we go lower into the poa api to avoid, or perhaps just use an interval index
     int32_t** offsets = st_calloc(numSeqs, sizeof(int32_t*));

--- a/bar/inc/endAligner.h
+++ b/bar/inc/endAligner.h
@@ -48,8 +48,9 @@ int alignedPair_cmpFn(const AlignedPair *alignedPair1, const AlignedPair *aligne
  * to the alignerPair comparison function.
  */
 stSortedSet *makeEndAlignment(StateMachine *sM, End *end, int64_t spanningTrees, int64_t maxSequenceLength,
-        bool useProgressiveMerging, float gapGamma,
-        PairwiseAlignmentParameters *pairwiseAlignmentBandingParameters);
+                              bool useProgressiveMerging, float gapGamma,
+                              PairwiseAlignmentParameters *pairwiseAlignmentBandingParameters,
+                              bool poa);
 
 /*
  * Writes an end alignment to the given file.

--- a/bar/inc/flowerAligner.h
+++ b/bar/inc/flowerAligner.h
@@ -25,14 +25,14 @@
  */
 stSortedSet *makeFlowerAlignment(StateMachine *sM, Flower *flower, int64_t spanningTrees,
         int64_t maxSequenceLength, bool useProgressiveMerging, float gapGamma,
-        PairwiseAlignmentParameters *pairwiseAlignmentBandingParameters, bool pruneOutStubAlignments);
+        PairwiseAlignmentParameters *pairwiseAlignmentBandingParameters, bool pruneOutStubAlignments, bool poa);
 
 /*
  * As above, but including alignments from disk.
  */
 stSortedSet *makeFlowerAlignment3(StateMachine *sM, Flower *flower, stList *listOfEndAlignmentFiles, int64_t spanningTrees,
         int64_t maxSequenceLength, bool useProgressiveMerging, float gapGamma,
-        PairwiseAlignmentParameters *pairwiseAlignmentBandingParameters, bool pruneOutStubAlignments);
+        PairwiseAlignmentParameters *pairwiseAlignmentBandingParameters, bool pruneOutStubAlignments, bool poa);
 
 /*
  * Ascertain which ends should be aligned separately.

--- a/bar/inc/poaAligner.h
+++ b/bar/inc/poaAligner.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2009-2011 by Benedict Paten (benedictpaten@gmail.com)
+ *
+ * Released under the MIT license, see LICENSE.txt
+ */
+
+/*
+ * poaAligner.h
+ *
+ *  Created on: 9 Oct 2020
+ *      Author: glennhickey
+ */
+
+#ifndef POA_ALIGNER_H_
+#define POA_ALIGNER_H_
+
+#include "sonLib.h"
+#include "multipleAligner.h"
+
+/**
+ * Drop-in replacement for makeAlignment() (in multipleAligner.h) that is based on an external POA library.
+ * For larger numbers of sequences, it can be orders of magnitude faster than Pecan.  But... the maximum
+ * length needs to be bounded or it'll just crash out right away trying to allocated a big matrix.   
+ */
+MultipleAlignment *makePartialOrderAlignment(StateMachine *sM, stList *seqFrags,
+                                             float matchGamma,
+                                             PairwiseAlignmentParameters *pairwiseAlignmentBandingParameters);
+
+
+
+
+/**
+ * Convert the gapped matrix structure that abpoa returns into list of aligned pairs.  The algorithm used is
+ * - For each column in the MSA
+ *   - scan until the first non-gapped entry, mark its sequence as the anchor
+ *   - keep scanning, reporting a pairwise alignment of each subsequent sequence and the anchor if non-gapped
+ * So the number of pairs here is O(N * L) (or linear in the size of the MSA matrix)
+ */
+stList *poaMatrixToAlignedPairs(uint8_t** msaSeq, int numSeqs, int msaWidth, int score, stList* seqFrags);
+
+#endif

--- a/bar/tests/endAlignerTest.c
+++ b/bar/tests/endAlignerTest.c
@@ -99,7 +99,7 @@ static void testMakeEndAlignments(CuTest *testCase) {
     int64_t maxLength = 4;
     for (int64_t endIndex = 0; endIndex < 3; endIndex++) {
         End *end = ends[endIndex];
-        stSortedSet *endAlignment = makeEndAlignment(stateMachine, end, 5, maxLength, end_getInstanceNumber(end) > 50, 0.5, pairwiseParameters);
+        stSortedSet *endAlignment = makeEndAlignment(stateMachine, end, 5, maxLength, end_getInstanceNumber(end) > 50, 0.5, pairwiseParameters, false);
 
         stSortedSetIterator *iterator = stSortedSet_getIterator(endAlignment);
         AlignedPair *alignedPair;
@@ -124,7 +124,7 @@ static void testReadAndWriteEndAlignments(CuTest *testCase) {
     int64_t maxLength = 4;
     for (int64_t endIndex = 0; endIndex < 3; endIndex++) {
         End *end = ends[endIndex];
-        stSortedSet *endAlignment = makeEndAlignment(stateMachine, end, 5, maxLength, end_getInstanceNumber(end) > 50, 0.5, pairwiseParameters);
+        stSortedSet *endAlignment = makeEndAlignment(stateMachine, end, 5, maxLength, end_getInstanceNumber(end) > 50, 0.5, pairwiseParameters, false);
         char *temporaryEndAlignmentFile = "temporaryEndAlignmentFile.end";
         FILE *fileHandle = fopen(temporaryEndAlignmentFile, "w");
         writeEndAlignmentToDisk(end, endAlignment, fileHandle);

--- a/bar/tests/flowerAlignerTest.c
+++ b/bar/tests/flowerAlignerTest.c
@@ -110,7 +110,7 @@ void test_flowerAlignerRandom(CuTest *testCase) {
     setup(testCase);
     int64_t maxLength = 5;
     StateMachine *sM = stateMachine5_construct(fiveState);
-    stSortedSet *flowerAlignment = makeFlowerAlignment(sM, flower, 5, maxLength, 1, 0.5, pairwiseParameters, st_random() > 0.5);
+    stSortedSet *flowerAlignment = makeFlowerAlignment(sM, flower, 5, maxLength, 1, 0.5, pairwiseParameters, st_random() > 0.5, false);
     stateMachine_destruct(sM);
     //Check the aligned pairs are all good..
     stSortedSetIterator *iterator = stSortedSet_getIterator(flowerAlignment);

--- a/bar/tests/runEndAlignment.c
+++ b/bar/tests/runEndAlignment.c
@@ -305,6 +305,16 @@ int main(int argc, char *argv[]) {
     stList* seqFrags = stList_construct3(0, free);
 
     fastaReadToFunction(fastaFile, seqFrags, add_fasta_fragment);
+
+    // cap the lengths
+    stListIterator *it = stList_getIterator(seqFrags);
+    SeqFrag* frag;
+    while ((frag = stList_getNext(it)) != NULL) {
+        if (frag->length > maximumLength) {
+            frag->length = maximumLength;
+            frag->seq[maximumLength] = '\0';
+        }
+    }
     
     fclose(fastaFile);
 
@@ -318,11 +328,11 @@ int main(int argc, char *argv[]) {
 
     fprintf(stderr, "doing poa alignment\n");
     t = clock();
-    MultipleAlignment *pA = makePartialOrderAlignment(sM, seqFrags, spanningTrees, 100000000, useProgressiveMerging, pairwiseAlignmentBandingParameters->gapGamma, pairwiseAlignmentBandingParameters);
+    MultipleAlignment *pA = makePartialOrderAlignment(sM, seqFrags, pairwiseAlignmentBandingParameters->gapGamma, pairwiseAlignmentBandingParameters);
     t = clock() - t;
     double abpoaTime = ((double)t)/CLOCKS_PER_SEC;
 
-    print_results(mA);
+    print_results(pA);
 
     fprintf(stderr, "Pecan Time = %lf seconds   abPOA Time = %lf seconds\n", pecanTime, abpoaTime);
 

--- a/bar/tests/runEndAlignment.c
+++ b/bar/tests/runEndAlignment.c
@@ -1,0 +1,348 @@
+/*
+ * This is a hook directly into the multiple alignment part of the end aligner.  It
+ * can be run directly on fasta inputs, in order to develop and debug new ideas
+ * without going through cactus_bar which can only read from the cactus_disk server.
+ * Otherwise, it attempts to take in the same sorts of parameters as cactus_bar
+ *
+ * Released under the MIT license, see LICENSE.txt
+ */
+
+#include <assert.h>
+#include <getopt.h>
+#include <sys/mman.h>
+#include <stdio.h>
+#include <stdio.h>
+#include <time.h>
+
+#include "cactus.h"
+#include "sonLib.h"
+#include "endAligner.h"
+#include "flowerAligner.h"
+#include "rescue.h"
+#include "commonC.h"
+#include "stCaf.h"
+#include "stPinchGraphs.h"
+#include "stPinchIterator.h"
+#include "stateMachine.h"
+#include "multipleAligner.h"
+#include "poaAligner.h"
+
+void usage() {
+    fprintf(stderr, "cactus_runEndAlignment [input-fasta], version 0.2\n");
+    fprintf(stderr, "-a --logLevel : Set the log level\n");
+    fprintf(
+            stderr,
+            "-i --spanningTrees (int >= 0) : The number of spanning trees construct in forming the set of pairwise alignments to include. If the number of pairwise alignments is less than the product of the total number of sequences and the number of spanning trees then all pairwise alignments will be included.\n");
+    fprintf(
+            stderr,
+            "-j --maximumLength (int  >= 0 ) : The maximum length of a sequence to align, only the prefix and suffix maximum length bases are aligned\n");
+    fprintf(stderr, "-k --useBanding : Use banding to speed up the alignments\n");
+    fprintf(stderr, "-l --gapGamma : (float >= 0) The gap gamma (as in the AMAP function)\n");
+    fprintf(stderr, "-L --matchGamma : (float [0, 1]) The match gamma (the avg. weight or greater to be allowed in the alignment)\n");
+    fprintf(stderr, "-o --splitMatrixBiggerThanThis : (int >= 0)  No dp matrix bigger than this number squared will be computed.\n");
+    fprintf(stderr,
+            "-p --anchorMatrixBiggerThanThis : (int >= 0)  Any matrix bigger than this number squared will be broken apart with banding.\n");
+    fprintf(
+            stderr,
+            "-q --repeatMaskMatrixBiggerThanThis : (int >= 0) Any matrix bigger than this after initial banding will be broken apart without repeat masking of the sequences\n");
+    fprintf(stderr, "-r --digaonalExpansion : (int >= 0 and even) Number of x-y diagonals to expand around anchors\n");
+    fprintf(stderr, "-t --constraintDiagonalTrim : (int >= 0) Amount to trim from ends of each anchor\n");
+
+    fprintf(stderr, "-u --minimumDegree : (int >= 0) Minimum number of sequences in a block to be included in the output graph\n");
+
+    fprintf(stderr, "-w --alignAmbiguityCharacters : Align ambiguity characters (anything not ACTGactg) as a wildcard\n");
+
+    fprintf(stderr, "-y --pruneOutStubAlignments : Prune out alignments of sequences that terminates in free stubs stubs\n");
+
+    fprintf(stderr, "-A --minimumIngroupDegree : Number of ingroup sequences required in a block.\n");
+
+    fprintf(stderr, "-B --minimumOutgroupDegree : Number of outgroup sequences required in a block.\n");
+
+    fprintf(stderr, "-D --precomputedAlignments : Precomputed end alignments.\n");
+
+    fprintf(stderr, "-E --endAlignmentsToPrecomputeOutputFile [fileName] : If this output file is provided then bar will read stdin first to parse the flower, then to parse the names of the end alignments to precompute. The results will be placed in this file.\n");
+
+    fprintf(stderr,
+            "-F --useProgressiveMerging : Use progressive merging instead of poset merging for constructing multiple sequence alignments.\n");
+
+    fprintf(stderr, "-G --calculateWhichEndsToComputeSeparately : Decide which end alignments to compute separately.\n");
+
+    fprintf(stderr, "-I --largeEndSize : The size of sequences in an end at which point to compute it separately.\n");
+
+    fprintf(stderr, "-J --ingroupCoverageFile : Binary coverage file containing ingroup regions that are covered by outgroups. These regions will be 'rescued' into single-degree blocks if they haven't been aligned to anything after the bar phase finished.\n");
+
+    fprintf(stderr, "-K --minimumSizeToRescue : Unaligned but covered segments must be at least this size to be rescued.\n");
+
+    fprintf(stderr, "-M --minimumCoverageToRescue : Unaligned segments must have at least this proportion of their bases covered by an outgroup to be rescued.\n");
+
+    fprintf(stderr, "-h --help : Print this help screen\n");
+}
+
+static int64_t minimumIngroupDegree = 0, minimumOutgroupDegree = 0, minimumDegree = 0, minimumNumberOfSpecies = 0;
+
+/* read each fasta sequence into a SeqFrag record with dummy End names */
+static void add_fasta_fragment(void* destination, const char *name, const char *seq, int64_t length) {
+    stList* fragList = (stList*)destination;
+    SeqFrag* frag = (SeqFrag*)malloc(sizeof(SeqFrag));
+    frag->seq = stString_copy(seq);
+    frag->length = length;
+    frag->leftEndId = 0; //(int64_t)name;
+    frag->rightEndId = 1; //(int64_t)name + 1;
+    stList_append(fragList, frag);
+    fprintf(stderr, "added fragment with name %s and length %ld\n", name, length);
+}
+
+static void print_results(MultipleAlignment *mA) {
+
+    stListIterator *it = stList_getIterator(mA->alignedPairs);
+    stIntTuple *mAP;
+    while ((mAP = stList_getNext(it)) != NULL) {
+        fprintf(stderr, "tuple %ld\t%ld\t%ld\t%ld\n", stIntTuple_get(mAP, 1), stIntTuple_get(mAP, 2), stIntTuple_get(mAP, 3), stIntTuple_get(mAP, 4)); 
+    }
+}
+
+int main(int argc, char *argv[]) {
+
+    char * logLevelString = NULL;
+    char * cactusDiskDatabaseString = NULL;
+    char * in_fasta = NULL;
+    int64_t i, j;
+    int64_t spanningTrees = 10;
+    int64_t maximumLength = 1500;
+    bool useProgressiveMerging = 0;
+    float matchGamma = 0.5;
+    bool useBanding = 0;
+    int64_t k;
+    stList *listOfEndAlignmentFiles = NULL;
+    char *endAlignmentsToPrecomputeOutputFile = NULL;
+    bool calculateWhichEndsToComputeSeparately = 0;
+    int64_t largeEndSize = 1000000;
+    int64_t chainLengthForBigFlower = 1000000;
+    int64_t longChain = 2;
+    char *ingroupCoverageFilePath = NULL;
+    int64_t minimumSizeToRescue = 1;
+    double minimumCoverageToRescue = 0.0;
+
+    PairwiseAlignmentParameters *pairwiseAlignmentBandingParameters = pairwiseAlignmentBandingParameters_construct();
+
+    /*
+     * Setup the input parameters for cactus core.
+     */
+    bool pruneOutStubAlignments = 0;
+
+    /*
+     * Parse the options.
+     */
+    while (1) {
+        static struct option long_options[] = { { "logLevel", required_argument, 0, 'a' }, { "cactusDisk", required_argument, 0, 'b' },
+                                                { "help", no_argument, 0, 'h' }, { "spanningTrees", required_argument, 0, 'i' },
+                                                { "maximumLength", required_argument, 0, 'j' }, { "useBanding", no_argument, 0, 'k' },
+                                                { "gapGamma", required_argument, 0, 'l' }, { "matchGamma", required_argument, 0, 'L' },
+                                                { "splitMatrixBiggerThanThis", required_argument, 0, 'o' },
+                                                { "anchorMatrixBiggerThanThis", required_argument, 0, 'p' },
+                                                { "repeatMaskMatrixBiggerThanThis", required_argument, 0, 'q' },
+                                                { "diagonalExpansion", required_argument, 0, 'r' },
+                                                { "constraintDiagonalTrim", required_argument, 0, 't' },
+                                                { "minimumDegree", required_argument, 0, 'u' },
+                                                { "alignAmbiguityCharacters", no_argument, 0, 'w' },
+                                                { "pruneOutStubAlignments", no_argument, 0, 'y' },
+                                                { "minimumIngroupDegree", required_argument, 0, 'A' },
+                                                { "minimumOutgroupDegree", required_argument, 0, 'B' },
+                                                { "precomputedAlignments", required_argument, 0, 'D' },
+                                                { "endAlignmentsToPrecomputeOutputFile", required_argument, 0, 'E' },
+                                                { "useProgressiveMerging",  no_argument, 0, 'F' },
+                                                { "calculateWhichEndsToComputeSeparately", no_argument, 0, 'G' },
+                                                { "largeEndSize", required_argument, 0, 'I' },
+                                                {"ingroupCoverageFile", required_argument, 0, 'J'},
+                                                {"minimumSizeToRescue", required_argument, 0, 'K'},
+                                                {"minimumCoverageToRescue", required_argument, 0, 'M'},
+                                                { "minimumNumberOfSpecies", required_argument, 0, 'N' },
+                                                {"inputFasta", required_argument, 0, 'f'},
+                                                { 0, 0, 0, 0 } };
+
+        int option_index = 0;
+
+        int key = getopt_long(argc, argv, "a:b:hi:j:kl:o:p:q:r:t:u:wy:A:B:D:E:FGI:J:K:L:M:N:f:", long_options, &option_index);
+
+        if (key == -1) {
+            break;
+        }
+
+        switch (key) {
+            case 'a':
+                logLevelString = stString_copy(optarg);
+                st_setLogLevelFromString(logLevelString);
+                break;
+            case 'b':
+                cactusDiskDatabaseString = stString_copy(optarg);
+                break;
+            case 'f':
+                in_fasta = stString_copy(optarg);
+                break;
+            case 'h':
+                usage();
+                return 0;
+            case 'i':
+                i = sscanf(optarg, "%" PRIi64 "", &spanningTrees);
+                (void) i;
+                assert(i == 1);
+                assert(spanningTrees >= 0);
+                break;
+            case 'j':
+                i = sscanf(optarg, "%" PRIi64 "", &maximumLength);
+                assert(i == 1);
+                assert(maximumLength >= 0);
+                break;
+            case 'k':
+                useBanding = !useBanding;
+                break;
+            case 'l':
+                i = sscanf(optarg, "%f", &pairwiseAlignmentBandingParameters->gapGamma);
+                assert(i == 1);
+                assert(pairwiseAlignmentBandingParameters->gapGamma >= 0.0);
+                break;
+            case 'L':
+                i = sscanf(optarg, "%f", &matchGamma);
+                assert(i == 1);
+                assert(matchGamma >= 0.0);
+                break;
+            case 'o':
+                i = sscanf(optarg, "%" PRIi64 "", &k);
+                assert(i == 1);
+                assert(k >= 0);
+                pairwiseAlignmentBandingParameters->splitMatrixBiggerThanThis = (int64_t) k * k;
+                break;
+            case 'p':
+                i = sscanf(optarg, "%" PRIi64 "", &k);
+                assert(i == 1);
+                assert(k >= 0);
+                pairwiseAlignmentBandingParameters->anchorMatrixBiggerThanThis = (int64_t) k * k;
+                break;
+            case 'q':
+                i = sscanf(optarg, "%" PRIi64 "", &k);
+                assert(i == 1);
+                assert(k >= 0);
+                pairwiseAlignmentBandingParameters->repeatMaskMatrixBiggerThanThis = (int64_t) k * k;
+                break;
+            case 'r':
+                i = sscanf(optarg, "%" PRIi64 "", &pairwiseAlignmentBandingParameters->diagonalExpansion);
+                assert(i == 1);
+                assert(pairwiseAlignmentBandingParameters->diagonalExpansion >= 0);
+                assert(pairwiseAlignmentBandingParameters->diagonalExpansion % 2 == 0);
+                break;
+            case 't':
+                i = sscanf(optarg, "%" PRIi64 "", &pairwiseAlignmentBandingParameters->constraintDiagonalTrim);
+                assert(i == 1);
+                assert(pairwiseAlignmentBandingParameters->constraintDiagonalTrim >= 0);
+                break;
+            case 'u':
+                i = sscanf(optarg, "%" PRIi64 "", &minimumDegree);
+                assert(i == 1);
+                break;
+            case 'w':
+                pairwiseAlignmentBandingParameters->alignAmbiguityCharacters = 1;
+                break;
+            case 'y':
+                pruneOutStubAlignments = 1;
+                break;
+            case 'A':
+                i = sscanf(optarg, "%" PRIi64 "", &minimumIngroupDegree);
+                assert(i == 1);
+                break;
+            case 'B':
+                i = sscanf(optarg, "%" PRIi64 "", &minimumOutgroupDegree);
+                assert(i == 1);
+                break;
+            case 'D':
+                listOfEndAlignmentFiles = stString_split(optarg);
+                break;
+            case 'E':
+                endAlignmentsToPrecomputeOutputFile = stString_copy(optarg);
+                break;
+            case 'F':
+                useProgressiveMerging = 1;
+                break;
+            case 'G':
+                calculateWhichEndsToComputeSeparately = 1;
+                break;
+            case 'I':
+                i = sscanf(optarg, "%" PRIi64 "", &largeEndSize);
+                assert(i == 1);
+                break;
+            case 'J':
+                ingroupCoverageFilePath = stString_copy(optarg);
+                break;
+            case 'K':
+                i = sscanf(optarg, "%" PRIi64, &minimumSizeToRescue);
+                assert(i == 1);
+                break;
+            case 'M':
+                i = sscanf(optarg, "%lf", &minimumCoverageToRescue);
+                assert(i == 1);
+                break;
+            case 'N':
+                i = sscanf(optarg, "%" PRIi64, &minimumNumberOfSpecies);
+                if (i != 1) {
+                    st_errAbort("Error parsing minimumNumberOfSpecies parameter");
+                }
+                break;
+            default:
+                usage();
+                return 1;
+        }
+    }
+
+    if (in_fasta == NULL) {
+        fprintf(stderr, "-f option is mandatory\n");
+        exit(1);
+    }
+    st_setLogLevelFromString(logLevelString);
+
+    StateMachine *sM = stateMachine5_construct(fiveState);
+
+    fprintf(stderr, "opening %s\n", in_fasta);
+    FILE* fastaFile = fopen(in_fasta, "r");
+    stList* seqFrags = stList_construct3(0, free);
+
+    fastaReadToFunction(fastaFile, seqFrags, add_fasta_fragment);
+    
+    fclose(fastaFile);
+
+    fprintf(stderr, "doing pecan alignment\n");
+    clock_t t = clock();
+    MultipleAlignment *mA = makeAlignment(sM, seqFrags, spanningTrees, 100000000, useProgressiveMerging, pairwiseAlignmentBandingParameters->gapGamma, pairwiseAlignmentBandingParameters);
+    t = clock() - t;
+    double pecanTime = ((double)t)/CLOCKS_PER_SEC;
+
+    print_results(mA);
+
+    fprintf(stderr, "doing poa alignment\n");
+    t = clock();
+    MultipleAlignment *pA = makePartialOrderAlignment(sM, seqFrags, spanningTrees, 100000000, useProgressiveMerging, pairwiseAlignmentBandingParameters->gapGamma, pairwiseAlignmentBandingParameters);
+    t = clock() - t;
+    double abpoaTime = ((double)t)/CLOCKS_PER_SEC;
+
+    print_results(mA);
+
+    fprintf(stderr, "Pecan Time = %lf seconds   abPOA Time = %lf seconds\n", pecanTime, abpoaTime);
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Cleanup
+    ///////////////////////////////////////////////////////////////////////////
+
+    stList_destruct(seqFrags);
+
+    stateMachine_destruct(sM);
+    //destructCactusCoreInputParameters(cCIP);
+    free(cactusDiskDatabaseString);
+    if (listOfEndAlignmentFiles != NULL) {
+        stList_destruct(listOfEndAlignmentFiles);
+    }
+    if (logLevelString != NULL) {
+        free(logLevelString);
+    }
+    st_logInfo("Finished with the flower disk for this flower.\n");
+
+    //while(1);
+    return 0;
+}

--- a/build-tools/makeBinRelease
+++ b/build-tools/makeBinRelease
@@ -52,7 +52,7 @@ build-tools/downloadHal2vg && mv hal2vg ${binPackageDir}/bin
 cp -r .git ${binPackageDir}
 rm -rf ${binPackageDir}/.git/modules
 # remove test executables
-rm -f ${binPackageDir}/bin/*test ${binPackageDir}/bin/*tests ${binPackageDir}/bin/*Test ${binPackageDir}/bin/*Tests
+rm -f ${binPackageDir}/bin/*test ${binPackageDir}/bin/*tests ${binPackageDir}/bin/*Test ${binPackageDir}/bin/*Tests ${binPackageDir}/bin/cactus_runEndAlignment
 # make binaries smaller
 strip -d ${binPackageDir}/bin/* 2> /dev/null || true
 tar -czf ${buildDir}/cactus-bin-${REL_TAG}.tar.gz ${binPackageDir}

--- a/include.mk
+++ b/include.mk
@@ -55,5 +55,5 @@ sonLibLibs = ${sonLibDir}/sonLib.a ${sonLibDir}/cuTest.a
 
 databaseLibs = ${kyotoTycoonLib} ${tokyoCabinetLib}
 
-LDLIBS += ${cactusLibs} ${sonLibLibs} ${databaseLibs} ${LIBS} -lm
+LDLIBS += ${cactusLibs} ${sonLibLibs} ${databaseLibs} ${LIBS} -lm -labpoa
 LIBDEPENDS = ${sonLibDir}/sonLib.a ${sonLibDir}/cuTest.a

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -147,12 +147,12 @@
 	<!-- The caf tag contains parameters for the bar algorithm. -->
 	<!-- The veryLargeEndSize parameter determines how big an end needs to be (in terms of bases in sequences incident with the end)
 	for the end to be aligned on its own. -->
-        <!-- The rescue parameter defines whether to run "bar rescue",
-             which makes single-degree blocks for anything that was
-             covered by an outgroup in the bar phase but is still
-             unaligned at the end of bar. This pushes those regions
-             into the ancestor, hopefully to get aligned to something
-             else eventually -->
+   <!-- The rescue parameter defines whether to run "bar rescue",
+        which makes single-degree blocks for anything that was
+        covered by an outgroup in the bar phase but is still
+        unaligned at the end of bar. This pushes those regions
+        into the ancestor, hopefully to get aligned to something
+        else eventually -->
 	<bar
 		runBar="1"
 		spanningTrees="5" 
@@ -177,6 +177,7 @@
                 rescue="0"
                 minimumSizeToRescue="100"
                 minimumCoverageToRescue="0.5"
+		partialOrderAlignment="0"
 	>
 		<CactusBarRecursion maxFlowerGroupSize="100000000"/>
 		<!-- The maxFlowerGroupSize in cactusBarWrapper determines how many bases to allow in one "small" job which will be run using the "littleMemory" -->

--- a/src/cactus/pipeline/cactus_workflow.py
+++ b/src/cactus/pipeline/cactus_workflow.py
@@ -988,6 +988,11 @@ class CactusBarWrapperWithPrecomputedEndAlignments(CactusRecursionJob):
             messages = runBarForJob(self, features=self.featuresFn(),
                                     fileStore=fileStore,
                                     precomputedAlignments=precomputedAlignments)
+            # these are created with cleanup=false, so we clean them up after they are used here to prevent
+            # the jobstore getting clogged
+            for fileID in self.precomputedAlignmentIDs:
+                fileStore.deleteGlobalFile(fileID)
+            self.precomputedAlignmentIDs = None
         else:
             messages = runBarForJob(self)
         for message in messages:

--- a/src/cactus/pipeline/cactus_workflow.py
+++ b/src/cactus/pipeline/cactus_workflow.py
@@ -875,7 +875,8 @@ def runBarForJob(self, fileStore=None, features=None, calculateWhichEndsToComput
                  ingroupCoverageFile=self.cactusWorkflowArguments.ingroupCoverageID if self.getOptionalPhaseAttrib("rescue", bool) else None,
                  minimumSizeToRescue=self.getOptionalPhaseAttrib("minimumSizeToRescue"),
                  minimumCoverageToRescue=self.getOptionalPhaseAttrib("minimumCoverageToRescue"),
-                 minimumNumberOfSpecies=self.getOptionalPhaseAttrib("minimumNumberOfSpecies", int))
+                 minimumNumberOfSpecies=self.getOptionalPhaseAttrib("minimumNumberOfSpecies", int),
+                 partialOrderAlignment=self.getOptionalPhaseAttrib("partialOrderAlignment", bool))
 
 class CactusBarWrapper(CactusRecursionJob):
     """Runs the BAR algorithm implementation.

--- a/src/cactus/pipeline/cactus_workflow.py
+++ b/src/cactus/pipeline/cactus_workflow.py
@@ -30,6 +30,7 @@ from sonLib.bioio import getLogLevelString
 from toil.job import Job
 from toil.common import Toil
 from toil.realtimeLogger import RealtimeLogger
+from toil.lib.humanize import bytes2human
 
 from cactus.shared.common import makeURL
 from cactus.shared.common import cactus_call
@@ -848,6 +849,10 @@ class CactusBarRecursion(CactusRecursionJob):
                                job=CactusBarWrapper, overlargeJob=CactusBarWrapperLarge)
 
 def runBarForJob(self, fileStore=None, features=None, calculateWhichEndsToComputeSeparately=False, endAlignmentsToPrecomputeOutputFile=None, precomputedAlignments=None):
+    if features is not None:
+        # this will cause it to be printed out to the realtime logger in cactus_call which, with CACTUS_LOG_MEMORY defined will
+        # also print the actual memory.  the two values together can be used to assess how well resources are being set
+        features["jobMem"] = bytes2human(self.memory)
     return runCactusBar(jobName=self.__class__.__name__,
                  fileStore=fileStore,
                  features=features,

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -1313,13 +1313,16 @@ def cactus_call(tool=None,
 
     if process.returncode == 0:
         run_time = time.time() - start_time
-        rt_msg = "Successfully ran: \"{}\" in {} seconds".format(' '.join(call) if not shell else call, run_time)
+        rt_message = "Successfully ran: \"{}\"" 
+        if features:
+            rt_message += ' (features={})'.format(features)
+        rt_message += " in {} seconds".format(' '.join(call) if not shell else call, run_time)
         if time_v:
             for line in stderr.split('\n'):
                 if 'Maximum resident set size (kbytes):' in line:
-                    rt_msg += ' and {} memory'.format(bytes2human(int(line.split()[-1]) * 1024))
+                    rt_message += ' and {} memory'.format(bytes2human(int(line.split()[-1]) * 1024))
                     break
-        cactus_realtime_log(rt_msg, log_debug = 'ktremotemgr' in call)
+        cactus_realtime_log(rt_message, log_debug = 'ktremotemgr' in call)
 
     if check_result:
         return process.returncode

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -22,7 +22,7 @@ import math
 import threading
 import traceback
 import errno
-
+import shlex
 
 from urllib.parse import urlparse
 from datetime import datetime
@@ -33,6 +33,7 @@ from toil.lib.bioio import getLogLevelString
 from toil.common import Toil
 from toil.job import Job
 from toil.realtimeLogger import RealtimeLogger
+from toil.lib.humanize import bytes2human
 
 from sonLib.bioio import popenCatch
 
@@ -903,9 +904,9 @@ def maxMemUsageOfContainer(containerInfo):
 
 # send a time/date stamped message to the realtime logger, truncating it
 # if it's too long (so it's less likely to be dropped)
-def cactus_realtime_log(msg, max_len = 1000, log_debug=False):
+def cactus_realtime_log(msg, max_len = 1500, log_debug=False):
     if len(msg) > max_len:
-        msg = msg[:max_len-107] + " <...> " + msg[-100:]
+        msg = msg[:max_len-207] + " <...> " + msg[-200:]
     if not log_debug:
         RealtimeLogger.info("{}: {}".format(datetime.now(), msg))
     else:
@@ -1214,6 +1215,9 @@ def cactus_call(tool=None,
     if tool is None:
         tool = "cactus"
 
+    # hack to keep track of memory usage for single machine
+    time_v = os.environ.get("CACTUS_LOG_MEMORY") is not None
+    
     entrypoint = None
     if (len(parameters) > 0) and isinstance(parameters[0], list):
         # We have a list of lists, which is the convention for commands piped into one another.
@@ -1258,7 +1262,19 @@ def cactus_call(tool=None,
         stdoutFileHandle = subprocess.PIPE
 
     _log.info("Running the command %s" % call)
-    cactus_realtime_log("Running the command: \"{}\"".format(' '.join(call)), log_debug = 'ktremotemgr' in call)
+    rt_message = 'Running the command: \"{}\"'.format(' '.join(call))
+    if features:
+        rt_message += ' (features={})'.format(features)
+    cactus_realtime_log(rt_message, log_debug = 'ktremotemgr' in call)
+
+    # use /usr/bin/time -v to get peak memory usage
+    if time_v and 'ktserver' not in call:
+        if not shell:
+            shell = True
+            call = ' '.join(shlex.quote(t) for t in call)
+        swallowStdErr = True
+        call = '/usr/bin/time -v {}'.format(call)
+        
     process = subprocess.Popen(call, shell=shell, encoding="ascii",
                                stdin=stdinFileHandle, stdout=stdoutFileHandle,
                                stderr=subprocess.PIPE if swallowStdErr else sys.stderr,
@@ -1297,8 +1313,13 @@ def cactus_call(tool=None,
 
     if process.returncode == 0:
         run_time = time.time() - start_time
-        cactus_realtime_log("Successfully ran the command: \"{}\" in {} seconds".format(' '.join(call), run_time),
-                            log_debug = 'ktremotemgr' in call)
+        rt_msg = "Successfully ran: \"{}\" in {} seconds".format(' '.join(call) if not shell else call, run_time)
+        if time_v:
+            for line in stderr.split('\n'):
+                if 'Maximum resident set size (kbytes):' in line:
+                    rt_msg += ' and {} memory'.format(bytes2human(int(line.split()[-1]) * 1024))
+                    break
+        cactus_realtime_log(rt_msg, log_debug = 'ktremotemgr' in call)
 
     if check_result:
         return process.returncode

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -492,6 +492,7 @@ def runCactusBar(cactusDiskDatabaseString, flowerNames, logLevel=None,
                  minimumSizeToRescue=None,
                  minimumCoverageToRescue=None,
                  minimumNumberOfSpecies=None,
+                 partialOrderAlignment=None,
                  jobName=None,
                  fileStore=None,
                  features=None):
@@ -547,6 +548,10 @@ def runCactusBar(cactusDiskDatabaseString, flowerNames, logLevel=None,
         args += ["--minimumCoverageToRescue", str(minimumCoverageToRescue)]
     if minimumNumberOfSpecies is not None:
         args += ["--minimumNumberOfSpecies", str(minimumNumberOfSpecies)]
+    if partialOrderAlignment is not None:
+        args += ["--partialOrderAlignment"]
+    else:
+        assert False
 
     masterMessages = cactus_call(stdin_string=flowerNames, check_output=True,
                                  parameters=["cactus_bar"] + args,

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -549,10 +549,8 @@ def runCactusBar(cactusDiskDatabaseString, flowerNames, logLevel=None,
         args += ["--minimumCoverageToRescue", str(minimumCoverageToRescue)]
     if minimumNumberOfSpecies is not None:
         args += ["--minimumNumberOfSpecies", str(minimumNumberOfSpecies)]
-    if partialOrderAlignment is not None:
+    if partialOrderAlignment is True:
         args += ["--partialOrderAlignment"]
-    else:
-        assert False
 
     masterMessages = cactus_call(stdin_string=flowerNames, check_output=True,
                                  parameters=["cactus_bar"] + args,
@@ -1313,11 +1311,13 @@ def cactus_call(tool=None,
 
     if process.returncode == 0:
         run_time = time.time() - start_time
-        rt_message = "Successfully ran: \"{}\"" 
+        if time_v:
+            call = call[len("/usr/bin/time -v "):]
+        rt_message = "Successfully ran: \"{}\"".format(' '.join(call) if not shell else call)
         if features:
             rt_message += ' (features={})'.format(features)
-        rt_message += " in {} seconds".format(' '.join(call) if not shell else call, run_time)
-        if time_v:
+        rt_message += " in {} seconds".format(round(run_time, 4))
+        if time_v:            
             for line in stderr.split('\n'):
                 if 'Maximum resident set size (kbytes):' in line:
                     rt_message += ' and {} memory'.format(bytes2human(int(line.split()[-1]) * 1024))

--- a/test/evolverMammals-default.comp.xml
+++ b/test/evolverMammals-default.comp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<alignmentComparisons numberOfSamples="100000000" near="0" seed="105039039046552" maf1="evolverMammals-default.maf" maf2="all.maf" numberOfPairsInMaf1="4544153" numberOfPairsInMaf2="5755666" version="version 0.9 May 2013" buildDate="2020-07-10T14:42EDT" buildBranch="master" buildCommit="6b6a73ceba29805a64caf40e06a02f44d782365a">
-	<homologyTests fileA="evolverMammals-default.maf" fileB="all.maf">
+<alignmentComparisons numberOfSamples="100000000" near="0" seed="105039039046552" maf1="mammals-default.maf" maf2="mammals-truth.maf" numberOfPairsInMaf1="4544153" numberOfPairsInMaf2="5755666" version="version 0.9 May 2013" buildDate="2020-07-10T14:42EDT" buildBranch="master" buildCommit="6b6a73ceba29805a64caf40e06a02f44d782365a">
+	<homologyTests fileA="mammals-default.maf" fileB="mammals-truth.maf">
 		<aggregateResults>
 			<all totalTests="4544153" totalTrue="3476823" totalFalse="1067330" average="0.765120"/>
 		</aggregateResults>
@@ -259,7 +259,7 @@
 			</homologyTest>
 		</homologyPairTests>
 	</homologyTests>
-	<homologyTests fileA="all.maf" fileB="evolverMammals-default.maf">
+	<homologyTests fileA="mammals-truth.maf" fileB="mammals-default.maf">
 		<aggregateResults>
 			<all totalTests="5755666" totalTrue="3476823" totalFalse="2278843" average="0.604070"/>
 		</aggregateResults>

--- a/test/evolverMammals-default.comp.xml
+++ b/test/evolverMammals-default.comp.xml
@@ -1,0 +1,523 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<alignmentComparisons numberOfSamples="100000000" near="0" seed="105039039046552" maf1="evolverMammals-default.maf" maf2="all.maf" numberOfPairsInMaf1="4544153" numberOfPairsInMaf2="5755666" version="version 0.9 May 2013" buildDate="2020-07-10T14:42EDT" buildBranch="master" buildCommit="6b6a73ceba29805a64caf40e06a02f44d782365a">
+	<homologyTests fileA="evolverMammals-default.maf" fileB="all.maf">
+		<aggregateResults>
+			<all totalTests="4544153" totalTrue="3476823" totalFalse="1067330" average="0.765120"/>
+		</aggregateResults>
+		<homologyPairTests>
+			<homologyTest sequenceA="simRat.chr6" sequenceB="simRat.chr6">
+				<aggregateResults>
+					<all totalTests="8532" totalTrue="5153" totalFalse="3379" average="0.603962"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simRat.chr6" sequenceB="simRat.chr6">
+						<aggregateResults>
+							<all totalTests="8532" totalTrue="5153" totalFalse="3379" average="0.603962"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simRat.chr6" sequenceB="aggregate">
+				<aggregateResults>
+					<all totalTests="1768027" totalTrue="1344879" totalFalse="423148" average="0.760667"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simRat.chr6" sequenceB="aggregate">
+						<aggregateResults>
+							<all totalTests="1768027" totalTrue="1344879" totalFalse="423148" average="0.760667"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simMouse.chr6" sequenceB="simRat.chr6">
+				<aggregateResults>
+					<all totalTests="458028" totalTrue="429795" totalFalse="28233" average="0.938360"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simMouse.chr6" sequenceB="simRat.chr6">
+						<aggregateResults>
+							<all totalTests="458028" totalTrue="429795" totalFalse="28233" average="0.938360"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simMouse.chr6" sequenceB="simMouse.chr6">
+				<aggregateResults>
+					<all totalTests="7779" totalTrue="5229" totalFalse="2550" average="0.672194"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simMouse.chr6" sequenceB="simMouse.chr6">
+						<aggregateResults>
+							<all totalTests="7779" totalTrue="5229" totalFalse="2550" average="0.672194"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simMouse.chr6" sequenceB="aggregate">
+				<aggregateResults>
+					<all totalTests="1779344" totalTrue="1353139" totalFalse="426205" average="0.760471"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simMouse.chr6" sequenceB="aggregate">
+						<aggregateResults>
+							<all totalTests="1779344" totalTrue="1353139" totalFalse="426205" average="0.760471"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simHuman.chr6" sequenceB="simRat.chr6">
+				<aggregateResults>
+					<all totalTests="440389" totalTrue="324550" totalFalse="115839" average="0.736962"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simHuman.chr6" sequenceB="simRat.chr6">
+						<aggregateResults>
+							<all totalTests="440389" totalTrue="324550" totalFalse="115839" average="0.736962"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simHuman.chr6" sequenceB="simMouse.chr6">
+				<aggregateResults>
+					<all totalTests="444423" totalTrue="327473" totalFalse="116950" average="0.736850"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simHuman.chr6" sequenceB="simMouse.chr6">
+						<aggregateResults>
+							<all totalTests="444423" totalTrue="327473" totalFalse="116950" average="0.736850"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simHuman.chr6" sequenceB="simHuman.chr6">
+				<aggregateResults>
+					<all totalTests="2676" totalTrue="2611" totalFalse="65" average="0.975710"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simHuman.chr6" sequenceB="simHuman.chr6">
+						<aggregateResults>
+							<all totalTests="2676" totalTrue="2611" totalFalse="65" average="0.975710"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simHuman.chr6" sequenceB="aggregate">
+				<aggregateResults>
+					<all totalTests="1860952" totalTrue="1452114" totalFalse="408838" average="0.780307"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simHuman.chr6" sequenceB="aggregate">
+						<aggregateResults>
+							<all totalTests="1860952" totalTrue="1452114" totalFalse="408838" average="0.780307"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simDog.chr6" sequenceB="simRat.chr6">
+				<aggregateResults>
+					<all totalTests="430080" totalTrue="294222" totalFalse="135858" average="0.684110"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simDog.chr6" sequenceB="simRat.chr6">
+						<aggregateResults>
+							<all totalTests="430080" totalTrue="294222" totalFalse="135858" average="0.684110"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simDog.chr6" sequenceB="simMouse.chr6">
+				<aggregateResults>
+					<all totalTests="434054" totalTrue="296891" totalFalse="137163" average="0.683996"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simDog.chr6" sequenceB="simMouse.chr6">
+						<aggregateResults>
+							<all totalTests="434054" totalTrue="296891" totalFalse="137163" average="0.683996"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simDog.chr6" sequenceB="simHuman.chr6">
+				<aggregateResults>
+					<all totalTests="487543" totalTrue="401537" totalFalse="86006" average="0.823593"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simDog.chr6" sequenceB="simHuman.chr6">
+						<aggregateResults>
+							<all totalTests="487543" totalTrue="401537" totalFalse="86006" average="0.823593"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simDog.chr6" sequenceB="simDog.chr6">
+				<aggregateResults>
+					<all totalTests="3302" totalTrue="3108" totalFalse="194" average="0.941248"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simDog.chr6" sequenceB="simDog.chr6">
+						<aggregateResults>
+							<all totalTests="3302" totalTrue="3108" totalFalse="194" average="0.941248"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simDog.chr6" sequenceB="aggregate">
+				<aggregateResults>
+					<all totalTests="1824989" totalTrue="1396614" totalFalse="428375" average="0.765273"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simDog.chr6" sequenceB="aggregate">
+						<aggregateResults>
+							<all totalTests="1824989" totalTrue="1396614" totalFalse="428375" average="0.765273"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simCow.chr6" sequenceB="simRat.chr6">
+				<aggregateResults>
+					<all totalTests="430998" totalTrue="291159" totalFalse="139839" average="0.675546"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simCow.chr6" sequenceB="simRat.chr6">
+						<aggregateResults>
+							<all totalTests="430998" totalTrue="291159" totalFalse="139839" average="0.675546"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simCow.chr6" sequenceB="simMouse.chr6">
+				<aggregateResults>
+					<all totalTests="435060" totalTrue="293751" totalFalse="141309" average="0.675197"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simCow.chr6" sequenceB="simMouse.chr6">
+						<aggregateResults>
+							<all totalTests="435060" totalTrue="293751" totalFalse="141309" average="0.675197"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simCow.chr6" sequenceB="simHuman.chr6">
+				<aggregateResults>
+					<all totalTests="485921" totalTrue="395943" totalFalse="89978" average="0.814830"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simCow.chr6" sequenceB="simHuman.chr6">
+						<aggregateResults>
+							<all totalTests="485921" totalTrue="395943" totalFalse="89978" average="0.814830"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simCow.chr6" sequenceB="simDog.chr6">
+				<aggregateResults>
+					<all totalTests="470010" totalTrue="400856" totalFalse="69154" average="0.852867"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simCow.chr6" sequenceB="simDog.chr6">
+						<aggregateResults>
+							<all totalTests="470010" totalTrue="400856" totalFalse="69154" average="0.852867"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simCow.chr6" sequenceB="simCow.chr6">
+				<aggregateResults>
+					<all totalTests="5358" totalTrue="4545" totalFalse="813" average="0.848264"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simCow.chr6" sequenceB="simCow.chr6">
+						<aggregateResults>
+							<all totalTests="5358" totalTrue="4545" totalFalse="813" average="0.848264"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simCow.chr6" sequenceB="aggregate">
+				<aggregateResults>
+					<all totalTests="1827347" totalTrue="1386254" totalFalse="441093" average="0.758616"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simCow.chr6" sequenceB="aggregate">
+						<aggregateResults>
+							<all totalTests="1827347" totalTrue="1386254" totalFalse="441093" average="0.758616"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="self" sequenceB="self">
+				<aggregateResults>
+					<all totalTests="27647" totalTrue="20646" totalFalse="7001" average="0.746772"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="self" sequenceB="self">
+						<aggregateResults>
+							<all totalTests="27647" totalTrue="20646" totalFalse="7001" average="0.746772"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+		</homologyPairTests>
+	</homologyTests>
+	<homologyTests fileA="all.maf" fileB="evolverMammals-default.maf">
+		<aggregateResults>
+			<all totalTests="5755666" totalTrue="3476823" totalFalse="2278843" average="0.604070"/>
+		</aggregateResults>
+		<homologyPairTests>
+			<homologyTest sequenceA="simRat.chr6" sequenceB="simRat.chr6">
+				<aggregateResults>
+					<all totalTests="75923" totalTrue="5153" totalFalse="70770" average="0.067871"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simRat.chr6" sequenceB="simRat.chr6">
+						<aggregateResults>
+							<all totalTests="75923" totalTrue="5153" totalFalse="70770" average="0.067871"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simRat.chr6" sequenceB="aggregate">
+				<aggregateResults>
+					<all totalTests="2372499" totalTrue="1344879" totalFalse="1027620" average="0.566862"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simRat.chr6" sequenceB="aggregate">
+						<aggregateResults>
+							<all totalTests="2372499" totalTrue="1344879" totalFalse="1027620" average="0.566862"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simMouse.chr6" sequenceB="simRat.chr6">
+				<aggregateResults>
+					<all totalTests="712341" totalTrue="429795" totalFalse="282546" average="0.603356"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simMouse.chr6" sequenceB="simRat.chr6">
+						<aggregateResults>
+							<all totalTests="712341" totalTrue="429795" totalFalse="282546" average="0.603356"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simMouse.chr6" sequenceB="simMouse.chr6">
+				<aggregateResults>
+					<all totalTests="76556" totalTrue="5229" totalFalse="71327" average="0.068303"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simMouse.chr6" sequenceB="simMouse.chr6">
+						<aggregateResults>
+							<all totalTests="76556" totalTrue="5229" totalFalse="71327" average="0.068303"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simMouse.chr6" sequenceB="aggregate">
+				<aggregateResults>
+					<all totalTests="2380709" totalTrue="1353139" totalFalse="1027570" average="0.568376"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simMouse.chr6" sequenceB="aggregate">
+						<aggregateResults>
+							<all totalTests="2380709" totalTrue="1353139" totalFalse="1027570" average="0.568376"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simHuman.chr6" sequenceB="simRat.chr6">
+				<aggregateResults>
+					<all totalTests="537174" totalTrue="324550" totalFalse="212624" average="0.604180"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simHuman.chr6" sequenceB="simRat.chr6">
+						<aggregateResults>
+							<all totalTests="537174" totalTrue="324550" totalFalse="212624" average="0.604180"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simHuman.chr6" sequenceB="simMouse.chr6">
+				<aggregateResults>
+					<all totalTests="538567" totalTrue="327473" totalFalse="211094" average="0.608045"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simHuman.chr6" sequenceB="simMouse.chr6">
+						<aggregateResults>
+							<all totalTests="538567" totalTrue="327473" totalFalse="211094" average="0.608045"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simHuman.chr6" sequenceB="simHuman.chr6">
+				<aggregateResults>
+					<all totalTests="25939" totalTrue="2611" totalFalse="23328" average="0.100659"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simHuman.chr6" sequenceB="simHuman.chr6">
+						<aggregateResults>
+							<all totalTests="25939" totalTrue="2611" totalFalse="23328" average="0.100659"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simHuman.chr6" sequenceB="aggregate">
+				<aggregateResults>
+					<all totalTests="2167249" totalTrue="1452114" totalFalse="715135" average="0.670026"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simHuman.chr6" sequenceB="aggregate">
+						<aggregateResults>
+							<all totalTests="2167249" totalTrue="1452114" totalFalse="715135" average="0.670026"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simDog.chr6" sequenceB="simRat.chr6">
+				<aggregateResults>
+					<all totalTests="525304" totalTrue="294222" totalFalse="231082" average="0.560099"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simDog.chr6" sequenceB="simRat.chr6">
+						<aggregateResults>
+							<all totalTests="525304" totalTrue="294222" totalFalse="231082" average="0.560099"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simDog.chr6" sequenceB="simMouse.chr6">
+				<aggregateResults>
+					<all totalTests="528403" totalTrue="296891" totalFalse="231512" average="0.561865"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simDog.chr6" sequenceB="simMouse.chr6">
+						<aggregateResults>
+							<all totalTests="528403" totalTrue="296891" totalFalse="231512" average="0.561865"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simDog.chr6" sequenceB="simHuman.chr6">
+				<aggregateResults>
+					<all totalTests="534277" totalTrue="401537" totalFalse="132740" average="0.751552"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simDog.chr6" sequenceB="simHuman.chr6">
+						<aggregateResults>
+							<all totalTests="534277" totalTrue="401537" totalFalse="132740" average="0.751552"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simDog.chr6" sequenceB="simDog.chr6">
+				<aggregateResults>
+					<all totalTests="32930" totalTrue="3108" totalFalse="29822" average="0.094382"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simDog.chr6" sequenceB="simDog.chr6">
+						<aggregateResults>
+							<all totalTests="32930" totalTrue="3108" totalFalse="29822" average="0.094382"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simDog.chr6" sequenceB="aggregate">
+				<aggregateResults>
+					<all totalTests="2172599" totalTrue="1396614" totalFalse="775985" average="0.642831"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simDog.chr6" sequenceB="aggregate">
+						<aggregateResults>
+							<all totalTests="2172599" totalTrue="1396614" totalFalse="775985" average="0.642831"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simCow.chr6" sequenceB="simRat.chr6">
+				<aggregateResults>
+					<all totalTests="521757" totalTrue="291159" totalFalse="230598" average="0.558036"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simCow.chr6" sequenceB="simRat.chr6">
+						<aggregateResults>
+							<all totalTests="521757" totalTrue="291159" totalFalse="230598" average="0.558036"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simCow.chr6" sequenceB="simMouse.chr6">
+				<aggregateResults>
+					<all totalTests="524842" totalTrue="293751" totalFalse="231091" average="0.559694"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simCow.chr6" sequenceB="simMouse.chr6">
+						<aggregateResults>
+							<all totalTests="524842" totalTrue="293751" totalFalse="231091" average="0.559694"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simCow.chr6" sequenceB="simHuman.chr6">
+				<aggregateResults>
+					<all totalTests="531292" totalTrue="395943" totalFalse="135349" average="0.745246"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simCow.chr6" sequenceB="simHuman.chr6">
+						<aggregateResults>
+							<all totalTests="531292" totalTrue="395943" totalFalse="135349" average="0.745246"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simCow.chr6" sequenceB="simDog.chr6">
+				<aggregateResults>
+					<all totalTests="551685" totalTrue="400856" totalFalse="150829" average="0.726603"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simCow.chr6" sequenceB="simDog.chr6">
+						<aggregateResults>
+							<all totalTests="551685" totalTrue="400856" totalFalse="150829" average="0.726603"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simCow.chr6" sequenceB="simCow.chr6">
+				<aggregateResults>
+					<all totalTests="38676" totalTrue="4545" totalFalse="34131" average="0.117515"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simCow.chr6" sequenceB="simCow.chr6">
+						<aggregateResults>
+							<all totalTests="38676" totalTrue="4545" totalFalse="34131" average="0.117515"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simCow.chr6" sequenceB="aggregate">
+				<aggregateResults>
+					<all totalTests="2168252" totalTrue="1386254" totalFalse="781998" average="0.639342"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simCow.chr6" sequenceB="aggregate">
+						<aggregateResults>
+							<all totalTests="2168252" totalTrue="1386254" totalFalse="781998" average="0.639342"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="self" sequenceB="self">
+				<aggregateResults>
+					<all totalTests="250024" totalTrue="20646" totalFalse="229378" average="0.082576"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="self" sequenceB="self">
+						<aggregateResults>
+							<all totalTests="250024" totalTrue="20646" totalFalse="229378" average="0.082576"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+		</homologyPairTests>
+	</homologyTests>
+	<wigglePairs>
+	</wigglePairs>
+</alignmentComparisons>

--- a/test/evolverPrimates-default.comp.xml
+++ b/test/evolverPrimates-default.comp.xml
@@ -1,0 +1,367 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<alignmentComparisons numberOfSamples="10000000" near="0" seed="105061638669895" maf1="primates-default.maf" maf2="primates-truth.maf" numberOfPairsInMaf1="3518660" numberOfPairsInMaf2="3565765" version="version 0.9 May 2013" buildDate="2020-07-10T14:42EDT" buildBranch="master" buildCommit="6b6a73ceba29805a64caf40e06a02f44d782365a">
+	<homologyTests fileA="primates-default.maf" fileB="primates-truth.maf">
+		<aggregateResults>
+			<all totalTests="3518660" totalTrue="3514287" totalFalse="4373" average="0.998757"/>
+		</aggregateResults>
+		<homologyPairTests>
+			<homologyTest sequenceA="simOrang.chr6" sequenceB="simOrang.chr6">
+				<aggregateResults>
+					<all totalTests="524" totalTrue="523" totalFalse="1" average="0.998092"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simOrang.chr6" sequenceB="simOrang.chr6">
+						<aggregateResults>
+							<all totalTests="524" totalTrue="523" totalFalse="1" average="0.998092"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simOrang.chr6" sequenceB="aggregate">
+				<aggregateResults>
+					<all totalTests="1741600" totalTrue="1738851" totalFalse="2749" average="0.998422"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simOrang.chr6" sequenceB="aggregate">
+						<aggregateResults>
+							<all totalTests="1741600" totalTrue="1738851" totalFalse="2749" average="0.998422"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simHuman.chr6" sequenceB="simOrang.chr6">
+				<aggregateResults>
+					<all totalTests="580083" totalTrue="579222" totalFalse="861" average="0.998516"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simHuman.chr6" sequenceB="simOrang.chr6">
+						<aggregateResults>
+							<all totalTests="580083" totalTrue="579222" totalFalse="861" average="0.998516"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simHuman.chr6" sequenceB="aggregate">
+				<aggregateResults>
+					<all totalTests="1764967" totalTrue="1763150" totalFalse="1817" average="0.998971"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simHuman.chr6" sequenceB="aggregate">
+						<aggregateResults>
+							<all totalTests="1764967" totalTrue="1763150" totalFalse="1817" average="0.998971"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simGorilla.chr6" sequenceB="simOrang.chr6">
+				<aggregateResults>
+					<all totalTests="580673" totalTrue="579662" totalFalse="1011" average="0.998259"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simGorilla.chr6" sequenceB="simOrang.chr6">
+						<aggregateResults>
+							<all totalTests="580673" totalTrue="579662" totalFalse="1011" average="0.998259"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simGorilla.chr6" sequenceB="simHuman.chr6">
+				<aggregateResults>
+					<all totalTests="592832" totalTrue="592199" totalFalse="633" average="0.998932"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simGorilla.chr6" sequenceB="simHuman.chr6">
+						<aggregateResults>
+							<all totalTests="592832" totalTrue="592199" totalFalse="633" average="0.998932"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simGorilla.chr6" sequenceB="simGorilla.chr6">
+				<aggregateResults>
+					<all totalTests="638" totalTrue="622" totalFalse="16" average="0.974922"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simGorilla.chr6" sequenceB="simGorilla.chr6">
+						<aggregateResults>
+							<all totalTests="638" totalTrue="622" totalFalse="16" average="0.974922"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simGorilla.chr6" sequenceB="aggregate">
+				<aggregateResults>
+					<all totalTests="1765186" totalTrue="1762877" totalFalse="2309" average="0.998692"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simGorilla.chr6" sequenceB="aggregate">
+						<aggregateResults>
+							<all totalTests="1765186" totalTrue="1762877" totalFalse="2309" average="0.998692"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simChimp.chr6" sequenceB="simOrang.chr6">
+				<aggregateResults>
+					<all totalTests="580320" totalTrue="579444" totalFalse="876" average="0.998490"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simChimp.chr6" sequenceB="simOrang.chr6">
+						<aggregateResults>
+							<all totalTests="580320" totalTrue="579444" totalFalse="876" average="0.998490"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simChimp.chr6" sequenceB="simHuman.chr6">
+				<aggregateResults>
+					<all totalTests="592052" totalTrue="591729" totalFalse="323" average="0.999454"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simChimp.chr6" sequenceB="simHuman.chr6">
+						<aggregateResults>
+							<all totalTests="592052" totalTrue="591729" totalFalse="323" average="0.999454"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simChimp.chr6" sequenceB="simGorilla.chr6">
+				<aggregateResults>
+					<all totalTests="591043" totalTrue="590394" totalFalse="649" average="0.998902"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simChimp.chr6" sequenceB="simGorilla.chr6">
+						<aggregateResults>
+							<all totalTests="591043" totalTrue="590394" totalFalse="649" average="0.998902"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simChimp.chr6" sequenceB="simChimp.chr6">
+				<aggregateResults>
+					<all totalTests="495" totalTrue="492" totalFalse="3" average="0.993939"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simChimp.chr6" sequenceB="simChimp.chr6">
+						<aggregateResults>
+							<all totalTests="495" totalTrue="492" totalFalse="3" average="0.993939"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simChimp.chr6" sequenceB="aggregate">
+				<aggregateResults>
+					<all totalTests="1763910" totalTrue="1762059" totalFalse="1851" average="0.998951"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simChimp.chr6" sequenceB="aggregate">
+						<aggregateResults>
+							<all totalTests="1763910" totalTrue="1762059" totalFalse="1851" average="0.998951"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="self" sequenceB="self">
+				<aggregateResults>
+					<all totalTests="1657" totalTrue="1637" totalFalse="20" average="0.987930"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="self" sequenceB="self">
+						<aggregateResults>
+							<all totalTests="1657" totalTrue="1637" totalFalse="20" average="0.987930"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+		</homologyPairTests>
+	</homologyTests>
+	<homologyTests fileA="primates-truth.maf" fileB="primates-default.maf">
+		<aggregateResults>
+			<all totalTests="3565765" totalTrue="3514287" totalFalse="51478" average="0.985563"/>
+		</aggregateResults>
+		<homologyPairTests>
+			<homologyTest sequenceA="simOrang.chr6" sequenceB="simOrang.chr6">
+				<aggregateResults>
+					<all totalTests="2528" totalTrue="523" totalFalse="2005" average="0.206883"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simOrang.chr6" sequenceB="simOrang.chr6">
+						<aggregateResults>
+							<all totalTests="2528" totalTrue="523" totalFalse="2005" average="0.206883"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simOrang.chr6" sequenceB="aggregate">
+				<aggregateResults>
+					<all totalTests="1760010" totalTrue="1738851" totalFalse="21159" average="0.987978"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simOrang.chr6" sequenceB="aggregate">
+						<aggregateResults>
+							<all totalTests="1760010" totalTrue="1738851" totalFalse="21159" average="0.987978"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simHuman.chr6" sequenceB="simOrang.chr6">
+				<aggregateResults>
+					<all totalTests="585577" totalTrue="579222" totalFalse="6355" average="0.989147"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simHuman.chr6" sequenceB="simOrang.chr6">
+						<aggregateResults>
+							<all totalTests="585577" totalTrue="579222" totalFalse="6355" average="0.989147"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simHuman.chr6" sequenceB="simHuman.chr6">
+				<aggregateResults>
+					<all totalTests="2972" totalTrue="0" totalFalse="2972" average="0.000000"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simHuman.chr6" sequenceB="simHuman.chr6">
+						<aggregateResults>
+							<all totalTests="2972" totalTrue="0" totalFalse="2972" average="0.000000"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simHuman.chr6" sequenceB="aggregate">
+				<aggregateResults>
+					<all totalTests="1786225" totalTrue="1763150" totalFalse="23075" average="0.987082"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simHuman.chr6" sequenceB="aggregate">
+						<aggregateResults>
+							<all totalTests="1786225" totalTrue="1763150" totalFalse="23075" average="0.987082"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simGorilla.chr6" sequenceB="simOrang.chr6">
+				<aggregateResults>
+					<all totalTests="586301" totalTrue="579662" totalFalse="6639" average="0.988676"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simGorilla.chr6" sequenceB="simOrang.chr6">
+						<aggregateResults>
+							<all totalTests="586301" totalTrue="579662" totalFalse="6639" average="0.988676"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simGorilla.chr6" sequenceB="simHuman.chr6">
+				<aggregateResults>
+					<all totalTests="599411" totalTrue="592199" totalFalse="7212" average="0.987968"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simGorilla.chr6" sequenceB="simHuman.chr6">
+						<aggregateResults>
+							<all totalTests="599411" totalTrue="592199" totalFalse="7212" average="0.987968"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simGorilla.chr6" sequenceB="simGorilla.chr6">
+				<aggregateResults>
+					<all totalTests="3757" totalTrue="622" totalFalse="3135" average="0.165558"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simGorilla.chr6" sequenceB="simGorilla.chr6">
+						<aggregateResults>
+							<all totalTests="3757" totalTrue="622" totalFalse="3135" average="0.165558"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simGorilla.chr6" sequenceB="aggregate">
+				<aggregateResults>
+					<all totalTests="1787579" totalTrue="1762877" totalFalse="24702" average="0.986181"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simGorilla.chr6" sequenceB="aggregate">
+						<aggregateResults>
+							<all totalTests="1787579" totalTrue="1762877" totalFalse="24702" average="0.986181"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simChimp.chr6" sequenceB="simOrang.chr6">
+				<aggregateResults>
+					<all totalTests="585604" totalTrue="579444" totalFalse="6160" average="0.989481"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simChimp.chr6" sequenceB="simOrang.chr6">
+						<aggregateResults>
+							<all totalTests="585604" totalTrue="579444" totalFalse="6160" average="0.989481"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simChimp.chr6" sequenceB="simHuman.chr6">
+				<aggregateResults>
+					<all totalTests="598265" totalTrue="591729" totalFalse="6536" average="0.989075"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simChimp.chr6" sequenceB="simHuman.chr6">
+						<aggregateResults>
+							<all totalTests="598265" totalTrue="591729" totalFalse="6536" average="0.989075"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simChimp.chr6" sequenceB="simGorilla.chr6">
+				<aggregateResults>
+					<all totalTests="598110" totalTrue="590394" totalFalse="7716" average="0.987099"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simChimp.chr6" sequenceB="simGorilla.chr6">
+						<aggregateResults>
+							<all totalTests="598110" totalTrue="590394" totalFalse="7716" average="0.987099"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simChimp.chr6" sequenceB="simChimp.chr6">
+				<aggregateResults>
+					<all totalTests="3240" totalTrue="492" totalFalse="2748" average="0.151852"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simChimp.chr6" sequenceB="simChimp.chr6">
+						<aggregateResults>
+							<all totalTests="3240" totalTrue="492" totalFalse="2748" average="0.151852"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="simChimp.chr6" sequenceB="aggregate">
+				<aggregateResults>
+					<all totalTests="1785219" totalTrue="1762059" totalFalse="23160" average="0.987027"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="simChimp.chr6" sequenceB="aggregate">
+						<aggregateResults>
+							<all totalTests="1785219" totalTrue="1762059" totalFalse="23160" average="0.987027"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+			<homologyTest sequenceA="self" sequenceB="self">
+				<aggregateResults>
+					<all totalTests="12497" totalTrue="1637" totalFalse="10860" average="0.130991"/>
+				</aggregateResults>
+				<singleHomologyTests>
+					<singleHomologyTest sequenceA="self" sequenceB="self">
+						<aggregateResults>
+							<all totalTests="12497" totalTrue="1637" totalFalse="10860" average="0.130991"/>
+						</aggregateResults>
+					</singleHomologyTest>
+				</singleHomologyTests>
+			</homologyTest>
+		</homologyPairTests>
+	</homologyTests>
+	<wigglePairs>
+	</wigglePairs>
+</alignmentComparisons>

--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -28,10 +28,10 @@ class TestCase(unittest.TestCase):
     def _out_hal(self, binariesMode):
         return os.path.join(self.tempDir, 'evovler-{}.hal'.format(binariesMode))
 
-    def _run_evolver(self, binariesMode, configFile = None):
+    def _run_evolver(self, binariesMode, configFile = None, seqFile = './examples/evolverMammals.txt'):
         """ Run the full evolver test, putting the jobstore and output in tempDir
         """
-        cmd = ['cactus', self._job_store(binariesMode), './examples/evolverMammals.txt', self._out_hal(binariesMode),
+        cmd = ['cactus', self._job_store(binariesMode), seqFile, self._out_hal(binariesMode),
                                '--binariesMode', binariesMode, '--logInfo', '--realTimeLogging', '--workDir', self.tempDir]
         if configFile:
             cmd += ['--configFile', configFile]
@@ -42,6 +42,17 @@ class TestCase(unittest.TestCase):
 
         sys.stderr.write('Running {}'.format(' '.format(cmd)))
         subprocess.check_call(' '.join(cmd), shell=True)
+
+    def _run_evolver_primates_star(self, binariesMode, configFile = None):
+        """ Run cactus on the evolver primates with a star topology
+        """
+        seq_file_path = os.path.join(self.tempDir, 'primates.txt')
+        with open(seq_file_path, 'w') as seq_file:
+            seq_file.write('simChimp\thttps://raw.githubusercontent.com/UCSantaCruzComputationalGenomicsLab/cactusTestData/master/evolver/primates/loci1/simChimp.chr6\n')
+            seq_file.write('simGorilla\thttps://raw.githubusercontent.com/UCSantaCruzComputationalGenomicsLab/cactusTestData/master/evolver/primates/loci1/simGorilla.chr6\n')
+            seq_file.write('simOrang\thttps://raw.githubusercontent.com/UCSantaCruzComputationalGenomicsLab/cactusTestData/master/evolver/primates/loci1/simOrang.chr6\n')
+            seq_file.write('simHuman\thttps://raw.githubusercontent.com/UCSantaCruzComputationalGenomicsLab/cactusTestData/master/evolver/primates/loci1/simHuman.chr6\n')
+        self._run_evolver(binariesMode, configFile=configFile, seqFile=seq_file_path)
 
     def _run_evolver_decomposed(self, name):
         """ Run the full evolver test, putting the jobstore and output in tempDir
@@ -253,13 +264,14 @@ class TestCase(unittest.TestCase):
                 self.assertGreaterEqual(int(oval[i]), int(val[i]) - delta)
                 self.assertLessEqual(int(oval[i]), int(val[i]) + delta)
 
-    def _check_maf_accuracy(self, halPath, delta):
+    def _check_maf_accuracy(self, halPath, delta, dataset="mammals"):
         """ Compare mafComparator output of evolver mammals to baseline
         """
+        assert dataset in ('mammals', 'primates')
         # this is just pasted from a successful run.  it will be used to catch serious regressions
-        baseline_file = 'test/evolverMammals-default.comp.xml'
+        baseline_file = 'test/evolver{}-default.comp.xml'.format(dataset.capitalize())
         # this is downloaded in the Makefile
-        ground_truth_file = 'test/all.maf'
+        ground_truth_file = 'test/{}-truth.maf'.format(dataset)
 
         # run mafComparator on the evolver output
         subprocess.check_call(['bin/hal2maf', halPath,  halPath + '.maf', '--onlySequenceNames'], shell=False)
@@ -384,14 +396,10 @@ class TestCase(unittest.TestCase):
 
         # run cactus directly, the old school way
         name = "local"
-        self._run_evolver(name, configFile = poa_config_path)
+        #self._run_evolver_primates_star(name, configFile = poa_config_path)
 
-        hack_name = "/home/hickey/dev/cactus/evolverMammals-poa.hal"
-            
         # check the output
-        self._check_stats(self._out_hal("local"), delta_pct=2.5) # todo: why stats so different?
-        self._check_coverage(self._out_hal("local"), delta_pct=0.20, columns=1)
-        self._check_maf_accuracy(self._out_hal("local"), delta=0.01)
+        self._check_maf_accuracy(self._out_hal("local"), delta=0.0025, dataset='primates')
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -309,7 +309,7 @@ class TestCase(unittest.TestCase):
         # check the output
         self._check_stats(self._out_hal("wdl"), delta_pct=0.25)
         self._check_coverage(self._out_hal("wdl"), delta_pct=0.20)
-        self._check_maf_accuracy(self._out_hal(name), delta=0.01)
+        self._check_maf_accuracy(self._out_hal("wdl"), delta=0.01)
 
     def testEvolverPrepareToil(self):
 

--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -6,7 +6,6 @@ import shutil
 from sonLib.bioio import getTempDirectory, popenCatch, popen
 import xml.etree.ElementTree as ET
 from xml.dom import minidom
-from cactus.shared.common import cactusRootPath
 
 class TestCase(unittest.TestCase):
     def setUp(self):
@@ -346,7 +345,7 @@ class TestCase(unittest.TestCase):
         # check the output
         self._check_stats(self._out_hal("docker"), delta_pct=0.25)
         self._check_coverage(self._out_hal("docker"), delta_pct=0.20)
-        self._check_maf_accuracy(self._out_hal(name), delta=0.01)        
+        self._check_maf_accuracy(self._out_hal("docker"), delta=0.01)        
 
     def testEvolverPrepareNoOutgroupDocker(self):
 
@@ -371,7 +370,7 @@ class TestCase(unittest.TestCase):
         is reasonable... when using POA mode in BAR.
         """
         # use the same logic cactus does to get default config
-        config_path = os.path.join(cactusRootPath(), "cactus_progressive_config.xml")
+        config_path = 'src/cactus/cactus_progressive_config.xml'
         
         xml_root = ET.parse(config_path).getroot()
         bar_elem = xml_root.find("bar")

--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -295,7 +295,7 @@ class TestCase(unittest.TestCase):
         # check the output
         self._check_stats(self._out_hal(name), delta_pct=0.25)
         self._check_coverage(self._out_hal(name), delta_pct=0.20)
-        self._check_maf_accuracy(self._out_hal(name), delta_pct=0.01)
+        self._check_maf_accuracy(self._out_hal(name), delta=0.01)
 
     def testEvolverPrepareWDL(self):
 
@@ -305,7 +305,7 @@ class TestCase(unittest.TestCase):
         # check the output
         self._check_stats(self._out_hal("wdl"), delta_pct=0.25)
         self._check_coverage(self._out_hal("wdl"), delta_pct=0.20)
-        self._check_maf_accuracy(self._out_hal(name), delta_pct=0.01)
+        self._check_maf_accuracy(self._out_hal(name), delta=0.01)
 
     def testEvolverPrepareToil(self):
 
@@ -316,7 +316,7 @@ class TestCase(unittest.TestCase):
         # check the output
         self._check_stats(self._out_hal(name), delta_pct=0.25)
         self._check_coverage(self._out_hal(name), delta_pct=0.20)
-        self._check_maf_accuracy(self._out_hal(name), delta_pct=0.01)
+        self._check_maf_accuracy(self._out_hal(name), delta=0.01)
 
     def testEvolverDecomposedLocal(self):
         """ Check that the output of halStats on a hal file produced by running cactus with --binariesMode local is
@@ -329,7 +329,7 @@ class TestCase(unittest.TestCase):
         # check the output
         self._check_stats(self._out_hal(name), delta_pct=0.25)
         self._check_coverage(self._out_hal(name), delta_pct=0.20)
-        self._check_maf_accuracy(self._out_hal(name), delta_pct=0.01)
+        self._check_maf_accuracy(self._out_hal(name), delta=0.01)
 
     def testEvolverDocker(self):
         """ Check that the output of halStats on a hal file produced by running cactus with --binariesMode docker is
@@ -341,7 +341,7 @@ class TestCase(unittest.TestCase):
         # check the output
         self._check_stats(self._out_hal("docker"), delta_pct=0.25)
         self._check_coverage(self._out_hal("docker"), delta_pct=0.20)
-        self._check_maf_accuracy(self._out_hal(name), delta_pct=0.01)        
+        self._check_maf_accuracy(self._out_hal(name), delta=0.01)        
 
     def testEvolverPrepareNoOutgroupDocker(self):
 

--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -396,7 +396,7 @@ class TestCase(unittest.TestCase):
 
         # run cactus directly, the old school way
         name = "local"
-        #self._run_evolver_primates_star(name, configFile = poa_config_path)
+        self._run_evolver_primates_star(name, configFile = poa_config_path)
 
         # check the output
         self._check_maf_accuracy(self._out_hal("local"), delta=0.0025, dataset='primates')


### PR DESCRIPTION
The BAR phase runs multiple alignment jobs on the adjacency components of the graph.  Each job gets farmed off to `cactus_bar` which uses Pecan's multiple aligner to do the work.  The problem is that this approach doesn't scale well with the number of input sequences.  For example, when trying to run cactus with a star tree on 60 chr20 haplotypes, the bar phase takes hours and hours on hundreds of cores, while requiring up to 100s of Gigs of RAM for each job.  Reducing the maximum sequence length considered using `bandingLimit` in `<bar>` in the cactus config reduces the memory but the running time remains too high.

This PR adds an option to switch from using Pecan to [abPOA](https://github.com/yangao07/abPOA) in `cactus_bar`.  The latter is much faster.  A preliminary result for one test on 60 10kb sequences gave
```
Pecan Time = 8542.267868 seconds   abPOA Time = 5.424252 seconds
```
This is still a work in progress as it needs 
* more testing including automated tests on travis and gitlab
* more thought for parameter integration (right now poa only using default parameters)
* verifying the integration in general (ie does it need to happen on the flower aligner too?)
 