### PR TITLE
Fix graphmap-split filter

### DIFF
--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -131,7 +131,7 @@ fi
 cd ${pangenomeBuildDir}
 git clone https://github.com/ComparativeGenomicsToolkit/cactus-gfa-tools.git
 cd cactus-gfa-tools
-git checkout a563813cab1f3ef231a720b88401ce84bd98fad7
+git checkout 2daf56ba97af2bc3ddbe2b2baec2b33bbb05e3de
 make -j 4
 if [[ $STATIC_CHECK -ne 1 || $(ldd paf2lastz | grep so | wc -l) -eq 0 ]]
 then
@@ -148,6 +148,12 @@ fi
 if [[ $STATIC_CHECK -ne 1 || $(ldd rgfa-split | grep so | wc -l) -eq 0 ]]
 then
 	 mv rgfa-split ${binDir}
+else
+	 exit 1
+fi
+if [[ $STATIC_CHECK -ne 1 || $(ldd rgfa2paf | grep so | wc -l) -eq 0 ]]
+then
+	 mv rgfa2paf ${binDir}
 else
 	 exit 1
 fi

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -131,7 +131,7 @@ fi
 cd ${pangenomeBuildDir}
 git clone https://github.com/ComparativeGenomicsToolkit/cactus-gfa-tools.git
 cd cactus-gfa-tools
-git checkout 2daf56ba97af2bc3ddbe2b2baec2b33bbb05e3de
+git checkout d0be4d05522f11a008337e40fabeec645aba51ce
 make -j 4
 if [[ $STATIC_CHECK -ne 1 || $(ldd paf2lastz | grep so | wc -l) -eq 0 ]]
 then

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -1531,7 +1531,7 @@ def unzip_gz(job, input_path, input_id):
     assert input_path.endswith('.gz')
     fa_path = os.path.join(work_dir, os.path.basename(input_path))
     job.fileStore.readGlobalFile(input_id, fa_path, mutable=True)
-    cactus_call(parameters=['gzip', '-d', os.path.basename(fa_path)], work_dir=work_dir)
+    cactus_call(parameters=['gzip', '-fd', os.path.basename(fa_path)], work_dir=work_dir)
     return job.fileStore.writeGlobalFile(fa_path[:-3])
 
 def zip_gzs(job, input_paths, input_ids, list_elems = None):


### PR DESCRIPTION
When `cactus-graphmap-split` assigns contigs to chromosomes, it uses alignment coverage from a PAF file.  There is a coverage filter (default=80%) that is applied to make sure only contigs that align well enough to a chromosome get assigned.  The PR fixes a bug in this filter where the query interval was used to compute coverage without taking into account softclips.  Now it's changed to use the mapped bases field which should be much more stringent. 

This PR also adds the `--refFromGFA` option to `cactus-graphmap` that will use the GFA to infer alignments of the reference sequence (instead of realigning with minigraph as done by default).  The idea is that this will give a more complete alignment (for chrY, for instance, less than half the reference sequence aligns to the minigraph).  But it may also promote incomplete cactus blocks (test in progress).  