### PR TITLE
Graphmap masking pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,8 +20,8 @@ test-job:
     - virtualenv -p python3 venv
     - source venv/bin/activate
     - pip install -r toil-requirement.txt
-    - pip install -U .
     - build-tools/downloadMiniTools
+    - pip install -U .	 
     - make -j 8 evolver_test
   artifacts:
     # Let Gitlab see the junit report

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Cactus uses many different algorithms and individual code contributions, princip
 - Bob Harris for providing endless support for his [LastZ](https://github.com/lastz/lastz) pairwise, blast-like genome alignment tool.
 - Sneha Goenka and Yatish Turakhia for the [GPU-accelerated version of LastZ](https://github.com/ComparativeGenomicsToolkit/SegAlign).
 - Yan Gao et al. for [abPOA](https://github.com/yangao07/abPOA)
-- Heng Li for [minigraph](https://github.com/lh3/minigraph), [minimap2](https://github.com/lh3/minimap2) and [gfatools](https://github.com/lh3/gfatools)
+- Heng Li for [minigraph](https://github.com/lh3/minigraph), [minimap2](https://github.com/lh3/minimap2), [gfatools](https://github.com/lh3/gfatools) and [dna-brnn](https://github.com/lh3/dna-rnn)
 
 ## Setup
 

--- a/bar/inc/poaBarAligner.h
+++ b/bar/inc/poaBarAligner.h
@@ -108,9 +108,10 @@ char *get_adjacency_string(Cap *cap, int *length);
  * @param max_seq_length is the maximum length of the prefix of an unaligned sequence
  * to attempt to align.
  * @param window_size Sliding window size which limits length of poa sub-alignments.  Memory usage is quardatic in this. 
+ * @param mask_filter Trim input sequences if encountering this many consecutive soft of hard masked bases (0 = disabled)
  * Returns a list of AlignmentBlock ojects
  */
-stList *make_flower_alignment_poa(Flower *flower, int64_t max_seq_length, int64_t window_size);
+stList *make_flower_alignment_poa(Flower *flower, int64_t max_seq_length, int64_t window_size, int64_t mask_filter);
 
 /**
  * Create a pinch iterator for a list of alignment blocks.

--- a/bar/tests/poaBarTest.c
+++ b/bar/tests/poaBarTest.c
@@ -181,7 +181,7 @@ void test_make_flower_alignment_poa(CuTest *testCase) {
     }
     flower_destructEndIterator(endIterator);
 
-    stList *alignment_blocks = make_flower_alignment_poa(flower, 2, 1000000);
+    stList *alignment_blocks = make_flower_alignment_poa(flower, 2, 1000000, 5);
 
     for(int64_t i=0; i<stList_length(alignment_blocks); i++) {
         AlignmentBlock *b = stList_get(alignment_blocks, i);
@@ -194,7 +194,7 @@ void test_make_flower_alignment_poa(CuTest *testCase) {
 void test_alignment_block_iterator(CuTest *testCase) {
     setup(testCase);
 
-    stList *alignment_blocks = make_flower_alignment_poa(flower, 10000, 1000000);
+    stList *alignment_blocks = make_flower_alignment_poa(flower, 10000, 1000000, 5);
 
     for(int64_t i=0; i<stList_length(alignment_blocks); i++) {
         AlignmentBlock *b = stList_get(alignment_blocks, i);

--- a/build-tools/downloadMiniTools
+++ b/build-tools/downloadMiniTools
@@ -87,7 +87,7 @@ fi
 cd ${miniBuildDir}
 git clone https://github.com/glennhickey/mzgaf2paf.git
 cd mzgaf2paf
-git checkout b29f62a4a1ac1fb5abf658f55bd74607b50d2d67
+git checkout c43c0b6121b95979ff484106a6c543180cdd89a2
 CXXFLAGS="-static" make -j 4
 if [ $(ldd mzgaf2paf | grep so | wc -l) -eq 0 ]
 then

--- a/build-tools/downloadMiniTools
+++ b/build-tools/downloadMiniTools
@@ -13,6 +13,8 @@ set -beEu -o pipefail
 
 miniBuildDir=$(realpath -m build-mini)
 binDir=$(pwd)/bin
+# just use cactusRootPath for now
+dataDir=$(pwd)/src/cactus
 CWD=$(pwd)
 
 set -x
@@ -65,6 +67,22 @@ else
 	 exit 1
 fi
 
+# dna-brnn
+cd ${miniBuildDir}
+git clone https://github.com/lh3/dna-nn.git
+cd dna-nn
+git checkout 2e6d242ae339457b985f50086e85194c3ce418b1
+# hack in a static build
+sed -i Makefile -e 's/CFLAGS=/CFLAGS+=/' -e 's/LIBS=/LIBS+=/'
+CFLAGS="-static" LIBS="-static" make -j 4
+if [ $(ldd dna-brnn | grep so | wc -l) -eq 0 ]
+then
+	 mv dna-brnn ${binDir}
+	 cp models/attcc-alpha.knm ${dataDir}
+else
+	 exit 1
+fi
+
 # mzgaf2paf
 cd ${miniBuildDir}
 git clone https://github.com/glennhickey/mzgaf2paf.git
@@ -90,3 +108,7 @@ fi
 
 cd ${CWD}
 rm -rf ${miniBuildDir}
+
+echo "--------------------------------------------------"
+echo "(re)run pip install -U . to install dna-brnn model"
+echo "--------------------------------------------------"

--- a/preprocessor/Makefile
+++ b/preprocessor/Makefile
@@ -6,7 +6,7 @@ CFLAGS += ${tokyoCabinetIncl} ${hiredisIncl}
 all: all_libs all_progs
 all_libs: 
 all_progs: all_libs
-	${MAKE} ${BINDIR}/cactus_analyseAssembly ${BINDIR}/cactus_batch_mergeChunks ${BINDIR}/cactus_makeAlphaNumericHeaders.py ${BINDIR}/cactus_filterSmallFastaSequences.py
+	${MAKE} ${BINDIR}/cactus_analyseAssembly ${BINDIR}/cactus_batch_mergeChunks ${BINDIR}/cactus_makeAlphaNumericHeaders.py ${BINDIR}/cactus_filterSmallFastaSequences.py ${BINDIR}/cactus_softmask2hardmask
 	cd lastzRepeatMasking && ${MAKE} all
 
 ${BINDIR}/cactus_filterSmallFastaSequences.py : cactus_filterSmallFastaSequences.py
@@ -23,7 +23,10 @@ ${BINDIR}/cactus_analyseAssembly : cactus_analyseAssembly.c ${LIBDEPENDS} ${LIBD
 ${BINDIR}/cactus_batch_mergeChunks : *.c ${LIBDIR}/cactusLib.a ${LIBDEPENDS}
 	${CC} ${CPPFLAGS} ${CFLAGS} ${LDFLAGS} -o ${BINDIR}/cactus_batch_mergeChunks cactus_batch_mergeChunks.c ${LIBDIR}/cactusLib.a ${LDLIBS}
 
+${BINDIR}/cactus_softmask2hardmask : cactus_softmask2hardmask.c ${LIBDEPENDS} ${LIBDIR}/cactusLib.a
+	${CC} ${CPPFLAGS} ${CFLAGS} ${LDFLAGS} -o ${BINDIR}/cactus_softmask2hardmask cactus_softmask2hardmask.c ${LIBDIR}/cactusLib.a ${LDLIBS}
+
 clean : 
 	rm -f *.o
-	rm -f ${BINDIR}/cactus_analyseAssembly ${BINDIR}/cactus_batch_mergeChunks
+	rm -f ${BINDIR}/cactus_analyseAssembly ${BINDIR}/cactus_batch_mergeChunks ${BINDIR}/cactus_softmask2hardmask
 	cd lastzRepeatMasking && ${MAKE} clean

--- a/preprocessor/cactus_softmask2hardmask.c
+++ b/preprocessor/cactus_softmask2hardmask.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2009-2011 by Benedict Paten (benedictpaten@gmail.com)
+ *
+ * Released under the MIT license, see LICENSE.txt
+ */
+
+#include <assert.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <time.h>
+#include <getopt.h>
+#include <inttypes.h>
+#include <sys/types.h>
+#include <sys/param.h>
+#include <sys/stat.h>
+#include <dirent.h>
+#include <math.h>
+#include <ctype.h>
+
+#include "bioioC.h"
+#include "cactus.h"
+
+void usage() {
+    fprintf(stderr, "cactus_softmask2hardmask [fastaFile]\n");
+}
+
+static void hardmask(void* out_file, const char* name, const char* seq, int64_t length) {
+    char* uc_seq = (char*)seq;
+    for (int64_t i = 0; i < length; ++i) {
+        if (islower(uc_seq[i])) {
+            uc_seq[i] = 'N';
+        }
+    }
+    fastaWrite(uc_seq, (char*)name, (FILE*)out_file);
+}
+
+int main(int argc, char *argv[]) {
+    if(argc == 1) {
+        usage();
+        return 0;
+    }
+
+    for (int64_t j = 1; j < argc; j++) {
+        FILE *fileHandle;
+        if (strcmp(argv[j], "-") == 0) {
+            fileHandle = stdin;
+        } else {
+            fileHandle = fopen(argv[j], "r");
+            if (fileHandle == NULL) {
+                st_errnoAbort("Could not open input file %s", argv[j]);
+            }
+        }
+        fastaReadToFunction(fileHandle, stdout, hardmask);
+    }
+
+    return 0;
+}

--- a/preprocessor/lastzRepeatMasking/cactus_fasta_softmask_intervals.py
+++ b/preprocessor/lastzRepeatMasking/cactus_fasta_softmask_intervals.py
@@ -25,6 +25,7 @@ def usage(s=None):
                               (default is to mask with lowercase)
     --unmask                  remove any previous softmasking from sequence being masked (covert to upper case
                               before masking)
+    --minLength=<N>           ignore intervals less than N
                               """
 
 	if (s == None): exit (message)
@@ -41,6 +42,7 @@ def main():
 	maskChar         = None
 	intervalsFile    = None
 	unmask = False
+	minLength = None        
 
 	for arg in argv[1:]:
 		if ("=" in arg):
@@ -63,6 +65,8 @@ def main():
 			if (len(maskChar) != 1): usage("--mask requires a single character")
 		elif (arg.startswith("--unmask")):
 			unmask = True
+		elif (arg.startswith("--minLength=")):
+			minLength = int(argVal)
 		elif (arg.startswith("--")):
 			usage("can't understand %s" % arg)
 		elif (intervalsFile == None):
@@ -104,7 +108,8 @@ def main():
 			continue
 
 		if (chrom not in chromToIntervals): chromToIntervals[chrom] = []
-		chromToIntervals[chrom] += [(start,end)]
+		if minLength is None or end-start >= minLength:
+			chromToIntervals[chrom] += [(start,end)]
 
 	f.close()
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     packages = find_packages(where='src'),
     include_package_data = True,
     package_data = {
-        'cactus': ['*_config.xml']
+        'cactus': ['*_config.xml', '*.knm']
     },
     # We use the __file__ attribute so this package isn't zip_safe.
     zip_safe = False,

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -253,6 +253,7 @@
 	<!-- cactus-graphmap options -->
 	<!-- assemblyName: special name of "virtual" minigraph assembly, which is just the list of sequences from the graph. -->
 	<!-- universalMZFilter: only use minimizers who appear in this proportion (1.0 == 100%) of sequences that map over them. -->
+	<!-- nodeBasedUniversal: universal filter calculated in terms of nodes istead of mapped regions. -->
 	<!-- minMZBlockLength: only use minimizers that form contiguous blocks at least this long -->
 	<!-- minMAPQ: ignore minigraph alignments with mapping quality less than this -->
 	<!-- minGAFBlockLength: ignore minigraph alignments with block length less than this -->	
@@ -260,9 +261,11 @@
 		 assemblyName="__MINIGRAPH_SEQUENCES__"
 		 minigraphMapOptions="-S --write-mz -xasm -K4g --inv=no"
 		 universalMZFilter="1.0"
+		 nodeBasedUniversal="1"
 		 minMZBlockLength="50"
 		 minMAPQ="5"
 		 minGAFBlockLength="100000"
+		 
 	/>
   	<multi_cactus>
 		<outgroup 

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -11,9 +11,13 @@
 	<!-- The preprocessor tags are used to modify/check the input sequences before alignment -->
 	<!-- The first preprocessor tag checks that the first word of every fasta header is unique, as this is required for HAL. It throws errors if this is not the case -->
 	<!-- The checkAssemblyHub option (if enabled) ensures that the first word contains only alphanumeric or '_', '-', ':', or '.' characters, and is unique. If you don't intend to make an assembly hub, you can turn off this option here. -->
-	<preprocessor check="1" memory="littleMemory" preprocessJob="checkUniqueHeaders" checkAssemblyHub="1"/>
+	<preprocessor check="1" memory="littleMemory" preprocessJob="checkUniqueHeaders" checkAssemblyHub="1" active="1"/>
 	<!-- The preprocessor for cactus_lastzRepeatMask masks every seed that is part of more than XX other alignments, this stops a combinatorial explosion in pairwise alignments -->
-	<preprocessor unmask="0" chunkSize="3000000" proportionToSample="0.2" memory="littleMemory" preprocessJob="lastzRepeatMask" minPeriod="50" lastzOpts='--step=3 --ambiguous=iupac,100,100 --ungapped --queryhsplimit=keep,nowarn:1500' gpuLastz="false"/>
+	<preprocessor unmask="0" chunkSize="3000000" proportionToSample="0.2" memory="littleMemory" preprocessJob="lastzRepeatMask" minPeriod="50" lastzOpts='--step=3 --ambiguous=iupac,100,100 --ungapped --queryhsplimit=keep,nowarn:1500' gpuLastz="false" active="1"/>
+	<!-- Softmask alpha-satellite blocks of at least "minLength" using the dna-brnn tool -->
+	<!-- This preprocessor is off by default, and will replace the lastzRepeatMask preprocessor via command line toggle (or setting active=1)-->
+	<!-- It will attempt to load its included "attcc-alpha.knm" model by default unless a different one is specified below -->
+	<preprocessor unmask="1" memory="littleMemory" preprocessJob="dna-brnn" minLength="100000" dna-brnnOpts='-A' active="0"/>			  	
         <!-- Options for trimming ingroups & outgroups using the trim strategy -->
         <!-- Ingroup trim options: -->
         <!-- trimFlanking: The length of flanking sequence to attach
@@ -153,6 +157,10 @@
         unaligned at the end of bar. This pushes those regions
         into the ancestor, hopefully to get aligned to something
         else eventually -->
+   <!-- bandingLimit is the maximum sequence size fed into the multiple aligner.  Sequences longer than this are trimmed accordingly -->
+   <!-- partialOrderAlignment toggles between cPecan and abpoa for the core multiple alignment algorithm.  abpoa is much faster but not as reliable for divered sequences -->
+   <!-- partialOrderAlignmentWindow a sliding window approach (with hardcoded 50% overlap) is used to perform abpoa alignments.  memory is quadratic in this.  it is applied after bandingLimit -->
+   <!-- partialOrderAlignmentMaskFilter trim input sequences as soon as this many soft or hard masked bases are encountered (0=disabled) -->
 	<bar
 		runBar="1"
 		spanningTrees="5" 
@@ -179,6 +187,7 @@
                 minimumCoverageToRescue="0.5"
 		partialOrderAlignment="0"
 		partialOrderAlignmentWindow="10000"
+		partialOrderAlignmentMaskFilter="0"
 	>
 		<CactusBarRecursion maxFlowerGroupSize="100000000"/>
 		<!-- The maxFlowerGroupSize in cactusBarWrapper determines how many bases to allow in one "small" job which will be run using the "littleMemory" -->
@@ -241,13 +250,13 @@
 		<CactusHalGeneratorRecursion maxFlowerGroupSize="2000000"/>
 		<CactusHalGeneratorUpWrapper/>
 	</hal>
-	<!-- cactus-refgraph options -->
+	<!-- cactus-graphmap options -->
 	<!-- assemblyName: special name of "virtual" minigraph assembly, which is just the list of sequences from the graph. -->
 	<!-- universalMZFilter: only use minimizers who appear in this proportion (1.0 == 100%) of sequences that map over them. -->
 	<!-- minMZBlockLength: only use minimizers that form contiguous blocks at least this long -->
 	<!-- minMAPQ: ignore minigraph alignments with mapping quality less than this -->
 	<!-- minGAFBlockLength: ignore minigraph alignments with block length less than this -->	
-	<refgraph
+	<graphmap
 		 assemblyName="__MINIGRAPH_SEQUENCES__"
 		 minigraphMapOptions="-S --write-mz -xasm -K4g --inv=no"
 		 universalMZFilter="1.0"

--- a/src/cactus/pipeline/cactus_workflow.py
+++ b/src/cactus/pipeline/cactus_workflow.py
@@ -883,7 +883,8 @@ def runBarForJob(self, fileStore=None, features=None, calculateWhichEndsToComput
                  minimumCoverageToRescue=self.getOptionalPhaseAttrib("minimumCoverageToRescue"),
                  minimumNumberOfSpecies=self.getOptionalPhaseAttrib("minimumNumberOfSpecies", int),
                  partialOrderAlignment=self.getOptionalPhaseAttrib("partialOrderAlignment", bool),
-                 partialOrderAlignmentWindow=self.getOptionalPhaseAttrib("partialOrderAlignmentWindow", int))
+                 partialOrderAlignmentWindow=self.getOptionalPhaseAttrib("partialOrderAlignmentWindow", int),
+                 partialOrderAlignmentMaskFilter=self.getOptionalPhaseAttrib("partialOrderAlignmentMaskFilter", int))
 
 class CactusBarWrapper(CactusRecursionJob):
     """Runs the BAR algorithm implementation.

--- a/src/cactus/preprocessor/dnabrnnMasking.py
+++ b/src/cactus/preprocessor/dnabrnnMasking.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Uses dna-brnn to mask alpha satellites with a given length threshold
+"""
+
+import os
+import re
+import sys
+import shutil
+
+from toil.lib.threading import cpu_count
+
+from sonLib.bioio import catFiles
+
+from cactus.shared.common import cactus_call
+from cactus.shared.common import RoundedJob
+from cactus.shared.common import cactusRootPath
+from toil.realtimeLogger import RealtimeLogger
+
+class DnabrnnMaskJob(RoundedJob):
+    def __init__(self, fastaID, minLength, dnabrnnOpts):
+        memory = 4*1024*1024*1024
+        disk = 2*(fastaID.size)
+        # todo: clean up
+        cores = cpu_count()
+        RoundedJob.__init__(self, memory=memory, disk=disk, cores=cores, preemptable=True)
+        self.fastaID = fastaID
+        self.minLength = minLength
+        self.dnabrnnOpts = dnabrnnOpts
+
+    def run(self, fileStore):
+        """
+        mask alpha satellites with dna-brnn
+        """
+        fastaFile = fileStore.readGlobalFile(self.fastaID)
+
+        cmd = ['dna-brnn', fastaFile] + self.dnabrnnOpts.split()
+        if '-i' not in self.dnabrnnOpts:
+            # pull up the model
+            # todo: is there are more robust way?
+            cmd += ['-i', os.path.join(cactusRootPath(), 'attcc-alpha.knm')]
+        
+        if self.cores:
+            cmd += ['-t', str(self.cores)]
+
+        bedFile = fileStore.getLocalTempFile()
+
+        # run dna-brnn to make a bed file
+        cactus_call(outfile=bedFile, parameters=cmd)
+
+        maskedFile = fileStore.getLocalTempFile()
+
+        mask_cmd = ['cactus_fasta_softmask_intervals.py', '--origin=zero', '--minLength={}'.format(self.minLength), bedFile]
+
+        # do the softmasking
+        cactus_call(infile=fastaFile, outfile=maskedFile, parameters=mask_cmd)
+
+        return fileStore.writeGlobalFile(maskedFile)
+
+

--- a/src/cactus/refmap/cactus_graphmap.py
+++ b/src/cactus/refmap/cactus_graphmap.py
@@ -257,6 +257,8 @@ def merge_gafs_into_paf(job, config, gaf_file_ids):
     mz_filter = getOptionalAttrib(xml_node, "universalMZFilter", float)
     if mz_filter:
         mzgaf2paf_opts += ['-u', str(mz_filter)]
+    if getOptionalAttrib(xml_node, "nodeBasedUniversal", typeFn=bool, default=False):
+        mzgaf2paf_opts += ['-n']
     min_mz = getOptionalAttrib(xml_node, "minMZBlockLength", int)
     if min_mz:
         mzgaf2paf_opts += ['-m', str(min_mz)]

--- a/src/cactus/refmap/cactus_graphmap.py
+++ b/src/cactus/refmap/cactus_graphmap.py
@@ -50,6 +50,7 @@ def main():
     parser.add_argument("minigraphGFA", help = "Minigraph-compatible reference graph in GFA format (can be gzipped)")
     parser.add_argument("outputPAF", type=str, help = "Output pairwise alignment file in PAF format")
     parser.add_argument("--outputFasta", type=str, help = "Output graph sequence file in FASTA format (required if not present in seqFile)")
+    parser.add_argument("--ignoreSoftmasked", action="store_true", help = "Ignore softmasked sequence (by hardmasking before sending to minigraph)")
 
     #WDL hacks
     parser.add_argument("--pathOverrides", nargs="*", help="paths (multiple allowed) to override from seqFile")
@@ -120,7 +121,7 @@ def runCactusGraphMap(options):
             config.substituteAllPredefinedConstantsWithLiterals()
 
             # get the minigraph "virutal" assembly name
-            graph_event = getOptionalAttrib(findRequiredNode(configNode, "refgraph"), "assemblyName", default="__MINIGRAPH_SEQUENCES__")
+            graph_event = getOptionalAttrib(findRequiredNode(configNode, "graphmap"), "assemblyName", default="__MINIGRAPH_SEQUENCES__")
 
             # load the seqfile
             seqFile = SeqFile(options.seqFile)
@@ -135,8 +136,9 @@ def runCactusGraphMap(options):
 
             #import the sequences (that we need to align for the given event, ie leaves and outgroups)
             seqIDMap = {}
+            leaves = set([seqFile.tree.getName(node) for node in seqFile.tree.getLeaves()])
             for genome, seq in seqFile.pathMap.items():
-                if genome != graph_event:
+                if genome != graph_event and genome in leaves:
                     if os.path.isdir(seq):
                         tmpSeq = getTempFile()
                         catFiles([os.path.join(seq, subSeq) for subSeq in os.listdir(seq)], tmpSeq)
@@ -163,7 +165,7 @@ def minigraph_workflow(job, options, config, seq_id_map, gfa_id, graph_event):
         fa_job = job.addChildJobFn(make_minigraph_fasta, gfa_id, graph_event)
         fa_id = fa_job.rv()
     
-    paf_job = job.addChildJobFn(minigraph_map_all, config, gfa_id, seq_id_map)
+    paf_job = job.addChildJobFn(minigraph_map_all, config, gfa_id, seq_id_map, options.ignoreSoftmasked)
 
     return paf_job.rv(), fa_id                                
         
@@ -177,13 +179,12 @@ def make_minigraph_fasta(job, gfa_file_id, name):
     
     job.fileStore.readGlobalFile(gfa_file_id, gfa_path)
 
-    with open(fa_path, "w") as fa_file:
-        cactus_call(work_dir=work_dir, outfile=fa_path,
-                    parameters=["gfatools", "gfa2fa", os.path.basename(gfa_path)])
+    cactus_call(work_dir=work_dir, outfile=fa_path,
+                parameters=["gfatools", "gfa2fa", os.path.basename(gfa_path)])
 
     return job.fileStore.writeGlobalFile(fa_path)
 
-def minigraph_map_all(job, config, gfa_id, fa_id_map):
+def minigraph_map_all(job, config, gfa_id, fa_id_map, ignore_softmasked):
     """ top-level job to run the minigraph mapping in parallel, returns paf """
     
     # hang everything on this job, to self-contain workflow
@@ -195,6 +196,7 @@ def minigraph_map_all(job, config, gfa_id, fa_id_map):
     for event, fa_id in fa_id_map.items():
         RealtimeLogger.info("adding child event={} faid={} gfaid={}".format(event, fa_id, gfa_id))
         minigraph_map_job = top_job.addChildJobFn(minigraph_map_one, config, event, fa_id, gfa_id,
+                                                  ignore_softmasked,
                                                   cores=1, disk=5*(fa_id.size + gfa_id.size))
         gaf_ids.append(minigraph_map_job.rv())
 
@@ -203,7 +205,7 @@ def minigraph_map_all(job, config, gfa_id, fa_id_map):
 
     return paf_job.rv()
 
-def minigraph_map_one(job, config, event_name, fa_file_id, gfa_file_id):
+def minigraph_map_one(job, config, event_name, fa_file_id, gfa_file_id, ignore_softmasked):
     """ Run minigraph to map a Fasta file to a GFA graph, producing a GAF output """
 
     work_dir = job.fileStore.getLocalTempDir()
@@ -215,7 +217,7 @@ def minigraph_map_one(job, config, event_name, fa_file_id, gfa_file_id):
     job.fileStore.readGlobalFile(fa_file_id, fa_path)
 
     # parse options from the config
-    xml_node = findRequiredNode(config.xmlRoot, "refgraph")
+    xml_node = findRequiredNode(config.xmlRoot, "graphmap")
     minigraph_opts = getOptionalAttrib(xml_node, "minigraphMapOptions", str, default="")     
     opts_list = minigraph_opts.split()
     # add required options if not present
@@ -226,11 +228,17 @@ def minigraph_map_one(job, config, event_name, fa_file_id, gfa_file_id):
     if "-t" not in opts_list:
         opts_list += ["-t", str(int(job.cores))]
 
+    cmd = ["minigraph",
+           os.path.basename(gfa_path),
+           os.path.basename(fa_path),
+           "-o", os.path.basename(gaf_path)] + opts_list
+
+    if ignore_softmasked:
+        cmd[2] = '-'
+        cmd = [['cactus_softmask2hardmask', os.path.basename(fa_path)], cmd]
+    
     # todo: pipe into gzip directly as these files can be huge!!! (requires gzip support be added to mzgaf2paf)
-    cactus_call(work_dir=work_dir, parameters=["minigraph",
-                                               os.path.basename(gfa_path),
-                                               os.path.basename(fa_path),
-                                               "-o", os.path.basename(gaf_path)] + opts_list)
+    cactus_call(work_dir=work_dir, parameters=cmd)
 
     return job.fileStore.writeGlobalFile(gaf_path)
 
@@ -244,7 +252,7 @@ def merge_gafs_into_paf(job, config, gaf_file_ids):
         gaf_paths.append("mz_alignment_{}.gaf".format(i))
         job.fileStore.readGlobalFile(gaf_id, os.path.join(work_dir, gaf_paths[-1]))
 
-    xml_node = findRequiredNode(config.xmlRoot, "refgraph")
+    xml_node = findRequiredNode(config.xmlRoot, "graphmap")
     mzgaf2paf_opts = []
     mz_filter = getOptionalAttrib(xml_node, "universalMZFilter", float)
     if mz_filter:

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -493,6 +493,7 @@ def runCactusBar(cactusDiskDatabaseString, flowerNames, logLevel=None,
                  minimumNumberOfSpecies=None,
                  partialOrderAlignment=None,
                  partialOrderAlignmentWindow=None,
+                 partialOrderAlignmentMaskFilter=None,
                  jobName=None,
                  fileStore=None,
                  features=None):
@@ -551,6 +552,8 @@ def runCactusBar(cactusDiskDatabaseString, flowerNames, logLevel=None,
     if partialOrderAlignment is True:
         assert partialOrderAlignmentWindow is not None and int(partialOrderAlignmentWindow) > 1
         args += ["--partialOrderAlignmentWindow", str(partialOrderAlignmentWindow)]
+    if partialOrderAlignmentMaskFilter:
+        args += ["--maskFilter", str(partialOrderAlignmentMaskFilter)]
 
     masterMessages = cactus_call(stdin_string=flowerNames, check_output=True,
                                  parameters=["cactus_bar"] + args,

--- a/src/cactus/shared/configWrapper.py
+++ b/src/cactus/shared/configWrapper.py
@@ -241,4 +241,22 @@ class ConfigWrapper:
         for node in self.xmlRoot.findall("preprocessor"):
             self.xmlRoot.remove(node)
 
+    def setPreprocessorActive(self, preprocessorJob, state):
+        """Set active flag of preprocessor """
+        assert state in (True, False)
+        set_count = 0
+        for node in self.xmlRoot.findall("preprocessor"):
+            if getOptionalAttrib(node, "preprocessJob") == preprocessorJob:
+                node.attrib["active"] = "1" if state else "0"
+                set_count += 1
+        return set_count
+
+    def getPreprocessorActive(self, preprocessorJob, default_val=True):
+        """Get active flag of preprocessor (first one with name match)"""
+        for node in self.xmlRoot.findall("preprocessor"):
+            if getOptionalAttrib(node, "preprocessJob") == preprocessorJob:
+                return getOptionalAttrib(node, "active", default="1" if default_val else "0") == "1"
+        return default_val
+                        
+
         


### PR DESCRIPTION
* `--alphaMask` option added to `cactus-preprocess`
* `--ignoreSoftmasked` option added to `cactus-graphmap`
* `--maskFilter` option added to `cactus_bar` (set using `partialOrderAlignmentMaskFilter` in the config given to `cactus-align`)

Together, these give more fine-grained control for keeping certain subregions from ever being aligned (while preserving their sequence in the output)