### PR TITLE
Fix bar mask filter bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN mkdir -p /wheels && cd /wheels && python3 -m pip install -U pip && python3 -
 FROM ubuntu:bionic-20200112
 
 # apt dependencies for runtime
-RUN apt-get update && apt-get install -y --no-install-recommends git python3 python3-pip python3-distutils zlib1g libbz2-1.0 net-tools libhdf5-100 liblzo2-2 libtokyocabinet9 rsync libkrb5-3 libk5crypto3 time redis-server libhiredis0.13 liblzma5
+RUN apt-get update && apt-get install -y --no-install-recommends git python3 python3-pip python3-distutils zlib1g libbz2-1.0 net-tools libhdf5-100 liblzo2-2 libtokyocabinet9 rsync libkrb5-3 libk5crypto3 time redis-server libhiredis0.13 liblzma5 libcurl4
 
 # copy temporary files for installing cactus
 COPY --from=builder /home/cactus /tmp/cactus

--- a/bar/impl/poaBarAligner.c
+++ b/bar/impl/poaBarAligner.c
@@ -591,8 +591,8 @@ char *get_adjacency_string_and_overlap(Cap *cap, int *length, int64_t *overlap, 
 
     if (mask_filter >= 0) {
         // apply the mask filter on the forward strand
-        *length = get_unmasked_length(adjacency_string, seq_length, *length, true, mask_filter);
-        length_backward = get_unmasked_length(adjacency_string, seq_length, *length, false, mask_filter);
+        *length = get_unmasked_length(adjacency_string, seq_length, *length, false, mask_filter);
+        length_backward = get_unmasked_length(adjacency_string, seq_length, *length, true, mask_filter);
     }
 
     // Cleanup the string

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -131,7 +131,7 @@ fi
 cd ${pangenomeBuildDir}
 git clone https://github.com/ComparativeGenomicsToolkit/cactus-gfa-tools.git
 cd cactus-gfa-tools
-git checkout b08d4ced4f74427bdde74858e95fe5c251ccea2f
+git checkout ce4c5dd1a08f1be05abca3bb258ac09dec1802b1
 make -j 4
 if [[ $STATIC_CHECK -ne 1 || $(ldd paf2lastz | grep so | wc -l) -eq 0 ]]
 then

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -175,7 +175,7 @@ else
 fi
 
 # vg
-wget -q https://github.com/vgteam/vg/releases/download/v1.29.0/vg
+wget -q https://github.com/vgteam/vg/releases/download/v1.30.0/vg
 chmod +x vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd vg | grep so | wc -l) -eq 0 ]]
 then

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -49,7 +49,7 @@ fi
 cd ${pangenomeBuildDir}
 git clone https://github.com/lh3/minigraph.git
 pushd minigraph
-git checkout 274aec227d4bd9cccc9c7a4454ac3a890eed40b8
+git checkout 0004952995a8d50a9758c9e22a660c67bda09eec
 # hack in flags support
 sed -i Makefile -e 's/CFLAGS=/CFLAGS+=/'
 make -j 4
@@ -131,7 +131,7 @@ fi
 cd ${pangenomeBuildDir}
 git clone https://github.com/ComparativeGenomicsToolkit/cactus-gfa-tools.git
 cd cactus-gfa-tools
-git checkout ce4c5dd1a08f1be05abca3bb258ac09dec1802b1
+git checkout da055afd5371c40937fe197490f166f167ee47ca
 make -j 4
 if [[ $STATIC_CHECK -ne 1 || $(ldd paf2lastz | grep so | wc -l) -eq 0 ]]
 then

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -279,7 +279,7 @@
 		 strictUniversal="0"
 		 minMZBlockLength="0"
 		 minMAPQ="5"
-		 minGAFBlockLength="100000"
+		 minGAFBlockLength="5000"
 		 minGAFNodeLength="0"
 		 minGAFQueryOverlapFilter="10000"
 		 maskFilter="-1"

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -21,7 +21,7 @@
 	<!-- action: one of [softmask, hardmask, clip] -->
 	<!-- minLength: only mask intervals > than this length -->
 	<!-- mergeLength: merge up consecutive intervals if they are <= this far apart -->
-	<preprocessor unmask="1" memory="littleMemory" preprocessJob="dna-brnn" dna-brnnOpts='-A' active="0" action="softmask" cpu="2" minLength="0" mergeLength="0"/>
+	<preprocessor unmask="1" memory="littleMemory" preprocessJob="dna-brnn" dna-brnnOpts='-A' active="0" action="softmask" cpu="2" minLength="100000" mergeLength="100000"/>
         <!-- Options for trimming ingroups & outgroups using the trim strategy -->
         <!-- Ingroup trim options: -->
         <!-- trimFlanking: The length of flanking sequence to attach

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -278,8 +278,8 @@
 		 nodeBasedUniversal="0"
 		 strictUniversal="0"
 		 minMZBlockLength="0"
-		 minMAPQ="0"
-		 minGAFBlockLength="0"
+		 minMAPQ="5"
+		 minGAFBlockLength="100000"
 		 minGAFNodeLength="0"
 		 minGAFQueryOverlapFilter="10000"
 		 maskFilter="-1"
@@ -287,10 +287,14 @@
 		 />
 	<!-- cactus-graphmap-split options -->
 	<!-- minQueryCoverage: At least this fraction of input contig must align to reference contig for it to be assigned. -->
+	<!-- minQuerySmallCoverage: Like minQueryCoverage, but applied only to contigs with length < minQuerySmallThreshold. -->
+	<!-- minQuerySmallThreshold: Threshold used to toggle between minQueryCoverage and minuQuerySmallCoverage. -->
 	<!-- minQueryUniqueness: The ratio of the number of query bases aligned to the chosen ref contig vs the next best ref contig must exceed this threshold to not be considered ambigious. -->
 	<!-- ambiguousName: Contigs deemed ambiguous using the above filters get added to a "contig" with this name, and are preserved in output. -->		
 	<graphmap_split
 		 minQueryCoverage="0.55"
+		 minQuerySmallCoverage="0.85"
+		 minQuerySmallThreshold="5000000"
 		 minQueryUniqueness="2"
 		 ambiguousName="_AMBIGUOUS_"
 		 />

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -290,7 +290,7 @@
 	<!-- minQueryUniqueness: The ratio of the number of query bases aligned to the chosen ref contig vs the next best ref contig must exceed this threshold to not be considered ambigious. -->
 	<!-- ambiguousName: Contigs deemed ambiguous using the above filters get added to a "contig" with this name, and are preserved in output. -->		
 	<graphmap_split
-		 minQueryCoverage="0.80"
+		 minQueryCoverage="0.55"
 		 minQueryUniqueness="2"
 		 ambiguousName="_AMBIGUOUS_"
 		 />

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -279,7 +279,7 @@
 		 strictUniversal="0"
 		 minMZBlockLength="0"
 		 minMAPQ="5"
-		 minGAFBlockLength="5000"
+		 minGAFBlockLength="100000"
 		 minGAFNodeLength="0"
 		 minGAFQueryOverlapFilter="10000"
 		 maskFilter="-1"

--- a/src/cactus/preprocessor/cactus_preprocessor.py
+++ b/src/cactus/preprocessor/cactus_preprocessor.py
@@ -335,12 +335,10 @@ def stageWorkflow(outputSequenceDir, configFile, inputSequences, toil, restart=F
     if maskAlpha or clipAlpha:
         ConfigWrapper(configNode).setPreprocessorActive("lastzRepeatMask", False)
         ConfigWrapper(configNode).setPreprocessorActive("dna-brnn", True)
-        if clipAlpha:
-            for node in configNode.findall("preprocessor"):
-                if getOptionalAttrib(node, "preprocessJob") == 'dna-brnn':
-                    node.attrib["action"] = "clip"
-                    node.attrib["minLength"] = clipAlpha
-                    node.attrib["mergeLength"] = clipAlpha
+        for node in configNode.findall("preprocessor"):
+            if getOptionalAttrib(node, "preprocessJob") == 'dna-brnn':
+                if clipAlpha:
+                    node.attrib["action"] = "clip"                    
     if brnnCores is not None:
         for node in configNode.findall("preprocessor"):
             if getOptionalAttrib(node, "preprocessJob") == 'dna-brnn':
@@ -396,7 +394,7 @@ def main():
     parser.add_argument("--inPaths", nargs='*', help='Space-separated list of input fasta paths (to be used in place of --inSeqFile')
     parser.add_argument("--outPaths", nargs='*', help='Space-separated list of output fasta paths (one for each inPath, used in place of --outSeqFile)')
     parser.add_argument("--maskAlpha", action='store_true', help='Use dna-brnn instead of lastz for repeatmasking')
-    parser.add_argument("--clipAlpha", type=int, help='use dna-brnn instead of lastz for repeatmasking.  Also, clip sequence using given minimum length instead of softmasking')
+    parser.add_argument("--clipAlpha", action='store_true', help='use dna-brnn instead of lastz for repeatmasking.  Also, clip sequence using given minimum length instead of softmasking')
     parser.add_argument("--ignore", nargs='*', help='Space-separate list of genomes from inSeqFile to ignore', default=[])
     parser.add_argument("--maskPAF", type=str, help='Incorporate coverage gaps from given PAF when masking.  Only implemented for dna-brnn masking')
     parser.add_argument("--brnnCores", type=int, help='Specify number of cores for each dna-brnn job (overriding default value from the config)')

--- a/src/cactus/preprocessor/cactus_preprocessor.py
+++ b/src/cactus/preprocessor/cactus_preprocessor.py
@@ -319,7 +319,7 @@ class CactusPreprocessor2(RoundedJob):
             return self.addChild(BatchPreprocessor(prepXmlElems, self.inputSequenceID, 0)).rv()
 
 def stageWorkflow(outputSequenceDir, configFile, inputSequences, toil, restart=False, outputSequences = [], maskAlpha=False, clipAlpha=None,
-                  maskPAF=None, inputEventNames=None):
+                  maskPAF=None, inputEventNames=None, brnnCores=None):
     #Replace any constants
     configNode = ET.parse(configFile).getroot()
     if not outputSequences:
@@ -341,6 +341,10 @@ def stageWorkflow(outputSequenceDir, configFile, inputSequences, toil, restart=F
                     node.attrib["action"] = "clip"
                     node.attrib["minLength"] = clipAlpha
                     node.attrib["mergeLength"] = clipAlpha
+    if brnnCores is not None:
+        for node in configNode.findall("preprocessor"):
+            if getOptionalAttrib(node, "preprocessJob") == 'dna-brnn':
+                node.attrib["cpu"] = brnnCores
         
     if not restart:
         inputSequenceIDs = []
@@ -395,6 +399,7 @@ def main():
     parser.add_argument("--clipAlpha", type=int, help='use dna-brnn instead of lastz for repeatmasking.  Also, clip sequence using given minimum length instead of softmasking')
     parser.add_argument("--ignore", nargs='*', help='Space-separate list of genomes from inSeqFile to ignore', default=[])
     parser.add_argument("--maskPAF", type=str, help='Incorporate coverage gaps from given PAF when masking.  Only implemented for dna-brnn masking')
+    parser.add_argument("--brnnCores", type=int, help='Specify number of cores for each dna-brnn job (overriding default value from the config)')
     parser.add_argument("--latest", dest="latest", action="store_true",
                         help="Use the latest version of the docker container "
                         "rather than pulling one matching this version of cactus")
@@ -429,6 +434,8 @@ def main():
         options.maskAlpha = True
     if options.maskPAF and not options.inputNames and not options.inSeqFile:
         raise RuntimeError('--maskPAF requires event names specified wither with an input seqfile or with --inputNames')
+    if options.ignore and options.clipAlpha is None:
+        raise RuntimeError('--ignore can only be used with --clipAlpha')
 
     inSeqPaths = []
     outSeqPaths = []
@@ -486,7 +493,8 @@ def main():
                       maskAlpha=options.maskAlpha,
                       clipAlpha=options.clipAlpha,
                       maskPAF=options.maskPAF,
-                      inputEventNames=eventNames)
+                      inputEventNames=eventNames,
+                      brnnCores=options.brnnCores)
 
 if __name__ == '__main__':
     main()

--- a/src/cactus/preprocessor/dnabrnnMasking.py
+++ b/src/cactus/preprocessor/dnabrnnMasking.py
@@ -134,7 +134,7 @@ class DnabrnnMaskJob(RoundedJob):
         maskedFile = os.path.join(work_dir, 'masked.fa')
         
         if self.action in ('softmask', 'hardmask'):
-            mask_cmd = ['cactus_fasta_softmask_intervals.py', '--origin=zero', bedFile]
+            mask_cmd = ['cactus_fasta_softmask_intervals.py', '--origin=zero', mergedBedFile]
             if self.minLength:
                 mask_cmd += ['--minLength={}'.format(self.minLength)]
             if self.action == 'hardmask':

--- a/src/cactus/refmap/cactus_graphmap_split.py
+++ b/src/cactus/refmap/cactus_graphmap_split.py
@@ -201,6 +201,8 @@ def split_gfa(job, config, gfa_id, paf_id, ref_contigs, other_contig, reference_
 
     # get the specificity filters
     query_coverage = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_split"), "minQueryCoverage", default="0")
+    small_query_coverage = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_split"), "minQuerySmallCoverage", default="0")
+    small_coverage_threshold = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_split"), "minQuerySmallThreshold", default="0")
     query_uniqueness = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_split"), "minQueryUniqueness", default="0")
     amb_event = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_split"), "ambiguousName", default="_AMBIGUOUS_")
 
@@ -209,6 +211,8 @@ def split_gfa(job, config, gfa_id, paf_id, ref_contigs, other_contig, reference_
            '-p', paf_path,
            '-b', out_prefix,
            '-n', query_coverage,
+           '-N', small_query_coverage,
+           '-T', small_coverage_threshold,
            '-Q', query_uniqueness,
            '-a', amb_event]
     if other_contig:


### PR DESCRIPTION
I caught `cactus-bar` aligning together sofmasked sequences when they should have been ignored due to `--maskFilter`.  This PR attempts to fix this (one glaring bug found so far). 

It's crucial that this logic work if we're going to cut centromeres out post hoc in the hpp pipeline.  