### PR TITLE
fix cactus-blast --restart bug

### DIFF
--- a/src/cactus/blast/cactus_blast.py
+++ b/src/cactus/blast/cactus_blast.py
@@ -91,7 +91,7 @@ def runCactusBlastOnly(options):
         importSingularityImage(options)
         #Run the workflow
         if options.restart:
-            alignmentID = toil.restart()
+            outWorkFlowArgs = toil.restart()
         else:
             options.cactusDir = getTempDirectory()
 


### PR DESCRIPTION
There are no tests for the `--restart` logic, so these are always sneaking into master. Should resolve crash mentioned in #381