### PR TITLE
Adding Redis as a database option to Cactus

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,8 @@ image: quay.io/glennhickey/cactus-ci-base:latest
 
 before_script:
   - whoami
+  - sudo apt-get -q -y update
+  - sudo apt-get -q -y install redis-server libhiredis0.13 libhiredis-dev
   - startdocker || true
   - docker info
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ before_install:
   - |
     if [[ "$TRAVIS_OS_NAME" == "linux" && "$CACTUS_BINARIES_MODE" == "local" ]]; then
        sudo apt-get -qq update
-       sudo apt-get install -y git gcc g++ build-essential zlib1g-dev wget valgrind libbz2-dev pkg-config libhdf5-dev liblzo2-dev libtokyocabinet-dev
+       sudo apt-get install -y git gcc g++ build-essential zlib1g-dev wget valgrind libbz2-dev pkg-config libhdf5-dev liblzo2-dev libtokyocabinet-dev libhiredis-dev redis-server
     fi
   - |
     if [[ "$TRAVIS_OS_NAME" == "linux" && "$CACTUS_BINARIES_MODE" == "local" ]]; then
-       sudo apt-get install -y git gcc g++ build-essential zlib1g-dev wget valgrind libbz2-dev pkg-config libhdf5-dev liblzo2-dev libtokyocabinet-dev
+       sudo apt-get install -y git gcc g++ build-essential zlib1g-dev wget valgrind libbz2-dev pkg-config libhdf5-dev liblzo2-dev libtokyocabinet-dev libhiredis-dev redis-server
     fi
   - |
     if [[ ! -z "$SON_TRACE_DATASETS" ]]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/glennhickey/cactus-ci-base:latest as builder
 
 # apt dependencies for build
-RUN apt-get update && apt-get install -y build-essential git python3 python3-dev python3-pip zlib1g-dev wget libbz2-dev pkg-config libhdf5-dev liblzo2-dev libtokyocabinet-dev wget
+RUN apt-get update && apt-get install -y build-essential git python3 python3-dev python3-pip zlib1g-dev wget libbz2-dev pkg-config libhdf5-dev liblzo2-dev libtokyocabinet-dev wget libhiredis-dev
 
 # build cactus binaries
 RUN mkdir -p /home/cactus
@@ -39,7 +39,7 @@ RUN mkdir -p /wheels && cd /wheels && python3 -m pip install -U pip && python3 -
 FROM ubuntu:bionic-20200112
 
 # apt dependencies for runtime
-RUN apt-get update && apt-get install -y --no-install-recommends git python3 python3-pip python3-distutils zlib1g libbz2-1.0 net-tools libhdf5-100 liblzo2-2 libtokyocabinet9 rsync libkrb5-3 libk5crypto3 time
+RUN apt-get update && apt-get install -y --no-install-recommends git python3 python3-pip python3-distutils zlib1g libbz2-1.0 net-tools libhdf5-100 liblzo2-2 libtokyocabinet9 rsync libkrb5-3 libk5crypto3 time redis-server libhiredis0.13
 
 # copy temporary files for installing cactus
 COPY --from=builder /home/cactus /tmp/cactus

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,7 @@ testModules = \
     phylogeny/cactus_phylogenyTest.py \
     pipeline/cactus_evolverTest.py \
     pipeline/cactus_workflowTest.py \
+    pipeline/dbServerTest.py \
     preprocessor/cactus_preprocessorTest.py \
     preprocessor/lastzRepeatMasking/cactus_lastzRepeatMaskTest.py \
     progressive/cactus_progressiveTest.py \

--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,9 @@ evolver_test: all bin/mafComparator
 evolver_test_local: all bin/mafComparator
 	CACTUS_BINARIES_MODE=local CACTUS_DOCKER_MODE=0 ${PYTHON} -m pytest ${pytestOpts} test/evolverTest.py::TestCase::testEvolverLocal
 
+evolver_test_redis_local: all bin/mafComparator
+	CACTUS_BINARIES_MODE=local CACTUS_DOCKER_MODE=0 ${PYTHON} -m pytest ${pytestOpts} test/evolverTest.py::TestCase::testEvolverRedisLocal
+
 evolver_test_poa_local: all bin/mafComparator
 	CACTUS_BINARIES_MODE=local CACTUS_DOCKER_MODE=0 ${PYTHON} -m pytest ${pytestOpts} -s test/evolverTest.py::TestCase::testEvolverPOALocal
 

--- a/blast/Makefile
+++ b/blast/Makefile
@@ -1,7 +1,7 @@
 rootPath = ..
 include ${rootPath}/include.mk
 
-CFLAGS += ${tokyoCabinetIncl}
+CFLAGS += ${tokyoCabinetIncl} ${hiredisIncl}
 
 all: all_libs all_progs
 all_libs: 

--- a/blastLib/Makefile
+++ b/blastLib/Makefile
@@ -1,7 +1,7 @@
 rootPath = ..
 include ${rootPath}/include.mk
 
-CFLAGS += ${tokyoCabinetIncl}
+CFLAGS += ${tokyoCabinetIncl} ${hiredisIncl}
 
 libSources = blastAlignmentLib.c
 libHeaders = blastAlignmentLib.h

--- a/check/Makefile
+++ b/check/Makefile
@@ -1,7 +1,7 @@
 rootPath = ..
 include ${rootPath}/include.mk
 
-CFLAGS += ${tokyoCabinetIncl}
+CFLAGS += ${tokyoCabinetIncl} ${hiredisIncl}
 
 all: all_libs all_progs
 all_libs: 

--- a/include.mk
+++ b/include.mk
@@ -46,8 +46,8 @@ inclDirs = api/inc bar/inc caf/inc hal/inc reference/inc submodules/sonLib/C/inc
 
 kyotoTycoonIncl=-I${rootPath}/include -DHAVE_KYOTO_TYCOON=1
 kyotoTycoonLib=-L${rootPath}/lib -Wl,-rpath,${rootPath}/lib -lkyototycoon -lkyotocabinet -lz -lbz2 -lpthread -lm -lstdc++
-hiredisIncl=-I${rootPath}/include/hiredis -DHAVE_REDIS=1
-hiredisLib=-L${rootPath}/lib -lhiredis
+hiredisIncl=$(shell pkg-config --cflags hiredis) -DHAVE_REDIS=1
+hiredisLib=-lhiredis
 
 CPPFLAGS += ${inclDirs:%=-I${rootPath}/%} -I${LIBDIR} ${kyotoTycoonIncl}
 

--- a/include.mk
+++ b/include.mk
@@ -46,6 +46,7 @@ inclDirs = api/inc bar/inc caf/inc hal/inc reference/inc submodules/sonLib/C/inc
 
 kyotoTycoonIncl=-I${rootPath}/include -DHAVE_KYOTO_TYCOON=1
 kyotoTycoonLib=-L${rootPath}/lib -Wl,-rpath,${rootPath}/lib -lkyototycoon -lkyotocabinet -lz -lbz2 -lpthread -lm -lstdc++
+hiredisIncl=$(shell pkg-config --cflags hiredis) -DHAVE_REDIS=1
 hiredisLib=-lhiredis
 
 CPPFLAGS += ${inclDirs:%=-I${rootPath}/%} -I${LIBDIR} ${kyotoTycoonIncl}

--- a/include.mk
+++ b/include.mk
@@ -46,6 +46,7 @@ inclDirs = api/inc bar/inc caf/inc hal/inc reference/inc submodules/sonLib/C/inc
 
 kyotoTycoonIncl=-I${rootPath}/include -DHAVE_KYOTO_TYCOON=1
 kyotoTycoonLib=-L${rootPath}/lib -Wl,-rpath,${rootPath}/lib -lkyototycoon -lkyotocabinet -lz -lbz2 -lpthread -lm -lstdc++
+hiredisLib=-lhiredis
 
 CPPFLAGS += ${inclDirs:%=-I${rootPath}/%} -I${LIBDIR} ${kyotoTycoonIncl}
 
@@ -53,7 +54,7 @@ CPPFLAGS += ${inclDirs:%=-I${rootPath}/%} -I${LIBDIR} ${kyotoTycoonIncl}
 cactusLibs = ${LIBDIR}/stCaf.a ${LIBDIR}/stReference.a ${LIBDIR}/cactusBarLib.a ${LIBDIR}/cactusBlastAlignment.a ${LIBDIR}/cactusLib.a
 sonLibLibs = ${sonLibDir}/sonLib.a ${sonLibDir}/cuTest.a
 
-databaseLibs = ${kyotoTycoonLib} ${tokyoCabinetLib}
+databaseLibs = ${kyotoTycoonLib} ${tokyoCabinetLib} ${hiredisLib}
 
 LDLIBS += ${cactusLibs} ${sonLibLibs} ${databaseLibs} ${LIBS} -lm -labpoa
 LIBDEPENDS = ${sonLibDir}/sonLib.a ${sonLibDir}/cuTest.a

--- a/include.mk
+++ b/include.mk
@@ -46,8 +46,8 @@ inclDirs = api/inc bar/inc caf/inc hal/inc reference/inc submodules/sonLib/C/inc
 
 kyotoTycoonIncl=-I${rootPath}/include -DHAVE_KYOTO_TYCOON=1
 kyotoTycoonLib=-L${rootPath}/lib -Wl,-rpath,${rootPath}/lib -lkyototycoon -lkyotocabinet -lz -lbz2 -lpthread -lm -lstdc++
-hiredisIncl=$(shell pkg-config --cflags hiredis) -DHAVE_REDIS=1
-hiredisLib=-lhiredis
+hiredisIncl=-I${rootPath}/include/hiredis -DHAVE_REDIS=1
+hiredisLib=-L${rootPath}/lib -lhiredis
 
 CPPFLAGS += ${inclDirs:%=-I${rootPath}/%} -I${LIBDIR} ${kyotoTycoonIncl}
 

--- a/preprocessor/Makefile
+++ b/preprocessor/Makefile
@@ -1,7 +1,7 @@
 rootPath = ..
 include ${rootPath}/include.mk
 
-CFLAGS += ${tokyoCabinetIncl}
+CFLAGS += ${tokyoCabinetIncl} ${hiredisIncl}
 
 all: all_libs all_progs
 all_libs: 

--- a/preprocessor/lastzRepeatMasking/Makefile
+++ b/preprocessor/lastzRepeatMasking/Makefile
@@ -1,7 +1,7 @@
 rootPath = ../..
 include ${rootPath}/include.mk
 
-CFLAGS += ${tokyoCabinetIncl}
+CFLAGS += ${tokyoCabinetIncl} ${hiredisIncl}
 
 all :  ${BINDIR}/cactus_fasta_fragments.py ${BINDIR}/cactus_fasta_softmask_intervals.py ${BINDIR}/cactus_covered_intervals
 

--- a/reference/Makefile
+++ b/reference/Makefile
@@ -1,7 +1,7 @@
 rootPath = ..
 include ${rootPath}/include.mk
 
-CFLAGS += ${tokyoCabinetIncl}
+CFLAGS += ${tokyoCabinetIncl} ${hiredisIncl}
 
 libSources = impl/*.c
 libHeaders = inc/*.h

--- a/setup/Makefile
+++ b/setup/Makefile
@@ -1,7 +1,7 @@
 rootPath = ..
 include ${rootPath}/include.mk
 
-CFLAGS += ${tokyoCabinetIncl}
+CFLAGS += ${tokyoCabinetIncl} ${hiredisIncl}
 
 all: all_libs all_progs
 all_libs: 

--- a/src/cactus/blast/cactus_blast.py
+++ b/src/cactus/blast/cactus_blast.py
@@ -48,10 +48,6 @@ def main():
     parser.add_argument("--pathOverrideNames", nargs="*", help="names (must be same number as --paths) of path overrides")
 
     #Progressive Cactus Options
-    parser.add_argument("--database", dest="database",
-                      help="Database type: tokyo_cabinet or kyoto_tycoon"
-                      " [default: %(default)s]",
-                      default="kyoto_tycoon")
     parser.add_argument("--configFile", dest="configFile",
                         help="Specify cactus configuration file",
                         default=os.path.join(cactusRootPath(), "cactus_progressive_config.xml"))
@@ -69,8 +65,8 @@ def main():
                         "rather than pulling one from quay.io")
     parser.add_argument("--binariesMode", choices=["docker", "local", "singularity"],
                         help="The way to run the Cactus binaries", default=None)
-
     options = parser.parse_args()
+    options.database = "kyoto_tycoon"
 
     setupBinaries(options)
     setLoggingFromOptions(options)

--- a/src/cactus/pipeline/cactus_workflow.py
+++ b/src/cactus/pipeline/cactus_workflow.py
@@ -69,7 +69,7 @@ from cactus.preprocessor.cactus_preprocessor import CactusPreprocessor
 from cactus.shared.experimentWrapper import ExperimentWrapper
 from cactus.shared.experimentWrapper import DbElemWrapper
 from cactus.shared.configWrapper import ConfigWrapper
-from cactus.pipeline.dbserverToil import DbServerService, getDbServer
+from cactus.pipeline.dbServerToil import DbServerService, getDbServer
 
 ############################################################
 ############################################################

--- a/src/cactus/pipeline/dbServerCommon.py
+++ b/src/cactus/pipeline/dbServerCommon.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+"""
+Functions to get network info
+"""
+
+import platform
+import socket
+from contextlib import closing
+
+from toil.lib.bioio import logger
+from cactus.shared.common import cactus_call
+
+def getHostName():
+    if platform.system() == 'Darwin':
+        # macOS doesn't have a true Docker bridging mode, so each
+        # container is NATed with its own local IP and can't bind
+        # to/connect to this computer's external IP. We have to
+        # hardcode the loopback IP to work around this.
+        return '127.0.0.1'
+    return getPublicIP()
+
+# Borrowed from toil code.
+def getPublicIP():
+    """Get the IP that this machine uses to contact the internet.
+    If behind a NAT, this will still be this computer's IP, and not the router's."""
+    try:
+        # Try to get the internet-facing IP by attempting a connection
+        # to a non-existent server and reading what IP was used.
+        with closing(socket.socket(socket.AF_INET, socket.SOCK_DGRAM)) as sock:
+            # 203.0.113.0/24 is reserved as TEST-NET-3 by RFC 5737, so
+            # there is guaranteed to be no one listening on the other
+            # end (and we won't accidentally DOS anyone).
+            sock.connect(('203.0.113.1', 1))
+            ip = sock.getsockname()[0]
+        return ip
+    except:
+        # Something went terribly wrong. Just give loopback rather
+        # than killing everything, because this is often called just
+        # to provide a default argument
+        return '127.0.0.1'
+
+def findOccupiedPorts():
+    """Attempt to find all currently taken TCP ports.
+
+    Returns a set of ints, representing taken ports."""
+    netstatOutput = cactus_call(parameters=["netstat", "-tuplen"], check_output=True)
+    ports = set()
+    for line in netstatOutput.split("\n"):
+        fields = line.split()
+        if len(fields) != 9:
+            # Header or other garbage line
+            continue
+        port = int(fields[3].split(':')[-1])
+        ports.add(port)
+    logger.debug('Detected ports in use: %s' % repr(ports))
+    return ports

--- a/src/cactus/pipeline/dbServerTest.py
+++ b/src/cactus/pipeline/dbServerTest.py
@@ -1,0 +1,69 @@
+import unittest
+from toil.common import Toil
+from toil.job import Job
+
+from cactus.shared.experimentWrapper import DbElemWrapper
+from cactus.shared.common import cactus_call
+from cactus.pipeline.dbServerToil import DbServerService
+from cactus.shared.test import getGlobalDatabaseConf
+from cactus.pipeline.ktserverControl import KtServer
+
+import xml.etree.ElementTree as ET
+
+
+class DbTestJob(Job):
+    def __init__(self, dbElem, testFunc, memory="100M", cores=1, disk="100M"):
+        self.dbElem = dbElem
+        self.testFunc = testFunc
+        Job.__init__(self, memory=memory, cores=cores, disk=disk, preemptable=False)
+
+    def run(self, fileStore):
+        dbService = DbServerService(dbElem=self.dbElem, isSecondary=False,
+                                    memory="100M", cores=1, disk="100M")
+        xmlString = self.addService(dbService).rv(0)
+        self.addChildFn(self.testFunc, xmlString,
+                        memory="100M", cores=1, disk="100M")
+
+    def addService(self, service):
+        """Works around toil issue #1695, returning a Job rather than a Promise."""
+        super(DbTestJob, self).addService(service)
+        return self._services[-1]
+
+
+def runAndTestDbServerService(dbElem, testFunc):
+    dbTestJob = DbTestJob(dbElem, testFunc)
+    options = Job.Runner.getDefaultOptions("./testDbServerWorkflow")
+    options.logLevel = "INFO"
+    options.clean = "always"
+
+    with Toil(options) as toil:
+        toil.start(dbTestJob)
+
+
+def _testKt(xmlString):
+    dbElem = DbElemWrapper(ET.fromstring(xmlString))
+    ktServer = KtServer(dbElem)
+    cactus_call(parameters=['ktremotetest', 'order'] + ktServer.getRemoteParams() + ['10'])
+
+
+def _testRedis(xmlString):
+    pass
+
+
+class TestCase(unittest.TestCase):
+    def setUp(self):
+        xmlString = getGlobalDatabaseConf()
+        self.initialDbElem = DbElemWrapper(ET.fromstring(xmlString))
+
+    def testKtServerService(self):
+        self.initialDbElem.setDbType("kyoto_tycoon")
+        runAndTestDbServerService(self.initialDbElem, _testKt)
+
+    @unittest.skip("redis is not supported yet")
+    def testRedisServerService(self):
+        self.initialDbElem.setDbType("redis")
+        runAndTestDbServerService(self.initialDbElem, _testRedis)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/cactus/pipeline/dbServerTest.py
+++ b/src/cactus/pipeline/dbServerTest.py
@@ -1,4 +1,8 @@
+
+"""Tests the database servers using DbServerService
+"""
 import unittest
+import os
 from toil.common import Toil
 from toil.job import Job
 
@@ -15,17 +19,25 @@ REDIS_CONF_STRING = '<st_kv_database_conf type="redis"><redis in_memory="1" port
 
 
 class DbTestJob(Job):
-    def __init__(self, dbElem, testFunc, memory="100M", cores=1, disk="100M"):
+    def __init__(self, dbElem, testFunc, snapshotPath=None, memory="100M", cores=1, disk="100M"):
         self.dbElem = dbElem
         self.testFunc = testFunc
+        self.snapshotPath = snapshotPath
         Job.__init__(self, memory=memory, cores=cores, disk=disk, preemptable=False)
 
     def run(self, fileStore):
+        snapshotID = None
+        if self.snapshotPath is not None:
+            snapshotID = fileStore.importFile("file://" + self.snapshotPath)
         dbService = DbServerService(dbElem=self.dbElem, isSecondary=False,
+                                    existingSnapshotID=snapshotID,
                                     memory="100M", cores=1, disk="100M")
-        xmlString = self.addService(dbService).rv(0)
+
+        s = self.addService(dbService)
+        xmlString, snapshotExportID = s.rv(0), s.rv(1)
         self.addChildFn(self.testFunc, xmlString,
                         memory="100M", cores=1, disk="100M")
+        return snapshotExportID
 
     def addService(self, service):
         """Works around toil issue #1695, returning a Job rather than a Promise."""
@@ -33,41 +45,81 @@ class DbTestJob(Job):
         return self._services[-1]
 
 
-def runAndTestDbServerService(dbElem, testFunc):
-    dbTestJob = DbTestJob(dbElem, testFunc)
+def runAndTestDbServerService(dbElem, testFunc, inputSnapshotPath=None, outputSnapshotPath=None):
+    dbTestJob = DbTestJob(dbElem, testFunc, inputSnapshotPath)
     options = Job.Runner.getDefaultOptions("./testDbServerWorkflow")
     options.logLevel = "INFO"
     options.clean = "always"
 
     with Toil(options) as toil:
-        toil.start(dbTestJob)
+        snapshotID = toil.start(dbTestJob)
+        if outputSnapshotPath is not None:
+            toil.exportFile(snapshotID, "file://" + outputSnapshotPath)
 
 
-def _testKt(xmlString):
+def _testKtSetFlag(xmlString):
+    """ set FLAG to 1 in a Kyoto_Tycoon database (the first server)"""
     dbElem = DbElemWrapper(ET.fromstring(xmlString))
     ktServer = KtServer(dbElem)
-    cactus_call(parameters=['ktremotetest', 'order'] + ktServer.getRemoteParams() + ['10'])
+    cactus_call(parameters=['ktremotemgr', 'set'] + ktServer.getRemoteParams() + ['FLAG', '1'])
 
 
-def _testRedis(xmlString):
+def _testKtGetFlag(xmlString):
+    """ get and check FLAG in a Kyoto_Tycoon database (the second server)"""
+    dbElem = DbElemWrapper(ET.fromstring(xmlString))
+    ktServer = KtServer(dbElem)
+    flag = cactus_call(parameters=['ktremotemgr', 'get'] + ktServer.getRemoteParams() + ['FLAG'], check_output=True)
+    assert flag.strip() == '1'
+
+
+def _testRedisSetFlag(xmlString):
+    """ set FLAG to 1 in a Redis database (the first server)"""
     dbElem = DbElemWrapper(ET.fromstring(xmlString))
     redisServer = RedisServer(dbElem)
-    pingOut = cactus_call(parameters=['redis-cli'] + redisServer.getRemoteParams() + ['PING'],
-                          check_output=True)
-    assert pingOut.strip() == "PONG"
+    base_call = ['redis-cli'] + redisServer.getRemoteParams()
+    out = cactus_call(parameters=base_call + ['set', 'FLAG', '1'], check_output=True)
+    assert out.strip() == "OK"
+
+
+def _testRedisGetFlag(xmlString):
+    """ get and check FLAG in a Redis database (the second server)"""
+    dbElem = DbElemWrapper(ET.fromstring(xmlString))
+    redisServer = RedisServer(dbElem)
+    base_call = ['redis-cli'] + redisServer.getRemoteParams()
+    flag = cactus_call(parameters=base_call + ['get', 'FLAG'], check_output=True)
+    assert flag.strip() == '1'
 
 
 class TestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        """ make a file for saving snapshots """
+        os.mkdir("./testSnapshot")
+        self.snapshotTempPath = os.path.abspath("./testSnapshot/snapshot.temp")
+        open(self.snapshotTempPath, "w").close()
 
     #@unittest.skip("skip KT!")
     def testKtServerService(self):
         initialDbElem = DbElemWrapper(ET.fromstring(KT_CONF_STRING))
-        runAndTestDbServerService(initialDbElem, _testKt)
+        # The first database saves the snapshot after termination
+        runAndTestDbServerService(dbElem=initialDbElem, testFunc=_testKtSetFlag,
+                                  outputSnapshotPath=self.snapshotTempPath)
+        # The second database loads the snapshot
+        runAndTestDbServerService(dbElem=initialDbElem, testFunc=_testKtGetFlag,
+                                  inputSnapshotPath=self.snapshotTempPath)
 
     #@unittest.skip("skip Redis!")
     def testRedisServerService(self):
         initialDbElem = DbElemWrapper(ET.fromstring(REDIS_CONF_STRING))
-        runAndTestDbServerService(initialDbElem, _testRedis)
+        # The first database saves the snapshot after termination
+        runAndTestDbServerService(dbElem=initialDbElem, testFunc=_testRedisSetFlag,
+                                  outputSnapshotPath=self.snapshotTempPath)
+        # The second database loads the snapshot
+        runAndTestDbServerService(dbElem=initialDbElem, testFunc=_testRedisGetFlag,
+                                  inputSnapshotPath=self.snapshotTempPath)
+
+    def tearDown(self) -> None:
+        os.remove(self.snapshotTempPath)
+        os.rmdir("./testSnapshot")
 
 
 if __name__ == '__main__':

--- a/src/cactus/pipeline/dbServerToil.py
+++ b/src/cactus/pipeline/dbServerToil.py
@@ -8,6 +8,7 @@ import os
 import stat
 from toil.job import Job
 from cactus.pipeline.ktserverControl import KtServer
+from cactus.pipeline.redisServerControl import RedisServer
 
 class DbServerService(Job.Service):
     def __init__(self, dbElem, isSecondary, existingSnapshotID=None,
@@ -63,4 +64,6 @@ def getDbServer(dbElem, fileStore=None, existingSnapshotID=None, snapshotExportI
     """
     if dbElem.getDbType() == "kyoto_tycoon":
         return KtServer(dbElem, fileStore, existingSnapshotID, snapshotExportID)
+    elif dbElem.getDbType() == "redis":
+        return RedisServer(dbElem, fileStore, existingSnapshotID, snapshotExportID)
     raise RuntimeError("The database type, %s, is not supported" % dbElem.getDbType())

--- a/src/cactus/pipeline/dbServerToil.py
+++ b/src/cactus/pipeline/dbServerToil.py
@@ -7,10 +7,9 @@
 import os
 import stat
 from toil.job import Job
-from cactus.pipeline.ktserverControl import runKtserver, blockUntilKtserverIsRunning, stopKtserver, \
-    blockUntilKtserverIsFinished
+from cactus.pipeline.ktserverControl import KtServer
 
-class KtServerService(Job.Service):
+class DbServerService(Job.Service):
     def __init__(self, dbElem, isSecondary, existingSnapshotID=None,
                  memory=None, cores=None, disk=None):
         Job.Service.__init__(self, memory=memory, cores=cores, disk=disk, preemptable=False)
@@ -19,6 +18,7 @@ class KtServerService(Job.Service):
         self.existingSnapshotID = existingSnapshotID
         self.failed = False
         self.process = None
+        self.dbServer = None
 
     def start(self, job):
         snapshotExportID = job.fileStore.jobStore.getEmptyFileStoreID()
@@ -28,23 +28,24 @@ class KtServerService(Job.Service):
         # need to write something to it, obviously that won't do.
         path = job.fileStore.readGlobalFile(snapshotExportID)
         os.chmod(path, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP | stat.S_IROTH)
-        self.process, self.dbElem, self.logPath = runKtserver(self.dbElem, fileStore=job.fileStore,
-                                                              existingSnapshotID=self.existingSnapshotID,
-                                                              snapshotExportID=snapshotExportID)
+        self.dbServer = getDbServer(self.dbElem, fileStore=job.fileStore,
+                                    existingSnapshotID=self.existingSnapshotID,
+                                    snapshotExportID=snapshotExportID)
+        self.process, self.dbElem, self.logPath = self.dbServer.runServer()
         assert self.dbElem.getDbHost() != None
-        blockUntilKtserverIsRunning(self.logPath)
+        self.dbServer.blockUntilServerIsRunning()
         self.check()
         return self.dbElem.getConfString(), snapshotExportID
 
     def stop(self, job):
         self.check()
         try:
-            stopKtserver(self.dbElem)
+            self.dbServer.stopServer()
         except:
             # Server is probably already terminated
             pass
         if not self.failed:
-            blockUntilKtserverIsFinished(self.logPath, timeout=1200)
+            self.dbServer.blockUntilServerIsFinished()
 
     def check(self):
         if self.process.exceptionMsg.empty():
@@ -53,3 +54,13 @@ class KtServerService(Job.Service):
             self.failed = True
             msg = self.process.exceptionMsg.get()
             raise RuntimeError(msg)
+
+
+def getDbServer(dbElem, fileStore=None, existingSnapshotID=None, snapshotExportID=None):
+    """
+    Get the correct object that handles the database server based on database type
+    Each database has a specific class with common functionalities
+    """
+    if dbElem.getDbType() == "kyoto_tycoon":
+        return KtServer(dbElem, fileStore, existingSnapshotID, snapshotExportID)
+    raise RuntimeError("The database type, %s, is not supported" % dbElem.getDbType())

--- a/src/cactus/pipeline/ktserverControl.py
+++ b/src/cactus/pipeline/ktserverControl.py
@@ -22,46 +22,145 @@ MAX_KTSERVER_PORT = 32767
 # The name of the snapshot that KT outputs.
 KTSERVER_SNAPSHOT_NAME = "00000000.ktss"
 
-def runKtserver(dbElem, fileStore, existingSnapshotID=None, snapshotExportID=None):
-    """
-    Run a KTServer. This function launches a separate python process that manages the server.
 
-    Writing to the special key "TERMINATE" signals this thread to safely shut
-    down the DB and save the results. After finishing, the data will
-    eventually be written to snapshotFile.
+class KtServer:
+    def __init__(self, dbElem, fileStore=None, existingSnapshotID=None, snapshotExportID=None):
+        self.dbElem = dbElem
+        self.logPath = None
+        self.fileStore = fileStore
+        self.existingSnapshotID = existingSnapshotID
+        self.snapshotExportID = snapshotExportID
 
-    Returns a tuple containing an updated version of the database config dbElem and the
-    path to the log file.
-    """
-    logPath = fileStore.getLocalTempFile()
-    dbElem.setDbHost(getHostName())
+    def runServer(self):
+        """
+        Run a KTServer. This function launches a separate python process that manages the server.
 
-    # Find a suitable port to run on.
-    try:
-        occupiedPorts = findOccupiedPorts()
-        unoccupiedPorts = set(range(1025,MAX_KTSERVER_PORT)) - occupiedPorts
-        port = random.choice(list(unoccupiedPorts))
-    except:
-        logger.warning("Can't find which ports are occupied--likely netstat is not installed."
-                       " Choosing a random port to start the DB on, good luck!")
-        port = random.randint(1025,MAX_KTSERVER_PORT)
-    dbElem.setDbPort(port)
+        Writing to the special key "TERMINATE" signals this thread to safely shut
+        down the DB and save the results. After finishing, the data will
+        eventually be written to snapshotFile.
 
-    process = ServerProcess(dbElem, logPath, fileStore, existingSnapshotID, snapshotExportID)
-    process.daemon = True
-    process.start()
-
-    if not blockUntilKtserverIsRunning(logPath):
+        Returns a tuple containing an updated version of the database config dbElem and the
+        path to the log file.
+        """
+        self.logPath = self.fileStore.getLocalTempFile()
+        self.dbElem.setDbHost(getHostName())
+        # Find a suitable port to run on.
         try:
-            with open(logPath) as f:
-                log = f.read()
+            occupiedPorts = findOccupiedPorts()
+            unoccupiedPorts = set(range(1025, MAX_KTSERVER_PORT)) - occupiedPorts
+            port = random.choice(list(unoccupiedPorts))
         except:
-            log = ''
-        raise RuntimeError("Unable to launch ktserver in time. Log: %s" % log)
+            logger.warning("Can't find which ports are occupied--likely netstat is not installed."
+                           " Choosing a random port to start the DB on, good luck!")
+            port = random.randint(1025,MAX_KTSERVER_PORT)
+        self.dbElem.setDbPort(port)
+        process = KtServerProcess(self)
+        process.daemon = True
+        process.start()
 
-    return process, dbElem, logPath
+        if not self.blockUntilServerIsRunning():
+            try:
+                with open(self.logPath) as f:
+                    log = f.read()
+            except:
+                log = ''
+            raise RuntimeError("Unable to launch ktserver in time. Log: %s" % log)
 
-class ServerProcess(Process):
+        return process, self.dbElem, self.logPath
+
+    def blockUntilServerIsRunning(self, createTimeout=1800):
+        """Check status until it's successful, an error is found, or we timeout.
+
+        Returns True if the ktserver is now running, False if something went wrong."""
+        success = False
+        for i in range(createTimeout):
+            if self.isServerFailed():
+                logger.critical('Error starting ktserver.')
+                success = False
+                break
+            if self.isServerRunning():
+                logger.info('Ktserver running.')
+                success = True
+                break
+            sleep(1)
+        return success
+
+    def blockUntilServerIsFinished(self, timeout=1800, timeStep=10):
+        """Wait for the ktserver log to indicate that it shut down properly.
+
+        Returns True if the server shut down, False if the timeout expired."""
+        for i in range(0, timeout, timeStep):
+            with open(self.logPath) as f:
+                log = f.read()
+                if '[FINISH]' in log:
+                    return True
+            sleep(timeStep)
+        raise RuntimeError("Timeout reached while waiting for ktserver.")
+
+    def isServerRunning(self):
+        """Check if the server started running."""
+        success = False
+        with open(self.logPath) as f:
+            for line in f:
+                if line.lower().find("listening") >= 0:
+                    success = True
+        return success
+
+    def isServerFailed(self):
+        """Does the server log contain an error?"""
+        isFailed = False
+        with open(self.logPath) as f:
+            for line in f:
+                if line.lower().find("error") >= 0:
+                    isFailed = True
+                    break
+        return isFailed
+
+    def getTuningOptions(self):
+        """Get the appropriate KTServer tuning parameters (bucket size, etc.)"""
+        # these are some hardcoded defaults.  should think about moving to config
+        tuningOptions = "#opts=ls#bnum=30m#msiz=50g#ktopts=p"
+        # override default ktserver settings if they are present in the
+        # experiment xml file.
+        if self.dbElem.getDbTuningOptions() is not None:
+            tuningOptions = self.dbElem.getDbTuningOptions()
+        if self.dbElem.getDbCreateTuningOptions() is not None:
+            tuningOptions = self.dbElem.getDbCreateTuningOptions()
+        return tuningOptions
+
+    def getServerOptions(self):
+        # these are some hardcoded defaults.  should think about moving to config
+        serverOptions = "-ls -tout 200000 -th 64"
+        if self.dbElem.getDbServerOptions() is not None:
+            serverOptions = self.dbElem.getDbServerOptions()
+        return serverOptions
+
+    def getServerCommand(self, snapshotDir):
+        """Get a ktserver command line with the proper options (in popen-type list format)."""
+        serverOptions = self.getServerOptions()
+        tuning = self.getTuningOptions()
+        cmd = ["ktserver", "-port", str(self.dbElem.getDbPort())]
+        cmd += serverOptions.split()
+        # Configure background snapshots, but set the interval between
+        # snapshots to ~ 10 days so it'll never trigger. We are only
+        # interested in the snapshot that the DB creates on termination.
+        cmd += ["-bgs", snapshotDir, "-bgsc", "lzo", "-bgsi", "1000000"]
+        cmd += ["-log", self.logPath]
+        cmd += [":" + tuning]
+        return cmd
+
+    def getRemoteParams(self):
+        """Get parameters to supply to ktremotemgr to connect to the right DB."""
+        host = self.dbElem.getDbHost() or 'localhost'
+        return ['-port', str(self.dbElem.getDbPort()),
+                '-host', host]
+
+    def stopServer(self):
+        """Attempt to send the terminate signal to a ktserver."""
+        cactus_call(parameters=['ktremotemgr', 'set'] + self.getRemoteParams() + ['TERMINATE', '1'])
+
+
+class KtServerProcess(Process):
     """Independent process that babysits the ktserver process.
 
     Waits for the TERMINATE flag to be set, then kills the DB and
@@ -72,7 +171,7 @@ class ServerProcess(Process):
     def __init__(self, *args, **kwargs):
         self.args = args
         self.kwargs = kwargs
-        super(ServerProcess, self).__init__()
+        super(KtServerProcess, self).__init__()
 
     def run(self):
         """Run the tryRun method, signaling the main thread if an exception occurs."""
@@ -82,27 +181,25 @@ class ServerProcess(Process):
             self.exceptionMsg.put("".join(traceback.format_exception(*sys.exc_info())))
             raise
 
-    def tryRun(self, dbElem, logPath, fileStore, existingSnapshotID=None, snapshotExportID=None):
-        snapshotDir = os.path.join(fileStore.getLocalTempDir(), 'snapshot')
+    def tryRun(self, ktServer):
+        snapshotDir = os.path.join(ktServer.fileStore.getLocalTempDir(), 'snapshot')
         os.mkdir(snapshotDir)
         snapshotPath = os.path.join(snapshotDir, KTSERVER_SNAPSHOT_NAME)
-        if existingSnapshotID is not None:
+        if ktServer.existingSnapshotID is not None:
             # Extract the existing snapshot to the snapshot
             # directory so it will be automatically loaded
-            fileStore.readGlobalFile(existingSnapshotID, userPath=snapshotPath)
+            ktServer.fileStore.readGlobalFile(ktServer.existingSnapshotID, userPath=snapshotPath)
         process = cactus_call(server=True, shell=False,
-                              parameters=getKtserverCommand(dbElem, logPath, snapshotDir),
-                              port=dbElem.getDbPort())
-
-        blockUntilKtserverIsRunning(logPath)
-        if existingSnapshotID is not None:
+                              parameters=ktServer.getServerCommand(snapshotDir),
+                              port=ktServer.dbElem.getDbPort())
+        ktServer.blockUntilServerIsRunning()
+        if ktServer.existingSnapshotID is not None:
             # Clear the termination flag from the snapshot
-            cactus_call(parameters=["ktremotemgr", "remove"] + getRemoteParams(dbElem) + ["TERMINATE"])
-
+            cactus_call(parameters=["ktremotemgr", "remove"] + ktServer.getRemoteParams() + ["TERMINATE"])
         while True:
             # Check for the termination signal
             try:
-                cactus_call(parameters=["ktremotemgr", "get"] + getRemoteParams(dbElem) + ["TERMINATE"],
+                cactus_call(parameters=["ktremotemgr", "get"] + ktServer.getRemoteParams() + ["TERMINATE"],
                             swallowStdErr=True)
             except:
                 # No terminate signal sent yet
@@ -111,116 +208,24 @@ class ServerProcess(Process):
                 # Terminate signal received
                 break
             # Check that the DB is still alive
-            if process.poll() is not None or isKtServerFailed(logPath):
-                with open(logPath) as f:
+            if process.poll() is not None or ktServer.isServerFailed():
+                with open(ktServer.logPath) as f:
                     raise RuntimeError("KTServer failed. Log: %s" % f.read())
             sleep(60)
         process.send_signal(signal.SIGINT)
         process.wait()
-        blockUntilKtserverIsFinished(logPath)
-        if snapshotExportID is not None:
+        ktServer.blockUntilServerIsFinished()
+        if ktServer.snapshotExportID is not None:
             if not os.path.exists(snapshotPath):
-                with open(logPath) as f:
+                with open(ktServer.logPath) as f:
                     raise RuntimeError("KTServer did not leave a snapshot on termination,"
                                        " but a snapshot was requested. Log: %s" % f.read())
             if len(glob(os.path.join(snapshotDir, "*.ktss"))) != 1:
                 # More than one snapshot file. It's not clear what
                 # conditions trigger this--if any--but we
                 # don't support it right now.
-                with open(logPath) as f:
+                with open(ktServer.logPath) as f:
                     raise RuntimeError("KTServer left more than one snapshot. Log: %s" % f.read())
 
             # Export the snapshot file to the file store
-            fileStore.jobStore.updateFile(snapshotExportID, snapshotPath)
-
-def blockUntilKtserverIsRunning(logPath, createTimeout=1800):
-    """Check status until it's successful, an error is found, or we timeout.
-
-    Returns True if the ktserver is now running, False if something went wrong."""
-    success = False
-    for i in range(createTimeout):
-        if isKtServerFailed(logPath):
-            logger.critical('Error starting ktserver.')
-            success = False
-            break
-        if isKtServerRunning(logPath):
-            logger.info('Ktserver running.')
-            success = True
-            break
-        sleep(1)
-    return success
-
-def blockUntilKtserverIsFinished(logPath, timeout=1800,
-                                 timeStep=10):
-    """Wait for the ktserver log to indicate that it shut down properly.
-
-    Returns True if the server shut down, False if the timeout expired."""
-    for i in range(0, timeout, timeStep):
-        with open(logPath) as f:
-            log = f.read()
-            if '[FINISH]' in log:
-                return True
-        sleep(timeStep)
-    raise RuntimeError("Timeout reached while waiting for ktserver.")
-
-def isKtServerRunning(logPath):
-    """Check if the server started running."""
-    success = False
-    with open(logPath) as f:
-        for line in f:
-            if line.lower().find("listening") >= 0:
-                success = True
-    return success
-
-def isKtServerFailed(logPath):
-    """Does the server log contain an error?"""
-    isFailed = False
-    with open(logPath) as f:
-        for line in f:
-            if line.lower().find("error") >= 0:
-                isFailed = True
-                break
-    return isFailed
-
-def getKtTuningOptions(dbElem):
-    """Get the appropriate KTServer tuning parameters (bucket size, etc.)"""
-    # these are some hardcoded defaults.  should think about moving to config
-    tuningOptions = "#opts=ls#bnum=30m#msiz=50g#ktopts=p"
-    # override default ktserver settings if they are present in the
-    # experiment xml file.
-    if dbElem.getDbTuningOptions() is not None:
-        tuningOptions = dbElem.getDbTuningOptions()
-    if dbElem.getDbCreateTuningOptions() is not None:
-        tuningOptions = dbElem.getDbCreateTuningOptions()
-    return tuningOptions
-
-def getKtServerOptions(dbElem):
-    # these are some hardcoded defaults.  should think about moving to config
-    serverOptions = "-ls -tout 200000 -th 64"
-    if dbElem.getDbServerOptions() is not None:
-        serverOptions = dbElem.getDbServerOptions()
-    return serverOptions
-
-def getKtserverCommand(dbElem, logPath, snapshotDir):
-    """Get a ktserver command line with the proper options (in popen-type list format)."""
-    serverOptions = getKtServerOptions(dbElem)
-    tuning = getKtTuningOptions(dbElem)
-    cmd = ["ktserver", "-port", str(dbElem.getDbPort())]
-    cmd += serverOptions.split()
-    # Configure background snapshots, but set the interval between
-    # snapshots to ~ 10 days so it'll never trigger. We are only
-    # interested in the snapshot that the DB creates on termination.
-    cmd += ["-bgs", snapshotDir, "-bgsc", "lzo", "-bgsi", "1000000"]
-    cmd += ["-log", logPath]
-    cmd += [":" + tuning]
-    return cmd
-
-def getRemoteParams(dbElem):
-    """Get parameters to supply to ktremotemgr to connect to the right DB."""
-    host = dbElem.getDbHost() or 'localhost'
-    return ['-port', str(dbElem.getDbPort()),
-            '-host', host]
-
-def stopKtserver(dbElem):
-    """Attempt to send the terminate signal to a ktserver."""
-    cactus_call(parameters=['ktremotemgr', 'set'] + getRemoteParams(dbElem) + ['TERMINATE', '1'])
+            ktServer.fileStore.jobStore.updateFile(ktServer.snapshotExportID, snapshotPath)

--- a/src/cactus/pipeline/ktserverControl.py
+++ b/src/cactus/pipeline/ktserverControl.py
@@ -4,19 +4,17 @@ Functions to launch and manage KyotoTycoon servers.
 """
 
 import os
-import platform
 import random
-import socket
 import signal
 import sys
 import traceback
-from contextlib import closing
 from glob import glob
 from multiprocessing import Process, Queue
 from time import sleep
 
 from toil.lib.bioio import logger
 from cactus.shared.common import cactus_call
+from cactus.pipeline.dbServerCommon import getHostName, findOccupiedPorts
 
 # For some reason ktserver believes there are only 32768 TCP ports.
 MAX_KTSERVER_PORT = 32767
@@ -226,48 +224,3 @@ def getRemoteParams(dbElem):
 def stopKtserver(dbElem):
     """Attempt to send the terminate signal to a ktserver."""
     cactus_call(parameters=['ktremotemgr', 'set'] + getRemoteParams(dbElem) + ['TERMINATE', '1'])
-
-def getHostName():
-    if platform.system() == 'Darwin':
-        # macOS doesn't have a true Docker bridging mode, so each
-        # container is NATed with its own local IP and can't bind
-        # to/connect to this computer's external IP. We have to
-        # hardcode the loopback IP to work around this.
-        return '127.0.0.1'
-    return getPublicIP()
-
-# Borrowed from toil code.
-def getPublicIP():
-    """Get the IP that this machine uses to contact the internet.
-    If behind a NAT, this will still be this computer's IP, and not the router's."""
-    try:
-        # Try to get the internet-facing IP by attempting a connection
-        # to a non-existent server and reading what IP was used.
-        with closing(socket.socket(socket.AF_INET, socket.SOCK_DGRAM)) as sock:
-            # 203.0.113.0/24 is reserved as TEST-NET-3 by RFC 5737, so
-            # there is guaranteed to be no one listening on the other
-            # end (and we won't accidentally DOS anyone).
-            sock.connect(('203.0.113.1', 1))
-            ip = sock.getsockname()[0]
-        return ip
-    except:
-        # Something went terribly wrong. Just give loopback rather
-        # than killing everything, because this is often called just
-        # to provide a default argument
-        return '127.0.0.1'
-
-def findOccupiedPorts():
-    """Attempt to find all currently taken TCP ports.
-
-    Returns a set of ints, representing taken ports."""
-    netstatOutput = cactus_call(parameters=["netstat", "-tuplen"], check_output=True)
-    ports = set()
-    for line in netstatOutput.split("\n"):
-        fields = line.split()
-        if len(fields) != 9:
-            # Header or other garbage line
-            continue
-        port = int(fields[3].split(':')[-1])
-        ports.add(port)
-    logger.debug('Detected ports in use: %s' % repr(ports))
-    return ports

--- a/src/cactus/pipeline/redisServerControl.py
+++ b/src/cactus/pipeline/redisServerControl.py
@@ -137,7 +137,7 @@ class RedisServer:
     def getServerOptions(self):
         # these are some hardcoded defaults.  should think about moving to config
         # TODO: check if every necessary option is added
-        serverOptions = "--timeout 0 --databases 1"
+        serverOptions = "--timeout 0 --databases 1 --protected-mode no"
         if self.dbElem.getDbServerOptions() is not None:
             serverOptions = self.dbElem.getDbServerOptions()
         return serverOptions

--- a/src/cactus/pipeline/redisServerControl.py
+++ b/src/cactus/pipeline/redisServerControl.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""
+Functions to launch and manage Redis servers.
+"""
+
+import os
+import random
+import signal
+import sys
+import traceback
+from glob import glob
+from multiprocessing import Process, Queue
+from time import sleep
+
+from toil.lib.bioio import logger
+from cactus.shared.common import cactus_call
+from cactus.pipeline.dbServerCommon import getHostName, findOccupiedPorts
+
+# For some reason ktserver believes there are only 32768 TCP ports.
+MAX_KTSERVER_PORT = 32767
+
+# The name of the snapshot that KT outputs.
+KTSERVER_SNAPSHOT_NAME = "00000000.ktss"
+
+
+class RedisServer:
+    def __init__(self, dbElem, fileStore=None, existingSnapshotID=None, snapshotExportID=None):
+        self.dbElem = dbElem
+        self.logPath = None
+        self.fileStore = fileStore
+        self.existingSnapshotID = existingSnapshotID
+        self.snapshotExportID = snapshotExportID
+
+    def runServer(self):
+        """
+        Run a KTServer. This function launches a separate python process that manages the server.
+
+        Writing to the special key "TERMINATE" signals this thread to safely shut
+        down the DB and save the results. After finishing, the data will
+        eventually be written to snapshotFile.
+
+        Returns a tuple containing an updated version of the database config dbElem and the
+        path to the log file.
+        """
+        self.logPath = self.fileStore.getLocalTempFile()
+        self.dbElem.setDbHost(getHostName())
+        # Find a suitable port to run on.
+        try:
+            occupiedPorts = findOccupiedPorts()
+            unoccupiedPorts = set(range(1025, MAX_KTSERVER_PORT)) - occupiedPorts
+            port = random.choice(list(unoccupiedPorts))
+        except:
+            logger.warning("Can't find which ports are occupied--likely netstat is not installed."
+                           " Choosing a random port to start the DB on, good luck!")
+            port = random.randint(1025,MAX_KTSERVER_PORT)
+        self.dbElem.setDbPort(port)
+        process = RedisServerProcess(self)
+        process.daemon = True
+        process.start()
+
+        if not self.blockUntilServerIsRunning():
+            try:
+                with open(self.logPath) as f:
+                    log = f.read()
+            except:
+                log = ''
+            raise RuntimeError("Unable to launch ktserver in time. Log: %s" % log)
+
+        return process, self.dbElem, self.logPath
+
+    def blockUntilServerIsRunning(self, createTimeout=1800):
+        """Check status until it's successful, an error is found, or we timeout.
+
+        Returns True if the ktserver is now running, False if something went wrong."""
+        success = False
+        for i in range(createTimeout):
+            if self.isServerFailed():
+                logger.critical('Error starting ktserver.')
+                success = False
+                break
+            if self.isServerRunning():
+                logger.info('Ktserver running.')
+                success = True
+                break
+            sleep(1)
+        return success
+
+    def blockUntilServerIsFinished(self, timeout=1800, timeStep=10):
+        """Wait for the ktserver log to indicate that it shut down properly.
+
+        Returns True if the server shut down, False if the timeout expired."""
+        for i in range(0, timeout, timeStep):
+            with open(self.logPath) as f:
+                log = f.read()
+                if '[FINISH]' in log:
+                    return True
+            sleep(timeStep)
+        raise RuntimeError("Timeout reached while waiting for ktserver.")
+
+    def isServerRunning(self):
+        """Check if the server started running."""
+        success = False
+        with open(self.logPath) as f:
+            for line in f:
+                if line.lower().find("listening") >= 0:
+                    success = True
+        return success
+
+    def isServerFailed(self):
+        """Does the server log contain an error?"""
+        isFailed = False
+        with open(self.logPath) as f:
+            for line in f:
+                if line.lower().find("error") >= 0:
+                    isFailed = True
+                    break
+        return isFailed
+
+    def getTuningOptions(self):
+        """Get the appropriate KTServer tuning parameters (bucket size, etc.)"""
+        # these are some hardcoded defaults.  should think about moving to config
+        tuningOptions = "#opts=ls#bnum=30m#msiz=50g#ktopts=p"
+        # override default ktserver settings if they are present in the
+        # experiment xml file.
+        if self.dbElem.getDbTuningOptions() is not None:
+            tuningOptions = self.dbElem.getDbTuningOptions()
+        if self.dbElem.getDbCreateTuningOptions() is not None:
+            tuningOptions = self.dbElem.getDbCreateTuningOptions()
+        return tuningOptions
+
+    def getServerOptions(self):
+        # these are some hardcoded defaults.  should think about moving to config
+        serverOptions = "-ls -tout 200000 -th 64"
+        if self.dbElem.getDbServerOptions() is not None:
+            serverOptions = self.dbElem.getDbServerOptions()
+        return serverOptions
+
+    def getServerCommand(self, snapshotDir):
+        """Get a ktserver command line with the proper options (in popen-type list format)."""
+        serverOptions = self.getServerOptions()
+        tuning = self.getTuningOptions()
+        cmd = ["ktserver", "-port", str(self.dbElem.getDbPort())]
+        cmd += serverOptions.split()
+        # Configure background snapshots, but set the interval between
+        # snapshots to ~ 10 days so it'll never trigger. We are only
+        # interested in the snapshot that the DB creates on termination.
+        cmd += ["-bgs", snapshotDir, "-bgsc", "lzo", "-bgsi", "1000000"]
+        cmd += ["-log", self.logPath]
+        cmd += [":" + tuning]
+        return cmd
+
+    def getRemoteParams(self):
+        """Get parameters to supply to ktremotemgr to connect to the right DB."""
+        host = self.dbElem.getDbHost() or 'localhost'
+        return ['-port', str(self.dbElem.getDbPort()),
+                '-host', host]
+
+    def stopServer(self):
+        """Attempt to send the terminate signal to a ktserver."""
+        cactus_call(parameters=['ktremotemgr', 'set'] + self.getRemoteParams() + ['TERMINATE', '1'])
+
+
+class RedisServerProcess(Process):
+    """Independent process that babysits the ktserver process.
+
+    Waits for the TERMINATE flag to be set, then kills the DB and
+    copies the final snapshot to snapshotExportID.
+    """
+    exceptionMsg = Queue()
+
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+        super(RedisServerProcess, self).__init__()
+
+    def run(self):
+        """Run the tryRun method, signaling the main thread if an exception occurs."""
+        try:
+            self.tryRun(*self.args, **self.kwargs)
+        except BaseException:
+            self.exceptionMsg.put("".join(traceback.format_exception(*sys.exc_info())))
+            raise
+
+    def tryRun(self, ktServer):
+        snapshotDir = os.path.join(ktServer.fileStore.getLocalTempDir(), 'snapshot')
+        os.mkdir(snapshotDir)
+        snapshotPath = os.path.join(snapshotDir, KTSERVER_SNAPSHOT_NAME)
+        if ktServer.existingSnapshotID is not None:
+            # Extract the existing snapshot to the snapshot
+            # directory so it will be automatically loaded
+            ktServer.fileStore.readGlobalFile(ktServer.existingSnapshotID, userPath=snapshotPath)
+        process = cactus_call(server=True, shell=False,
+                              parameters=ktServer.getServerCommand(snapshotDir),
+                              port=ktServer.dbElem.getDbPort())
+        ktServer.blockUntilServerIsRunning()
+        if ktServer.existingSnapshotID is not None:
+            # Clear the termination flag from the snapshot
+            cactus_call(parameters=["ktremotemgr", "remove"] + ktServer.getRemoteParams() + ["TERMINATE"])
+        while True:
+            # Check for the termination signal
+            try:
+                cactus_call(parameters=["ktremotemgr", "get"] + ktServer.getRemoteParams() + ["TERMINATE"],
+                            swallowStdErr=True)
+            except:
+                # No terminate signal sent yet
+                pass
+            else:
+                # Terminate signal received
+                break
+            # Check that the DB is still alive
+            if process.poll() is not None or ktServer.isServerFailed():
+                with open(ktServer.logPath) as f:
+                    raise RuntimeError("KTServer failed. Log: %s" % f.read())
+            sleep(60)
+        process.send_signal(signal.SIGINT)
+        process.wait()
+        ktServer.blockUntilServerIsFinished()
+        if ktServer.snapshotExportID is not None:
+            if not os.path.exists(snapshotPath):
+                with open(ktServer.logPath) as f:
+                    raise RuntimeError("KTServer did not leave a snapshot on termination,"
+                                       " but a snapshot was requested. Log: %s" % f.read())
+            if len(glob(os.path.join(snapshotDir, "*.ktss"))) != 1:
+                # More than one snapshot file. It's not clear what
+                # conditions trigger this--if any--but we
+                # don't support it right now.
+                with open(ktServer.logPath) as f:
+                    raise RuntimeError("KTServer left more than one snapshot. Log: %s" % f.read())
+
+            # Export the snapshot file to the file store
+            ktServer.fileStore.jobStore.updateFile(ktServer.snapshotExportID, snapshotPath)

--- a/src/cactus/pipeline/redisServerControl.py
+++ b/src/cactus/pipeline/redisServerControl.py
@@ -8,7 +8,6 @@ import random
 import signal
 import sys
 import traceback
-from glob import glob
 from multiprocessing import Process, Queue
 from time import sleep
 
@@ -16,11 +15,11 @@ from toil.lib.bioio import logger
 from cactus.shared.common import cactus_call
 from cactus.pipeline.dbServerCommon import getHostName, findOccupiedPorts
 
-# For some reason ktserver believes there are only 32768 TCP ports.
-MAX_KTSERVER_PORT = 32767
 
-# The name of the snapshot that KT outputs.
-KTSERVER_SNAPSHOT_NAME = "00000000.ktss"
+MAX_REDIS_PORT = 65535
+
+# The name of the snapshot that Redis outputs.
+REDIS_SNAPSHOT_NAME = "dump.rdb"
 
 
 class RedisServer:
@@ -30,10 +29,11 @@ class RedisServer:
         self.fileStore = fileStore
         self.existingSnapshotID = existingSnapshotID
         self.snapshotExportID = snapshotExportID
+        self.databaseDir = None
 
     def runServer(self):
         """
-        Run a KTServer. This function launches a separate python process that manages the server.
+        Run a redis-server. This function launches a separate python process that manages the server.
 
         Writing to the special key "TERMINATE" signals this thread to safely shut
         down the DB and save the results. After finishing, the data will
@@ -42,17 +42,22 @@ class RedisServer:
         Returns a tuple containing an updated version of the database config dbElem and the
         path to the log file.
         """
-        self.logPath = self.fileStore.getLocalTempFile()
+
+        self.databaseDir = self.fileStore.getLocalTempDir()
+        # log file can be saved in a subdirectory of where the snapshot is being saved
+        self.logPath = os.path.join(self.databaseDir, "redis.log")
+        open(self.logPath, 'a').close()
+
         self.dbElem.setDbHost(getHostName())
         # Find a suitable port to run on.
         try:
             occupiedPorts = findOccupiedPorts()
-            unoccupiedPorts = set(range(1025, MAX_KTSERVER_PORT)) - occupiedPorts
+            unoccupiedPorts = set(range(1025, MAX_REDIS_PORT)) - occupiedPorts
             port = random.choice(list(unoccupiedPorts))
         except:
             logger.warning("Can't find which ports are occupied--likely netstat is not installed."
                            " Choosing a random port to start the DB on, good luck!")
-            port = random.randint(1025,MAX_KTSERVER_PORT)
+            port = random.randint(1025, MAX_REDIS_PORT)
         self.dbElem.setDbPort(port)
         process = RedisServerProcess(self)
         process.daemon = True
@@ -64,45 +69,45 @@ class RedisServer:
                     log = f.read()
             except:
                 log = ''
-            raise RuntimeError("Unable to launch ktserver in time. Log: %s" % log)
+            raise RuntimeError("Unable to launch redis-server in time. Log: %s" % log)
 
         return process, self.dbElem, self.logPath
 
     def blockUntilServerIsRunning(self, createTimeout=1800):
         """Check status until it's successful, an error is found, or we timeout.
 
-        Returns True if the ktserver is now running, False if something went wrong."""
+        Returns True if the redis-server is now running, False if something went wrong."""
         success = False
         for i in range(createTimeout):
             if self.isServerFailed():
-                logger.critical('Error starting ktserver.')
+                logger.critical('Error starting Redis server.')
                 success = False
                 break
             if self.isServerRunning():
-                logger.info('Ktserver running.')
+                logger.info('Redis server running.')
                 success = True
                 break
             sleep(1)
         return success
 
     def blockUntilServerIsFinished(self, timeout=1800, timeStep=10):
-        """Wait for the ktserver log to indicate that it shut down properly.
+        """Wait for the redis-server log to indicate that it shut down properly.
 
         Returns True if the server shut down, False if the timeout expired."""
         for i in range(0, timeout, timeStep):
             with open(self.logPath) as f:
                 log = f.read()
-                if '[FINISH]' in log:
+                if 'ready to exit' in log:
                     return True
             sleep(timeStep)
-        raise RuntimeError("Timeout reached while waiting for ktserver.")
+        raise RuntimeError("Timeout reached while waiting for redis server.")
 
     def isServerRunning(self):
         """Check if the server started running."""
         success = False
         with open(self.logPath) as f:
             for line in f:
-                if line.lower().find("listening") >= 0:
+                if line.lower().find("accept connections") >= 0:
                     success = True
         return success
 
@@ -117,10 +122,11 @@ class RedisServer:
         return isFailed
 
     def getTuningOptions(self):
-        """Get the appropriate KTServer tuning parameters (bucket size, etc.)"""
+        """Get the appropriate redis-server tuning parameters (bucket size, etc.)"""
         # these are some hardcoded defaults.  should think about moving to config
-        tuningOptions = "#opts=ls#bnum=30m#msiz=50g#ktopts=p"
-        # override default ktserver settings if they are present in the
+        # TODO: check if every necessary tuning option is added (maybe to be merged with getServerOptions())
+        tuningOptions = "--maxmemory 50Gb"
+        # override default redis-server settings if they are present in the
         # experiment xml file.
         if self.dbElem.getDbTuningOptions() is not None:
             tuningOptions = self.dbElem.getDbTuningOptions()
@@ -130,38 +136,41 @@ class RedisServer:
 
     def getServerOptions(self):
         # these are some hardcoded defaults.  should think about moving to config
-        serverOptions = "-ls -tout 200000 -th 64"
+        # TODO: check if every necessary option is added
+        serverOptions = "--timeout 0 --databases 1"
         if self.dbElem.getDbServerOptions() is not None:
             serverOptions = self.dbElem.getDbServerOptions()
         return serverOptions
 
     def getServerCommand(self, snapshotDir):
-        """Get a ktserver command line with the proper options (in popen-type list format)."""
+        """Get a redis-server command line with the proper options (in popen-type list format)."""
         serverOptions = self.getServerOptions()
         tuning = self.getTuningOptions()
-        cmd = ["ktserver", "-port", str(self.dbElem.getDbPort())]
+        cmd = ["redis-server", "--port", str(self.dbElem.getDbPort())]
         cmd += serverOptions.split()
         # Configure background snapshots, but set the interval between
         # snapshots to ~ 10 days so it'll never trigger. We are only
         # interested in the snapshot that the DB creates on termination.
-        cmd += ["-bgs", snapshotDir, "-bgsc", "lzo", "-bgsi", "1000000"]
-        cmd += ["-log", self.logPath]
-        cmd += [":" + tuning]
+        cmd += ["--save", "1000000", "1"]
+        cmd += ["--dir", snapshotDir, "--dbfilename", REDIS_SNAPSHOT_NAME]
+        cmd += ["--logfile", 'redis.log']
+        cmd += tuning.split()
         return cmd
 
     def getRemoteParams(self):
-        """Get parameters to supply to ktremotemgr to connect to the right DB."""
-        host = self.dbElem.getDbHost() or 'localhost'
-        return ['-port', str(self.dbElem.getDbPort()),
-                '-host', host]
+        """Get parameters to supply to redis-cli to connect to the right DB."""
+        # TODO: find why redis-cli raise error when called with an IP as the host
+        #host = self.dbElem.getDbHost() or 'localhost'
+        host = 'localhost'
+        return ['-p', str(self.dbElem.getDbPort()), '-h', host]
 
     def stopServer(self):
-        """Attempt to send the terminate signal to a ktserver."""
-        cactus_call(parameters=['ktremotemgr', 'set'] + self.getRemoteParams() + ['TERMINATE', '1'])
+        """Attempt to send the terminate signal to a redis-server."""
+        cactus_call(parameters=['redis-cli'] + self.getRemoteParams() + ['set', 'TERMINATE', '1'])
 
 
 class RedisServerProcess(Process):
-    """Independent process that babysits the ktserver process.
+    """Independent process that babysits the redis-server process.
 
     Waits for the TERMINATE flag to be set, then kills the DB and
     copies the final snapshot to snapshotExportID.
@@ -181,51 +190,43 @@ class RedisServerProcess(Process):
             self.exceptionMsg.put("".join(traceback.format_exception(*sys.exc_info())))
             raise
 
-    def tryRun(self, ktServer):
-        snapshotDir = os.path.join(ktServer.fileStore.getLocalTempDir(), 'snapshot')
-        os.mkdir(snapshotDir)
-        snapshotPath = os.path.join(snapshotDir, KTSERVER_SNAPSHOT_NAME)
-        if ktServer.existingSnapshotID is not None:
+    def tryRun(self, redisServer):
+        snapshotDir = redisServer.databaseDir
+        snapshotPath = os.path.join(snapshotDir, REDIS_SNAPSHOT_NAME)
+        if redisServer.existingSnapshotID is not None:
             # Extract the existing snapshot to the snapshot
             # directory so it will be automatically loaded
-            ktServer.fileStore.readGlobalFile(ktServer.existingSnapshotID, userPath=snapshotPath)
+            redisServer.fileStore.readGlobalFile(redisServer.existingSnapshotID, userPath=snapshotPath)
         process = cactus_call(server=True, shell=False,
-                              parameters=ktServer.getServerCommand(snapshotDir),
-                              port=ktServer.dbElem.getDbPort())
-        ktServer.blockUntilServerIsRunning()
-        if ktServer.existingSnapshotID is not None:
+                              parameters=redisServer.getServerCommand(snapshotDir),
+                              port=redisServer.dbElem.getDbPort())
+
+        redisServer.blockUntilServerIsRunning()
+        if redisServer.existingSnapshotID is not None:
             # Clear the termination flag from the snapshot
-            cactus_call(parameters=["ktremotemgr", "remove"] + ktServer.getRemoteParams() + ["TERMINATE"])
+            cactus_call(parameters=["redis-cli"] + redisServer.getRemoteParams() + ["del", "TERMINATE"])
         while True:
             # Check for the termination signal
-            try:
-                cactus_call(parameters=["ktremotemgr", "get"] + ktServer.getRemoteParams() + ["TERMINATE"],
-                            swallowStdErr=True)
-            except:
+            terminateFlag = cactus_call(parameters=["redis-cli"] + redisServer.getRemoteParams() + ["get", "TERMINATE"],
+                                        swallowStdErr=True, check_output=True)
+            if terminateFlag.strip() != '1':
                 # No terminate signal sent yet
                 pass
             else:
                 # Terminate signal received
                 break
             # Check that the DB is still alive
-            if process.poll() is not None or ktServer.isServerFailed():
-                with open(ktServer.logPath) as f:
-                    raise RuntimeError("KTServer failed. Log: %s" % f.read())
+            if process.poll() is not None or redisServer.isServerFailed():
+                with open(redisServer.logPath) as f:
+                    raise RuntimeError("redis server failed. Log: %s" % f.read())
             sleep(60)
         process.send_signal(signal.SIGINT)
         process.wait()
-        ktServer.blockUntilServerIsFinished()
-        if ktServer.snapshotExportID is not None:
+        redisServer.blockUntilServerIsFinished()
+        if redisServer.snapshotExportID is not None:
             if not os.path.exists(snapshotPath):
-                with open(ktServer.logPath) as f:
-                    raise RuntimeError("KTServer did not leave a snapshot on termination,"
+                with open(redisServer.logPath) as f:
+                    raise RuntimeError("redis-server did not leave a snapshot on termination,"
                                        " but a snapshot was requested. Log: %s" % f.read())
-            if len(glob(os.path.join(snapshotDir, "*.ktss"))) != 1:
-                # More than one snapshot file. It's not clear what
-                # conditions trigger this--if any--but we
-                # don't support it right now.
-                with open(ktServer.logPath) as f:
-                    raise RuntimeError("KTServer left more than one snapshot. Log: %s" % f.read())
-
             # Export the snapshot file to the file store
-            ktServer.fileStore.jobStore.updateFile(ktServer.snapshotExportID, snapshotPath)
+            redisServer.fileStore.jobStore.updateFile(redisServer.snapshotExportID, snapshotPath)

--- a/src/cactus/pipeline/redisServerControl.py
+++ b/src/cactus/pipeline/redisServerControl.py
@@ -137,7 +137,7 @@ class RedisServer:
     def getServerOptions(self):
         # these are some hardcoded defaults.  should think about moving to config
         # TODO: check if every necessary option is added
-        serverOptions = "--timeout 0 --databases 1 --protected-mode no"
+        serverOptions = "--timeout 0 --databases 1 --protected-mode no --maxclients 200"
         if self.dbElem.getDbServerOptions() is not None:
             serverOptions = self.dbElem.getDbServerOptions()
         return serverOptions

--- a/src/cactus/pipeline/redisServerControl.py
+++ b/src/cactus/pipeline/redisServerControl.py
@@ -125,7 +125,7 @@ class RedisServer:
         """Get the appropriate redis-server tuning parameters (bucket size, etc.)"""
         # these are some hardcoded defaults.  should think about moving to config
         # TODO: check if every necessary tuning option is added (maybe to be merged with getServerOptions())
-        tuningOptions = "--maxmemory 50Gb"
+        tuningOptions = "--maxmemory 1000Gb"
         # override default redis-server settings if they are present in the
         # experiment xml file.
         if self.dbElem.getDbTuningOptions() is not None:
@@ -151,7 +151,7 @@ class RedisServer:
         # Configure background snapshots, but set the interval between
         # snapshots to ~ 10 days so it'll never trigger. We are only
         # interested in the snapshot that the DB creates on termination.
-        cmd += ["--save", "1000000", "1"]
+        cmd += ["--save", "", "--save", "1000000", "1000000"]
         cmd += ["--dir", snapshotDir, "--dbfilename", REDIS_SNAPSHOT_NAME]
         cmd += ["--logfile", 'redis.log']
         cmd += tuning.split()
@@ -159,9 +159,7 @@ class RedisServer:
 
     def getRemoteParams(self):
         """Get parameters to supply to redis-cli to connect to the right DB."""
-        # TODO: find why redis-cli raise error when called with an IP as the host
-        #host = self.dbElem.getDbHost() or 'localhost'
-        host = 'localhost'
+        host = self.dbElem.getDbHost() or 'localhost'
         return ['-p', str(self.dbElem.getDbPort()), '-h', host]
 
     def stopServer(self):

--- a/src/cactus/pipeline/redisServerControl.py
+++ b/src/cactus/pipeline/redisServerControl.py
@@ -59,6 +59,10 @@ class RedisServer:
                            " Choosing a random port to start the DB on, good luck!")
             port = random.randint(1025, MAX_REDIS_PORT)
         self.dbElem.setDbPort(port)
+        try:
+            cactus_call(shell=False, parameters=['redis-server','--version'])
+        except:
+            raise RuntimeError("redis-server is not installed")
         process = RedisServerProcess(self)
         process.daemon = True
         process.start()

--- a/src/cactus/progressive/cactus_prepare.py
+++ b/src/cactus/progressive/cactus_prepare.py
@@ -115,9 +115,9 @@ def main(toil_mode=False):
     parser.add_argument("--blastPreemptible", type=int, help="Preemptible attempt count for each cactus-blast job [default=1]", default=1)
     parser.add_argument("--alignPreemptible", type=int, help="Preemptible attempt count for each cactus-align job [default=1]", default=1)
     parser.add_argument("--halAppendPreemptible", type=int, help="Preemptible attempt count for each halAppendSubtree job [default=1]", default=1)
+    parser.add_argument("--database", choices=["kyoto_tycoon", "redis"], help="The type of database", default="kyoto_tycoon")
 
     options = parser.parse_args()
-    options.database = 'kyoto_tycoon'
     #todo support root option
     options.root = None
 
@@ -574,9 +574,9 @@ def get_plan(options, project, inSeqFile, outSeqFile, toil):
                 plan += 'cactus-blast {} {} {} --root {} {} {}\n'.format(
                     get_jobstore(options), options.outSeqFile, cigarPath(event), event,
                     options.cactusOptions, get_toil_resource_opts(options, 'blast'))
-                plan += 'cactus-align {} {} {} {} --root {} {} {}\n'.format(
+                plan += 'cactus-align {} {} {} {} --root {} {} {} --database {}\n'.format(
                     get_jobstore(options), options.outSeqFile, cigarPath(event), halPath(event), event,
-                    options.cactusOptions, get_toil_resource_opts(options, 'align'))
+                    options.cactusOptions, get_toil_resource_opts(options, 'align'), options.database)
                 # todo: just output the fasta in cactus-align.
                 plan += 'hal2fasta {} {} {} > {}\n'.format(halPath(event), event, options.halOptions, outSeqFile.pathMap[event])
 

--- a/src/cactus/progressive/cactus_progressive.py
+++ b/src/cactus/progressive/cactus_progressive.py
@@ -362,6 +362,8 @@ def main():
                         "rather than pulling one from quay.io")
     parser.add_argument("--binariesMode", choices=["docker", "local", "singularity"],
                         help="The way to run the Cactus binaries", default=None)
+    parser.add_argument("--database", choices=["kyoto_tycoon", "redis"],
+                        help="The type of database", default="kyoto_tycoon")
 
     options = parser.parse_args()
 

--- a/src/cactus/progressive/projectWrapper.py
+++ b/src/cactus/progressive/projectWrapper.py
@@ -45,7 +45,7 @@ class ProjectWrapper:
         #create the cactus disk
         cdElem = ET.SubElement(expXml, "cactus_disk")
         database = self.options.database
-        assert database == "kyoto_tycoon"
+        assert database in ["kyoto_tycoon", "redis"]
         confElem = ET.SubElement(cdElem, "st_kv_database_conf")
         confElem.attrib["type"] = database
         ET.SubElement(confElem, database)

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -77,7 +77,8 @@ def main():
     parser.add_argument("--nonBlastMegablockFilter", action="store_true",
                         help="By default, the megablock filter is off for --nonBlastInput, as it does not play"
                         "nicely with reference-based alignments.  This flag will turn it back on")
-    
+    parser.add_argument("--database", choices=["kyoto_tycoon", "redis"],
+                        help="The type of database", default="kyoto_tycoon")
 
     options = parser.parse_args()
 
@@ -99,11 +100,6 @@ def main():
             # is there a way to get this out of Toil?  That would be more consistent
             if cpu_count() < 2:
                 raise RuntimeError('Only 1 CPU detected.  Cactus requires at least 2')
-
-    # tokyo_cabinet is no longer supported
-    options.database = "kyoto_tycoon"
-        
-    options.database = 'kyoto_tycoon'
 
     options.buildHal = True
     options.buildFasta = True

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -45,8 +45,6 @@ subprocess._has_poll = False
 
 def cactus_override_toil_options(options):
     """  Mess with some toil options to create useful defaults. """
-    # tokyo_cabinet is no longer supported
-    options.database = "kyoto_tycoon"
     # Caching generally slows down the cactus workflow, plus some
     # methods like readGlobalFileStream don't support forced
     # reads directly from the job store rather than from cache.

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -1266,7 +1266,7 @@ def cactus_call(tool=None,
     cactus_realtime_log(rt_message, log_debug = 'ktremotemgr' in call)
 
     # use /usr/bin/time -v to get peak memory usage
-    if time_v and 'ktserver' not in call:
+    if time_v and 'ktserver' not in call and 'redis-server' not in call:
         if not shell:
             shell = True
             call = ' '.join(shlex.quote(t) for t in call)

--- a/src/cactus/shared/experimentWrapper.py
+++ b/src/cactus/shared/experimentWrapper.py
@@ -55,6 +55,9 @@ class DbElemWrapper(object):
     def getDbType(self):
         return self.dbElem.tag
 
+    def setDbType(self, dbType):
+        self.dbElem.tag = dbType
+
     def getDbPort(self):
         assert self.getDbType() == "kyoto_tycoon"
         return int(self.dbElem.attrib["port"])

--- a/src/cactus/shared/experimentWrapper.py
+++ b/src/cactus/shared/experimentWrapper.py
@@ -43,6 +43,13 @@ class DbElemWrapper(object):
                 raise RuntimeError("Database conf is of kyoto tycoon but there is no nested kyoto tycoon tag: %s" % dataString)
             if not set(("host", "port", "database_dir")).issubset(set(kyotoTycoon.attrib.keys())):
                 raise RuntimeError("The kyoto tycoon tag has a missing attribute: %s" % dataString)
+        elif typeString == "redis":
+            redis = self.confElem.find("redis")
+            if redis == None:
+                raise RuntimeError("Database conf is of redis but there is no nested redis tag: %s" % dataString)
+            if not set(("host", "port", "database_dir")).issubset(set(redis.attrib.keys())):
+                raise RuntimeError("The redis tag has a missing attribute: %s" % dataString)
+
         else:
             raise RuntimeError("Unrecognised database type in conf string: %s" % typeString)
 
@@ -59,65 +66,65 @@ class DbElemWrapper(object):
         self.dbElem.tag = dbType
 
     def getDbPort(self):
-        assert self.getDbType() == "kyoto_tycoon"
+        assert self.getDbType() in ["kyoto_tycoon", "redis"]
         return int(self.dbElem.attrib["port"])
 
     def setDbPort(self, port):
-        assert self.getDbType() == "kyoto_tycoon"
+        assert self.getDbType() in ["kyoto_tycoon", "redis"]
         self.dbElem.attrib["port"] = str(port)
 
     def getDbHost(self):
-        assert self.getDbType() == "kyoto_tycoon"
+        assert self.getDbType() in ["kyoto_tycoon", "redis"]
         if "host" in self.dbElem.attrib:
             return self.dbElem.attrib["host"]
         return None
 
     def setDbHost(self, host):
-        assert self.getDbType() == "kyoto_tycoon"
+        assert self.getDbType() in ["kyoto_tycoon", "redis"]
         self.dbElem.attrib["host"] = host
 
     def getDbServerOptions(self):
-        assert self.getDbType() == "kyoto_tycoon"
+        assert self.getDbType() in ["kyoto_tycoon", "redis"]
         if "server_options" in self.dbElem.attrib:
             return self.dbElem.attrib["server_options"]
         return None
 
     def setDbServerOptions(self, options):
-        assert self.getDbType() == "kyoto_tycoon"
+        assert self.getDbType() in ["kyoto_tycoon", "redis"]
         self.dbElem.attrib["server_options"] = str(options)
 
     def getDbTuningOptions(self):
-        assert self.getDbType() == "kyoto_tycoon"
+        assert self.getDbType() in ["kyoto_tycoon", "redis"]
         if "tuning_options" in self.dbElem.attrib:
             return self.dbElem.attrib["tuning_options"]
         return None
 
     def setDbTuningOptions(self, options):
-        assert self.getDbType() == "kyoto_tycoon"
+        assert self.getDbType() in ["kyoto_tycoon", "redis"]
         self.dbElem.attrib["tuning_options"] = str(options)
 
     def getDbCreateTuningOptions(self):
-        assert self.getDbType() == "kyoto_tycoon"
+        assert self.getDbType() in ["kyoto_tycoon", "redis"]
         if "create_tuning_options" in self.dbElem.attrib:
             return self.dbElem.attrib["create_tuning_options"]
         return None
 
     def setDbCreateTuningOptions(self, options):
-        assert self.getDbType() == "kyoto_tycoon"
+        assert self.getDbType() in ["kyoto_tycoon", "redis"]
         self.dbElem.attrib["create_tuning_options"] = str(options)
 
     def getDbReadTuningOptions(self):
-        assert self.getDbType() == "kyoto_tycoon"
+        assert self.getDbType() in ["kyoto_tycoon", "redis"]
         if "read_tuning_options" in self.dbElem.attrib:
             return self.dbElem.attrib["read_tuning_options"]
         return None
 
     def setDbReadTuningOptions(self, options):
-        assert self.getDbType() == "kyoto_tycoon"
+        assert self.getDbType() in ["kyoto_tycoon", "redis"]
         self.dbElem.attrib["read_tuning_options"] = str(options)
 
     def getDbInMemory(self):
-        assert self.getDbType() == "kyoto_tycoon"
+        assert self.getDbType() in ["kyoto_tycoon", "redis"]
         if "in_memory" in self.dbElem.attrib:
             val = self.dbElem.attrib["in_memory"]
             retVal = val.lower() == "true" or val == "1"
@@ -126,19 +133,20 @@ class DbElemWrapper(object):
         return False
 
     def setDbInMemory(self, inMemory):
-        assert self.getDbType() == "kyoto_tycoon"
+        assert self.getDbType() in ["kyoto_tycoon", "redis"]
         self.dbElem.attrib["in_memory"] = str(int(inMemory))
 
     def getDbSnapshot(self):
-        assert self.getDbType() == "kyoto_tycoon"
+        assert self.getDbType() in ["kyoto_tycoon", "redis"]
         if "snapshot" in self.dbElem.attrib:
             val = self.dbElem.attrib["snapshot"]
             return val.lower() == "true" or val == "1"
         return self.getDbInMemory()
 
     def setDbSnapshot(self, snapshot):
-        assert self.getDbType() == "kyoto_tycoon"
+        assert self.getDbType() in ["kyoto_tycoon", "redis"]
         self.dbElem.attrib["snapshot"] = str(int(snapshot))
+
 
 class ExperimentWrapper(DbElemWrapper):
     def __init__(self, xmlRoot):


### PR DESCRIPTION
This PR contains the changes made to add Redis  as a database option to Cactus beside the currently used database, Kyoto Tycoon. The main changes are:

- Adding [Redis](https://github.com/redis/redis) and its C client library, [hiredis](https://github.com/redis/hiredis), as submodules to Cactus. I didn't use their Ubuntu packages since they are several versions behind the latest ones;
  - redis: [4.0.9](https://packages.ubuntu.com/bionic/redis-server) (the latest is [6.0.8](https://github.com/redis/redis/tags))
  - hiredis: [0.13](https://packages.ubuntu.com/bionic/libhiredis-dev) (the latest is [1.0.0](https://github.com/redis/hiredis/releases))

  (Maybe we can change it to use the ubuntu packages if new submodules make it difficult for users to build cactus but in that case we may not be able to use the latest versions)
- Adding python scripts for running a Redis server (or KT server) as a Toil Job.Service
- Adding a python test script ([pipeline/dbServerTest.py](https://github.com/ComparativeGenomicsToolkit/cactus/blob/redis/src/cactus/pipeline/dbServerTest.py)) to test launching the databases, saving and loading snapshot and shutting down
- Adding a test function to [tests/evolverTest.py](https://github.com/ComparativeGenomicsToolkit/cactus/blob/46baf25f200ea35bcb81e91bb0503f44175785d9/test/evolverTest.py#L316) for testing cactus with Redis
- Changed the HEAD of sonLib submodule to the [redis](https://github.com/ComparativeGenomicsToolkit/sonLib/tree/redis) branch of sonLib (We can change it whenever this branch is merged with sonLib master)