### PR TITLE
Enabling cactus to compile successfully even if hiredis is not installed

### DIFF
--- a/include.mk
+++ b/include.mk
@@ -46,8 +46,11 @@ inclDirs = api/inc bar/inc caf/inc hal/inc reference/inc submodules/sonLib/C/inc
 
 kyotoTycoonIncl=-I${rootPath}/include -DHAVE_KYOTO_TYCOON=1
 kyotoTycoonLib=-L${rootPath}/lib -Wl,-rpath,${rootPath}/lib -lkyototycoon -lkyotocabinet -lz -lbz2 -lpthread -lm -lstdc++
-hiredisIncl=$(shell pkg-config --cflags hiredis) -DHAVE_REDIS=1
-hiredisLib=-lhiredis
+HAVE_REDIS = $(shell pkg-config --exists hiredis; echo $$?)
+ifeq (${HAVE_REDIS},0)
+    hiredisIncl=$(shell pkg-config --cflags hiredis) -DHAVE_REDIS=1
+    hiredisLib=-lhiredis
+endif
 
 CPPFLAGS += ${inclDirs:%=-I${rootPath}/%} -I${LIBDIR} ${kyotoTycoonIncl}
 


### PR DESCRIPTION
Regarding the issue mentioned here https://github.com/ComparativeGenomicsToolkit/cactus/commit/d3d6361914091a97a56946f56763ead42e84ff90#commitcomment-43877817 
When `hiredis` is not installed on a system we expect to compile cactus with no error. In that case cactus wouldn't support redis but it can be run using kyoto tycoon as before.