### PR TITLE
Preprocess option to mask PAF coverage gaps in addtion to dna-brnn regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cactus
 [![Build Status](https://travis-ci.org/ComparativeGenomicsToolkit/cactus.svg?branch=master)](https://travis-ci.org/ComparativeGenomicsToolkit/cactus)
 
-Cactus is a reference-free whole-genome multiple alignment program. Please cite the [Progressive Cactus paper](https://doi.org/10.1038/s41586-020-2871-y) when using Cactus.  Additional descriptions can of the core algorithms can be found [here](https://doi.org/10.1101/gr.123356.111) and [here](https://doi.org/10.1089/cmb.2010.0252).
+Cactus is a reference-free whole-genome multiple alignment program. Please cite the [Progressive Cactus paper](https://doi.org/10.1038/s41586-020-2871-y) when using Cactus.  Additional descriptions of the core algorithms can be found [here](https://doi.org/10.1101/gr.123356.111) and [here](https://doi.org/10.1089/cmb.2010.0252).
 
 Please subscribe to the [cactus-announce](https://groups.google.com/d/forum/cactus-announce) low-volume mailing list so we may reach about releases and other announcements.
 
@@ -11,7 +11,7 @@ Cactus uses many different algorithms and individual code contributions, princip
 
 - Yung H. Tsin and Nima Norouzi for contributing their 3-edge connected components program code, which is crucial in constructing the cactus graph structure, see: Tsin,Y.H., "A simple 3-edge-connected component algorithm," Theory of Computing Systems, vol.40, No.2, 2007, pp.125-142.
 - Bob Harris for providing endless support for his [LastZ](https://github.com/lastz/lastz) pairwise, blast-like genome alignment tool.
-- Sneha Goenka and Yatish Turakhia for [SegAlign](https://github.com/ComparativeGenomicsToolkit/SegAlign), the GPU-accelerated version of LastZ.
+- Sneha Goenka and Yatish Turakhia for [SegAlign](https://github.com/gsneha26/SegAlign), the GPU-accelerated version of LastZ.
 - Yan Gao et al. for [abPOA](https://github.com/yangao07/abPOA)
 - Heng Li for [minigraph](https://github.com/lh3/minigraph), [minimap2](https://github.com/lh3/minimap2), [gfatools](https://github.com/lh3/gfatools) and [dna-brnn](https://github.com/lh3/dna-rnn)
 

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -131,7 +131,7 @@ fi
 cd ${pangenomeBuildDir}
 git clone https://github.com/ComparativeGenomicsToolkit/cactus-gfa-tools.git
 cd cactus-gfa-tools
-git checkout d0be4d05522f11a008337e40fabeec645aba51ce
+git checkout b08d4ced4f74427bdde74858e95fe5c251ccea2f
 make -j 4
 if [[ $STATIC_CHECK -ne 1 || $(ldd paf2lastz | grep so | wc -l) -eq 0 ]]
 then
@@ -154,6 +154,12 @@ fi
 if [[ $STATIC_CHECK -ne 1 || $(ldd rgfa2paf | grep so | wc -l) -eq 0 ]]
 then
 	 mv rgfa2paf ${binDir}
+else
+	 exit 1
+fi
+if [[ $STATIC_CHECK -ne 1 || $(ldd pafcoverage | grep so | wc -l) -eq 0 ]]
+then
+	 mv pafcoverage ${binDir}
 else
 	 exit 1
 fi

--- a/doc/pangenome.md
+++ b/doc/pangenome.md
@@ -87,10 +87,10 @@ Note: To mask the centromeres and leave them as unaligned bubbles in the graph (
 
 ### Map contigs to minigraph (about 3 hours)
 
-Use `cactus-graphmap` to do the mapping.  It will produce a PAF file of pairwise alignments for cactus to build on.  It will also edit the input seqfile in order to add the minigraph fasta (specfied with `--outputFasta`).  
+Use `cactus-graphmap` to do the mapping.  It will produce a PAF file of pairwise alignments for cactus to build on.  It will also edit the input seqfile in order to add the minigraph fasta (specfied with `--outputFasta`).  Note that `--refFromGFA hg38` is used in order to not map hg38 and instead pull its alignments from the rGFA tags.  
 
 ```
-cactus-graphmap <jobstore> `masked/seqfile.txt` <minigraph GFA> s3://<bucket>/GRCh38-freeze1.paf --realTimeLogging --logFile graphmap.log --batchSystem mesos --provisioner aws --defaultPreemptable --nodeTypes r3.8xlarge:0.7 --maxNodes 20 --outputFasta s3://<bucket>/GRCh38-freeze1.gfa.fa
+cactus-graphmap <jobstore> `masked/seqfile.txt` <minigraph GFA> s3://<bucket>/GRCh38-freeze1.paf --realTimeLogging --logFile graphmap.log --batchSystem mesos --provisioner aws --defaultPreemptable --nodeTypes r3.8xlarge:0.7 --maxNodes 20 --outputFasta s3://<bucket>/GRCh38-freeze1.gfa.fa --refFromGFA hg38
 ```
 
 ### Split the sequences by reference chromosome (about 1 hour)


### PR DESCRIPTION
It looks like there are too many unaligned bubbles in the whole-genome graphs coming out of the pangenome pipeline.  Especially in chr8 and chr21.  In theory, we hope `dna-brnn` catchces all such regions so we can mask them out.  In practice, it doesn't model everything.  So this is a hack to explore being more aggressive with masking.  This will help make cleaner graphs, and isolate/quantify problems coming from caf/bar phases:
* `--maskPAF` option added to `cactus-preprocess`.  It takes an input PAF file, computes the gaps in coverage, and merges these intervals with those found with `dna-brnn`. 

I took 2 shortcuts to get this implemented quickly in order to test:
1. `--maskPAF` can only be applied in conjunction with `dna-brnn` (which is the main use case right now, but not that hard to relax)
2. Using `--maskPAF` requires mapping everything twice, making the pipeline more ugly:  So instead of `cactus-preprocess -> cactus-graphmap` it becomes `cactus-graphmap -> cactus-preprocess -> cactus-graphmap`.  Fixing this is possible, but would require a fair amount of hacking.  Luckily `cactus-graphmap` has so far been one of the quicker steps in the pipeline, so overall time / cost shouldn't change that much. 