### PR TITLE
Update repo for GFA tools

### DIFF
--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -4,8 +4,9 @@
 # - minigraph
 # - gfatools
 # - dna-brnn
-# - mzgaf2paf
-# - paf2lastz
+# - cactus-gfa-tools
+# - samtools
+# - bedtools
 # The following tools are included to export and work with pangenome graph formats
 # - hal2vg
 # - vg
@@ -126,12 +127,18 @@ else
 	 exit 1
 fi
 
-# mzgaf2paf
+# cactus-gfa-tools
 cd ${pangenomeBuildDir}
-git clone https://github.com/glennhickey/mzgaf2paf.git
-cd mzgaf2paf
-git checkout 2e64e9437f7e41daae8816027d54668a7b74a021
+git clone https://github.com/ComparativeGenomicsToolkit/cactus-gfa-tools.git
+cd cactus-gfa-tools
+git checkout a563813cab1f3ef231a720b88401ce84bd98fad7
 make -j 4
+if [[ $STATIC_CHECK -ne 1 || $(ldd paf2lastz | grep so | wc -l) -eq 0 ]]
+then
+	 mv paf2lastz ${binDir}
+else
+	 exit 1
+fi
 if [[ $STATIC_CHECK -ne 1 || $(ldd mzgaf2paf | grep so | wc -l) -eq 0 ]]
 then
 	 mv mzgaf2paf ${binDir}
@@ -144,16 +151,6 @@ then
 else
 	 exit 1
 fi
-
-# paf2lastz
-wget -q https://github.com/glennhickey/paf2lastz/releases/download/v1.1/paf2lastz
-chmod +x paf2lastz
-if [[ $STATIC_CHECK -ne 1 || $(ldd paf2lastz | grep so | wc -l) -eq 0 ]]
-then
-	 mv paf2lastz ${binDir}
-else
-	 exit 1
-fi 
 
 # hal2vg
 wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.2/hal2vg


### PR DESCRIPTION
I hacked together a few tools while implementing the `cactus-graphmap` pipeline.  They ended up in these repos, and are necessary to run the pipeline:
https://github.com/glennhickey/paf2lastz
https://github.com/glennhickey/mzgaf2paf

This PR moves them to
https://github.com/ComparativeGenomicsToolkit/cactus-gfa-tools 
