### PR TITLE
Make sure bytes2human values can be used on cli

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,7 @@
+# Release 1.3.1
+
+- Fix bug in how `cactus-prepare` transmits Toil size parameters
+
 # Release 1.3.0   2021-02-11
 
 This release introduces the [Cactus Pangenome Pipeline](https://github.com/ComparativeGenomicsToolkit/cactus/blob/master/doc/pangenome.md), which can be used to align together samples from the same species in order to create a pangenome graph:

--- a/src/cactus/progressive/cactus_prepare.py
+++ b/src/cactus/progressive/cactus_prepare.py
@@ -251,6 +251,9 @@ def get_jobstore(options, task=None):
 def human2bytesN(s):
     return human2bytes(s) if s else s
 
+def bytes2humanN(s):
+    return bytes2human(s, fmt='%(value).1f%(symbol)s') if s else s
+
 def bytes2gigs(n):
     return int(int(n)/pow(2,30))
 
@@ -276,7 +279,7 @@ def get_toil_resource_opts(options, task):
     if mem and not options.wdl:
         if s:
             s += ' '
-        s += '--maxMemory {}'.format(bytes2human(mem))
+        s += '--maxMemory {}'.format(bytes2humanN(mem))
     return s
 
 def wdl_disk(options, task, max_local=300):
@@ -765,7 +768,7 @@ def toil_call_preprocess(job, options, in_seq_file, out_seq_file, name):
 
     cmd = ['cactus-preprocess', os.path.join(work_dir, 'js'), '--inPaths', in_path,
            '--outPaths', out_name, '--workDir', work_dir,
-           '--maxCores', str(int(job.cores)), '--maxDisk', bytes2human(job.disk), '--maxMemory', bytes2human(job.memory)] + options.cactusOptions.strip().split(' ')
+           '--maxCores', str(int(job.cores)), '--maxDisk', bytes2humanN(job.disk), '--maxMemory', bytes2humanN(job.memory)] + options.cactusOptions.strip().split(' ')
     
     cactus_call(parameters=cmd)
 
@@ -856,7 +859,7 @@ def toil_call_blast(job, options, seq_file, project, event, cigar_name, dep_name
             
     cactus_call(parameters=['cactus-blast', os.path.join(work_dir, 'js'), seq_file_path, os.path.join(work_dir, os.path.basename(cigar_name)),
                  '--root', event, '--pathOverrides'] + fa_paths+ ['--pathOverrideNames'] + dep_names +
-                ['--workDir', work_dir, '--maxCores', str(int(job.cores)), '--maxDisk', bytes2human(job.disk), '--maxMemory', bytes2human(job.memory)] + options.cactusOptions.strip().split(' '))
+                ['--workDir', work_dir, '--maxCores', str(int(job.cores)), '--maxDisk', bytes2humanN(job.disk), '--maxMemory', bytes2humanN(job.memory)] + options.cactusOptions.strip().split(' '))
 
     # scrape the output files out of the workdir
     out_nameids = []
@@ -959,7 +962,7 @@ def toil_call_align(job, options, seq_file, project, event, cigar_name, hal_path
     cactus_call(parameters=['cactus-align', os.path.join(work_dir, 'js'), seq_file_path] + blast_files +
                 [out_hal_path, '--root', event,
                  '--pathOverrides'] + fa_paths + ['--pathOverrideNames'] + dep_names +
-                ['--workDir', work_dir, '--maxCores', str(int(job.cores)), '--maxDisk', bytes2human(job.disk), '--maxMemory', bytes2human(job.memory)] + options.cactusOptions.strip().split(' '))
+                ['--workDir', work_dir, '--maxCores', str(int(job.cores)), '--maxDisk', bytes2humanN(job.disk), '--maxMemory', bytes2humanN(job.memory)] + options.cactusOptions.strip().split(' '))
 
     out_hal_id = job.fileStore.writeGlobalFile(out_hal_path)
 


### PR DESCRIPTION
`cactus-prepare` uses `bytes2human` and `human2bytes` while parsing disk and memory sizes.  But `bytes2human` sticks a space between the number and unit, meaning it can't be used as a single cli parameter.

Resolves #426