### PR TITLE
Filter ambiguously mapped contigs when splitting into chromosomes

### DIFF
--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -116,7 +116,7 @@ fi
 cd ${pangenomeBuildDir}
 git clone https://github.com/glennhickey/mzgaf2paf.git
 cd mzgaf2paf
-git checkout f844ebdbff565b34c5e3bd86ab9b052f7d6f9240
+git checkout 2e64e9437f7e41daae8816027d54668a7b74a021
 CXXFLAGS="-static ${CACTUS_MARCH}" make -j 4
 if [ $(ldd mzgaf2paf | grep so | wc -l) -eq 0 ]
 then

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -116,7 +116,7 @@ fi
 cd ${pangenomeBuildDir}
 git clone https://github.com/glennhickey/mzgaf2paf.git
 cd mzgaf2paf
-git checkout 5ec8846ae83e4079be5397bf176a391e95e25f77
+git checkout f844ebdbff565b34c5e3bd86ab9b052f7d6f9240
 CXXFLAGS="-static ${CACTUS_MARCH}" make -j 4
 if [ $(ldd mzgaf2paf | grep so | wc -l) -eq 0 ]
 then

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -284,7 +284,16 @@
 		 minGAFQueryOverlapFilter="10000"
 		 maskFilter="-1"
 		 cpu="4"
-	/>
+		 />
+	<!-- cactus-graphmap-split options -->
+	<!-- minQueryCoverage: At least this fraction of input contig must align to reference contig for it to be assigned. -->
+	<!-- minQueryUniqueness: The ratio of the number of query bases aligned to the chosen ref contig vs the next best ref contig must exceed this threshold to not be considered ambigious. -->
+	<!-- ambiguousName: Contigs deemed ambiguous using the above filters get added to a "contig" with this name, and are preserved in output. -->		
+	<graphmap_split
+		 minQueryCoverage="0.99"
+		 minQueryUniqueness="2"
+		 ambiguousName="__AMBIGUOUS_SEQUENCES__"
+		 />
   	<multi_cactus>
 		<outgroup 
 			strategy="greedyPreference"

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -272,7 +272,7 @@
 	<!-- maskFilter: any softmasked sequence intervals > than this many bp will be hardmasked before being read by the minigraph mapper [negative value = disable]-->
 	<!-- cpu: use up to this many cpus for each minigraph command. -->
 	<graphmap
-		 assemblyName="__MINIGRAPH_SEQUENCES__"
+		 assemblyName="_MINIGRAPH_"
 		 minigraphMapOptions="-S --write-mz -xasm"
 		 universalMZFilter="0"
 		 nodeBasedUniversal="0"
@@ -292,7 +292,7 @@
 	<graphmap_split
 		 minQueryCoverage="0.80"
 		 minQueryUniqueness="2"
-		 ambiguousName="__AMBIGUOUS_SEQUENCES__"
+		 ambiguousName="_AMBIGUOUS_"
 		 />
   	<multi_cactus>
 		<outgroup 

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -290,7 +290,7 @@
 	<!-- minQueryUniqueness: The ratio of the number of query bases aligned to the chosen ref contig vs the next best ref contig must exceed this threshold to not be considered ambigious. -->
 	<!-- ambiguousName: Contigs deemed ambiguous using the above filters get added to a "contig" with this name, and are preserved in output. -->		
 	<graphmap_split
-		 minQueryCoverage="0.99"
+		 minQueryCoverage="0.80"
 		 minQueryUniqueness="2"
 		 ambiguousName="__AMBIGUOUS_SEQUENCES__"
 		 />

--- a/src/cactus/pipeline/cactus_workflow.py
+++ b/src/cactus/pipeline/cactus_workflow.py
@@ -464,8 +464,7 @@ class CactusRecursionJob(CactusJob):
 ############################################################
 ############################################################
 
-def prependUniqueIDs(eventToFa, outputDir, idMap=None, firstID=0,
-                     eventNameAsID=os.environ.get('CACTUS_EVENT_NAME_AS_UNIQUE_ID', 0) != 0):
+def prependUniqueIDs(eventToFa, outputDir, idMap=None, firstID=0, eventNameAsID=None):
     """Prepend unique ints to fasta headers.
 
     (prepend rather than append since trimmed outgroups have a start
@@ -477,6 +476,9 @@ def prependUniqueIDs(eventToFa, outputDir, idMap=None, firstID=0,
     are based on a sorted order of the input event names. 
     Event Name IDs are better for paf-based pipeline as they are stable across commands even when working on subsets of events
     """
+    if eventNameAsID is None:
+        eventNameAsID = bool(os.environ.get('CACTUS_EVENT_NAME_AS_UNIQUE_ID', '0'))
+        
     uniqueID = firstID
     ret = {}
     for event in sorted(eventToFa.keys()):

--- a/src/cactus/pipeline/cactus_workflow.py
+++ b/src/cactus/pipeline/cactus_workflow.py
@@ -479,23 +479,25 @@ def prependUniqueIDs(eventToFa, outputDir, idMap=None, firstID=0, eventNameAsID=
     if eventNameAsID is None:
         eventNameAsID = os.environ.get('CACTUS_EVENT_NAME_AS_UNIQUE_ID', False)
         eventNameAsID = False if not bool(eventNameAsID) or eventNameAsID == '0' else True
-        
+
     uniqueID = firstID
     ret = {}
     for event in sorted(eventToFa.keys()):
         fa = eventToFa[event]
-        outPath = os.path.join(outputDir, os.path.basename(fa))
-        out = open(outPath, 'w')
-        for line in open(fa):
-            if len(line) > 0 and line[0] == '>':
-                idTag = event if eventNameAsID else uniqueID
-                header = "id={}|{}".format(idTag, line[1:-1])
-                out.write(">%s\n" % header)
-                if idMap is not None:
-                    idMap[line[1:-1].rstrip()] = header.rstrip()
-            else:
-                out.write(line)
-        ret[event] = outPath
+        # can handle none-values which serve only to space ids -- dont show in output
+        if fa:
+            outPath = os.path.join(outputDir, os.path.basename(fa))
+            out = open(outPath, 'w')
+            for line in open(fa):
+                if len(line) > 0 and line[0] == '>':
+                    idTag = event if eventNameAsID else uniqueID
+                    header = "id={}|{}".format(idTag, line[1:-1])
+                    out.write(">%s\n" % header)
+                    if idMap is not None:
+                        idMap[line[1:-1].rstrip()] = header.rstrip()
+                else:
+                    out.write(line)
+            ret[event] = outPath
         uniqueID += 1
     return ret
 

--- a/src/cactus/pipeline/cactus_workflow.py
+++ b/src/cactus/pipeline/cactus_workflow.py
@@ -477,7 +477,8 @@ def prependUniqueIDs(eventToFa, outputDir, idMap=None, firstID=0, eventNameAsID=
     Event Name IDs are better for paf-based pipeline as they are stable across commands even when working on subsets of events
     """
     if eventNameAsID is None:
-        eventNameAsID = bool(os.environ.get('CACTUS_EVENT_NAME_AS_UNIQUE_ID', '0'))
+        eventNameAsID = os.environ.get('CACTUS_EVENT_NAME_AS_UNIQUE_ID', False)
+        eventNameAsID = False if not bool(eventNameAsID) or eventNameAsID == '0' else True
         
     uniqueID = firstID
     ret = {}

--- a/src/cactus/pipeline/cactus_workflowTest.py
+++ b/src/cactus/pipeline/cactus_workflowTest.py
@@ -195,7 +195,7 @@ class TestCase(unittest.TestCase):
             fasta1.flush()
             fasta2.flush()
             outDir = mkdtemp()
-            eventToFa = {"A" : fasta1.name, "B" : fasta2.name}
+            eventToFa = {0 : fasta1.name, 1 : fasta2.name}
             outputPaths = prependUniqueIDs(eventToFa, outDir)
 
         assert len(outputPaths) == 2

--- a/src/cactus/pipeline/cactus_workflowTest.py
+++ b/src/cactus/pipeline/cactus_workflowTest.py
@@ -195,7 +195,8 @@ class TestCase(unittest.TestCase):
             fasta1.flush()
             fasta2.flush()
             outDir = mkdtemp()
-            outputPaths = prependUniqueIDs([fasta1.name, fasta2.name], outDir)
+            eventToFa = {"A" : fasta1.name, "B" : fasta2.name}
+            outputPaths = prependUniqueIDs(eventToFa, outDir)
 
         assert len(outputPaths) == 2
         with open(outputPaths[0]) as f:

--- a/src/cactus/refmap/cactus_graphmap.py
+++ b/src/cactus/refmap/cactus_graphmap.py
@@ -261,7 +261,7 @@ def minigraph_map_one(job, config, event_name, fa_path, fa_file_id, gfa_file_id,
         cactus_call(parameters = ['gzip', '-d', '-c', fa_path + '.gz'], outfile=fa_path)
 
     # prepend the unique id before mapping so the GAF has cactus-compatible event names
-    fa_path = prependUniqueIDs({event_name : fa_path}, work_dir, eventNameAsID=True)[0]
+    fa_path = prependUniqueIDs({event_name : fa_path}, work_dir, eventNameAsID=True)[event_name]
 
     # parse options from the config
     xml_node = findRequiredNode(config.xmlRoot, "graphmap")

--- a/src/cactus/refmap/cactus_refmap.py
+++ b/src/cactus/refmap/cactus_refmap.py
@@ -156,13 +156,15 @@ def run_prepend_unique_ids(job, assembly_files):
     Ensures all input sequences from assembly_files have unique names.
     This is adapted from run_prepend_unique_ids in cactus_align, in order to maintain order-dependent renamings.
     Because cactus-reference-align assumes that all input sequences are ingroups, it does not attempt to avoid renaming outgroup genomes.  
-    """    
-    # note: cactus now determines ids alphabetically, so we sort here to match that
-    events = sorted(assembly_files.keys())
+    """
     # download all the sequence files
-    sequence_paths = [job.fileStore.readGlobalFile(assembly_files[event]) for event in events]
-    # prepend unique id to each one
-    prepended_sequence_paths = prependUniqueIDs(sequence_paths, job.fileStore.getLocalTempDir())
+    event_to_path = {}
+    for event, assembly_id in assembly_files.items():
+        event_to_path[event] = job.fileStore.readGlobalFile(assembly_id)
+
+    # prepend unique id to each one (using event name instead of numeric id, as it's more stable across tools)
+    prepended_sequence_paths = prependUniqueIDs(event_to_path, job.fileStore.getLocalTempDir(), eventNameAsID=True)
+
     # write the prepended files back to the job store and return the dict
     for event, prepended_sequence_path in zip(events, prepended_sequence_paths):
         assembly_files[event] = job.fileStore.writeGlobalFile(prepended_sequence_path, cleanup=True)

--- a/src/cactus/refmap/cactus_refmap.py
+++ b/src/cactus/refmap/cactus_refmap.py
@@ -163,10 +163,10 @@ def run_prepend_unique_ids(job, assembly_files):
         event_to_path[event] = job.fileStore.readGlobalFile(assembly_id)
 
     # prepend unique id to each one (using event name instead of numeric id, as it's more stable across tools)
-    prepended_sequence_paths = prependUniqueIDs(event_to_path, job.fileStore.getLocalTempDir(), eventNameAsID=True)
+    event_to_unique_path = prependUniqueIDs(event_to_path, job.fileStore.getLocalTempDir(), eventNameAsID=True)
 
     # write the prepended files back to the job store and return the dict
-    for event, prepended_sequence_path in zip(events, prepended_sequence_paths):
+    for event, prepended_sequence_path in event_to_unique_path.items():
         assembly_files[event] = job.fileStore.writeGlobalFile(prepended_sequence_path, cleanup=True)
     return assembly_files
 

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -500,7 +500,7 @@ def run_prepend_unique_ids(job, cactusWorkflowArguments, project, renameCigars, 
     cactusWorkflowArguments.totalSequenceSize = sum(os.stat(x).st_size for x in eventToSequence.values())
     renamedInputSeqDir = job.fileStore.getLocalTempDir()
     id_map = {}
-    eventToUnique = prependUniqueIDs(eventToSequence, renamedInputSeqDir, id_map)
+    eventToUnique = prependUniqueIDs(eventToSequence, renamedInputSeqDir, idMap=id_map, eventNameAsID=eventNameAsID)    
     # Set the uniquified IDs for the ingroups and outgroups
     for event, uniqueFa in eventToUnique.items():
         uniqueFaID = job.fileStore.writeGlobalFile(uniqueFa, cleanup=True)

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -498,6 +498,9 @@ def run_prepend_unique_ids(job, cactusWorkflowArguments, project, renameCigars, 
             seqPath = seqPath[:-3]
         eventToSequence[g] = seqPath
     cactusWorkflowArguments.totalSequenceSize = sum(os.stat(x).st_size for x in eventToSequence.values())
+    # need to have outgroups in there just for id naming (don't need their sequence)
+    for g in exp.getOutgroupGenomes():
+        eventToSequence[g] = None
     renamedInputSeqDir = job.fileStore.getLocalTempDir()
     id_map = {}
     eventToUnique = prependUniqueIDs(eventToSequence, renamedInputSeqDir, idMap=id_map, eventNameAsID=eventNameAsID)    

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -500,12 +500,11 @@ def run_prepend_unique_ids(job, cactusWorkflowArguments, project, renameCigars, 
     cactusWorkflowArguments.totalSequenceSize = sum(os.stat(x).st_size for x in eventToSequence.values())
     renamedInputSeqDir = job.fileStore.getLocalTempDir()
     id_map = {}
-    uniqueFas = prependUniqueIDs(eventToSequence, renamedInputSeqDir, id_map)
-    uniqueFaIDs = [job.fileStore.writeGlobalFile(seq, cleanup=True) for seq in uniqueFas]
+    eventToUnique = prependUniqueIDs(eventToSequence, renamedInputSeqDir, id_map)
     # Set the uniquified IDs for the ingroups and outgroups
-    ingroupsAndNewIDs = list(zip(list(map(itemgetter(0), ingroupsAndOriginalIDs)), uniqueFaIDs[:len(ingroupsAndOriginalIDs)]))
-    for event, sequenceID in ingroupsAndNewIDs:
-        cactusWorkflowArguments.experimentWrapper.setSequenceID(event, sequenceID)
+    for event, uniqueFa in eventToUnique.items():
+        uniqueFaID = job.fileStore.writeGlobalFile(uniqueFa, cleanup=True)
+        cactusWorkflowArguments.experimentWrapper.setSequenceID(event, uniqueFaID)
 
     # if we're not taking cactus-[blast|refmap] input, then we have to apply to the cigar files too
     if renameCigars:

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -568,7 +568,7 @@ def export_vg(job, hal_id, configWrapper, doVG, doGFA, checkpointInfo=None, reso
     hal_path = os.path.join(work_dir, "out.hal")
     job.fileStore.readGlobalFile(hal_id, hal_path)
     
-    graph_event = getOptionalAttrib(findRequiredNode(configWrapper.xmlRoot, "graphmap"), "assemblyName", default="__MINIGRAPH_SEQUENCES__")
+    graph_event = getOptionalAttrib(findRequiredNode(configWrapper.xmlRoot, "graphmap"), "assemblyName", default="_MINIGRAPH_")
 
     vg_path = os.path.join(work_dir, "out.vg")
     cmd = ['hal2vg', hal_path, '--inMemory', '--progress', '--ignoreGenomes', 'Anc0,{}'.format(graph_event)]


### PR DESCRIPTION
`cactus-graphmap-split` use the minigraph alignments to partition a set of input contigs into reference chromosomes.  I've been doing this by just picking the chromosome to which a given contig maps to the most.  But this seems to be break down for smaller chromosomes (notably chr21) as they sponge off all kinds of partially and/or ambiguously mapping contigs leading to big messy graphs.  This adds PR adds 2 filters to exclude contigs if
* they don't overlap the given reference by enough or
* they aren't unique enough (determined by comparing to second-best assignment). 
Contigs that fail these filters don't get assigned a chromosome.  They can be viewed in the fake `__AMBIGUOUS_SEQUENCES__` bin where they are saved.  The defaults for these filters only filter out a few (small) input contigs but should vastly reduce the output graph size and complexity.  