### PR TITLE
Add support for Docker Hub mirror for CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,6 +4,12 @@ before_script:
   - whoami
   - sudo apt-get -q -y update
   - sudo apt-get -q -y install redis-server libhiredis0.13 libhiredis-dev liblzma-dev
+  # Configure Docker to use a mirror for Docker Hub and restart the daemon
+  # Set the registry as insecure because it is probably cluster-internal over plain HTTP.
+  - |
+    if [[ ! -z "${DOCKER_HUB_MIRROR}" ]] ; then
+        echo "{\"registry-mirrors\": [\"${DOCKER_HUB_MIRROR}\"], \"insecure-registries\": [\"${DOCKER_HUB_MIRROR##*://}\"]}" | sudo tee /etc/docker/daemon.json
+    fi
   - startdocker || true
   - docker info
 


### PR DESCRIPTION
Our CI system now has a caching mirror for Docker Hub. This sets CI to use it, in case we actually pull any Docker containers.