### PR TITLE
minimap2 fallback in graphmap-split

### DIFF
--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -131,7 +131,7 @@ fi
 cd ${pangenomeBuildDir}
 git clone https://github.com/ComparativeGenomicsToolkit/cactus-gfa-tools.git
 cd cactus-gfa-tools
-git checkout af063cdcce3e6600bd0b4d94062b32740e47cd5a
+git checkout 65baa2ac592532a2dc9c5eca79bd9bd1c6c7f178
 make -j 4
 if [[ $STATIC_CHECK -ne 1 || $(ldd paf2lastz | grep so | wc -l) -eq 0 ]]
 then
@@ -194,7 +194,7 @@ fi
 
 
 # vg
-wget -q https://github.com/vgteam/vg/releases/download/v1.30.0/vg
+wget -q https://github.com/vgteam/vg/releases/download/v1.31.0/vg
 chmod +x vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd vg | grep so | wc -l) -eq 0 ]]
 then

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -131,7 +131,7 @@ fi
 cd ${pangenomeBuildDir}
 git clone https://github.com/ComparativeGenomicsToolkit/cactus-gfa-tools.git
 cd cactus-gfa-tools
-git checkout 68b08782911e599f884634aee66e13c46d68de89
+git checkout af063cdcce3e6600bd0b4d94062b32740e47cd5a
 make -j 4
 if [[ $STATIC_CHECK -ne 1 || $(ldd paf2lastz | grep so | wc -l) -eq 0 ]]
 then

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -131,7 +131,7 @@ fi
 cd ${pangenomeBuildDir}
 git clone https://github.com/ComparativeGenomicsToolkit/cactus-gfa-tools.git
 cd cactus-gfa-tools
-git checkout 65baa2ac592532a2dc9c5eca79bd9bd1c6c7f178
+git checkout 49b41773971a99a85f60c4e4eabbf174acac5e6f
 make -j 4
 if [[ $STATIC_CHECK -ne 1 || $(ldd paf2lastz | grep so | wc -l) -eq 0 ]]
 then
@@ -165,7 +165,7 @@ else
 fi
 
 # hal2vg
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.7/hal2vg
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.8/hal2vg
 chmod +x hal2vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd hal2vg | grep so | wc -l) -eq 0 ]]
 then

--- a/build-tools/makeBinRelease
+++ b/build-tools/makeBinRelease
@@ -40,6 +40,14 @@ export LDFLAGS="-march=${CACTUS_ARCH} -static"
 
 make -j $(nproc) check-static
 
+# download all external tools used for pangenome pipeline
+# (only works for newer architectures as vg and some other binaries are built with -march=nehalem)
+# todo: should try to just use nocona for everything and make one release 
+if [ -z ${CACTUS_LEGACY_ARCH+x} ]	
+then
+	 build-tools/downloadPangenomeTools 1
+fi
+
 binPackageDir=cactus-bin-${REL_TAG}
 rm -rf ${binPackageDir}
 mkdir ${binPackageDir}
@@ -51,13 +59,6 @@ find submodules/sonLib -name '*.py' | cpio -pdum ${binPackageDir}
 # todo: probably a better way
 mkdir -p $(binPackageDir)/lib
 rsync -avm --include='*.py' -f 'hide,! */' ./submodules/hal ${binPackageDir}/lib
-# download all external tools used for pangenome pipeline
-# (only works for newer architectures as vg and some other binaries are built with -march=nehalem)
-# todo: should try to just use nocona for everything and make one release 
-if [ -z ${CACTUS_LEGACY_ARCH+x} ]	
-then
-	 build-tools/downloadPangenomeTools 1
-fi
 # need .git dir for pip install -U ., but don't need everything
 cp -r .git ${binPackageDir}
 rm -rf ${binPackageDir}/.git/modules

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -290,12 +290,14 @@
 	<!-- minQuerySmallCoverage: Like minQueryCoverage, but applied only to contigs with length < minQuerySmallThreshold. -->
 	<!-- minQuerySmallThreshold: Threshold used to toggle between minQueryCoverage and minuQuerySmallCoverage. -->
 	<!-- minQueryUniqueness: The ratio of the number of query bases aligned to the chosen ref contig vs the next best ref contig must exceed this threshold to not be considered ambigious. -->
+	<!-- maxGap: Include indel gaps <= maxGap when counting minigraph coverage -->	
 	<!-- ambiguousName: Contigs deemed ambiguous using the above filters get added to a "contig" with this name, and are preserved in output. -->		
 	<graphmap_split
 		 minQueryCoverage="0.75"
 		 minQuerySmallCoverage="0.85"
 		 minQuerySmallThreshold="1000000"
-		 minQueryUniqueness="2"
+		 minQueryUniqueness="3"
+		 maxGap="50000"
 		 ambiguousName="_AMBIGUOUS_"
 		 />
 	<!-- hal2vg options -->

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -293,9 +293,9 @@
 	<!-- maxGap: Include indel gaps <= maxGap when counting minigraph coverage -->	
 	<!-- ambiguousName: Contigs deemed ambiguous using the above filters get added to a "contig" with this name, and are preserved in output. -->		
 	<graphmap_split
-		 minQueryCoverage="0.75"
-		 minQuerySmallCoverage="0.85"
-		 minQuerySmallThreshold="1000000"
+		 minQueryCoverage="0.65"
+		 minQuerySmallCoverage="0.75"
+		 minQuerySmallThreshold="10000000"
 		 minQueryUniqueness="3"
 		 maxGap="50000"
 		 ambiguousName="_AMBIGUOUS_"

--- a/src/cactus/refmap/cactus_graphmap_split.py
+++ b/src/cactus/refmap/cactus_graphmap_split.py
@@ -541,9 +541,11 @@ def combine_paf_splits(job, seq_id_map, original_id_map, remap_id_map, amb_name)
             for event in remap_id_map[ref_contig]['fa']:
                 if remap_id_map[ref_contig]['fa'][event].size > 0:
                     # read the contigs assigned to this sample for this chromosome by scanning fasta headers
-                    tmp_fa_path = os.path.join(work_dir, '{}_tmp.fa'.format(event))
+                    tmp_fa_path = os.path.join(work_dir, 'tmp.fa')
                     if seq_id_map[event][0].endswith('.gz'):
                         tmp_fa_path += '.gz'
+                    if os.path.isfile(tmp_fa_path):
+                        os.remove(tmp_fa_path)
                     job.fileStore.readGlobalFile(remap_id_map[ref_contig]['fa'][event], tmp_fa_path, mutable=True)
                     contigs_path = os.path.join(work_dir, '{}.contigs')
                     cactus_call(parameters=[['zcat' if tmp_fa_path.endswith('.gz') else 'cat', tmp_fa_path],

--- a/src/cactus/refmap/cactus_graphmap_split.py
+++ b/src/cactus/refmap/cactus_graphmap_split.py
@@ -541,7 +541,7 @@ def combine_paf_splits(job, seq_id_map, original_id_map, remap_id_map, amb_name)
             for event in remap_id_map[ref_contig]['fa']:
                 if remap_id_map[ref_contig]['fa'][event].size > 0:
                     # read the contigs assigned to this sample for this chromosome by scanning fasta headers
-                    tmp_fa_path = os.path.join(work_dir, 'tmp.fa')
+                    tmp_fa_path = os.path.join(work_dir, '{}_tmp.fa'.format(event))
                     if seq_id_map[event][0].endswith('.gz'):
                         tmp_fa_path += '.gz'
                     job.fileStore.readGlobalFile(remap_id_map[ref_contig]['fa'][event], tmp_fa_path, mutable=True)

--- a/src/cactus/refmap/cactus_graphmap_split.py
+++ b/src/cactus/refmap/cactus_graphmap_split.py
@@ -75,8 +75,7 @@ def main():
     setLoggingFromOptions(options)
     enableDumpStack()
 
-    # todo: would be very nice to support s3 here
-    if options.outDir:
+    if options.outDir and not options.startswith('s3://'):
         if not os.path.isdir(options.outDir):
             os.makedirs(options.outDir)
         

--- a/src/cactus/refmap/cactus_graphmap_split.py
+++ b/src/cactus/refmap/cactus_graphmap_split.py
@@ -444,7 +444,7 @@ def minimap_index(job, ref_name, ref_id):
     idx_path = fa_path + ".idx"
     job.fileStore.readGlobalFile(ref_id, fa_path)
 
-    cactus_call(parameters=['minimap2', fa_path, '-d', idx_path])
+    cactus_call(parameters=['minimap2', fa_path, '-d', idx_path, '-x', 'asm5'])
 
     return job.fileStore.writeGlobalFile(idx_path)
 
@@ -457,7 +457,7 @@ def minimap_map(job, minimap_index_id, event, fa_id, fa_name):
     job.fileStore.readGlobalFile(fa_id, fa_path)
     paf_path = fa_path + ".paf"
 
-    cactus_call(parameters=['minimap2', idx_path, fa_path, '-c', '-x', 'asm10'], outfile=paf_path)
+    cactus_call(parameters=['minimap2', idx_path, fa_path, '-c', '-x', 'asm5'], outfile=paf_path)
 
     return job.fileStore.writeGlobalFile(paf_path)    
     


### PR DESCRIPTION
The pangenome pipeline currently uses `minigraph` to split the data into reference chromosomes.  This is for simplicity and consistency, as it's already being used to make the alignment anchors.  But it's been a struggle coming up with a coverage threshold that works for small contigs.   

This PR adds a second pass of contigs that can't be assigned using the existing minigraph logic.  They are remapped to the linear reference with minimap2, and then the same splitting logic is applied on these alignments.  In practice, the minimap2's base level alignments can dramatically increase the coverage of some small contigs, so they are "rescued" from the ambiguity pile by this procedure. 

This PR also relaxes the minigraph coverage computation to count gaps between minimizers (up to a given length).  