### PR TITLE
New preprocessor: CutHeaders

### DIFF
--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -9,6 +9,10 @@
   		<divergences useDefault="0" one="0.1" two="0.15" three="0.2" four="0.25" five="0.35"/>
 	</constants>
 	<!-- The preprocessor tags are used to modify/check the input sequences before alignment -->
+	<!-- The cutHeaders preprocess modifies fastsa sequence names to help them pass checkUniqueHeaders. -->
+	<!-- cutBefore: all characters up to and including the last occurrence of a character in this string are clipped out -->
+	<!-- cutAfter: all characters after and including the first occurrence of a character in this string are clipped out -->
+	<preprocessor memory="littleMemory" preprocessJob="cutHeaders" cutBefore="#" cutAfter=" 	" active="0"/>
 	<!-- The first preprocessor tag checks that the first word of every fasta header is unique, as this is required for HAL. It throws errors if this is not the case -->
 	<!-- The checkAssemblyHub option (if enabled) ensures that the first word contains only alphanumeric or '_', '-', ':', or '.' characters, and is unique. If you don't intend to make an assembly hub, you can turn off this option here. -->
 	<preprocessor check="1" memory="littleMemory" preprocessJob="checkUniqueHeaders" checkAssemblyHub="1" active="1"/>

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -12,7 +12,7 @@
 	<!-- The cutHeaders preprocess modifies fastsa sequence names to help them pass checkUniqueHeaders. -->
 	<!-- cutBefore: all characters up to and including the last occurrence of a character in this string are clipped out -->
 	<!-- cutAfter: all characters after and including the first occurrence of a character in this string are clipped out -->
-	<preprocessor memory="littleMemory" preprocessJob="cutHeaders" cutBefore="#" cutAfter=" 	" active="0"/>
+	<preprocessor memory="littleMemory" preprocessJob="cutHeaders" cutBefore="" cutAfter=" 	" active="1"/>
 	<!-- The first preprocessor tag checks that the first word of every fasta header is unique, as this is required for HAL. It throws errors if this is not the case -->
 	<!-- The checkAssemblyHub option (if enabled) ensures that the first word contains only alphanumeric or '_', '-', ':', or '.' characters, and is unique. If you don't intend to make an assembly hub, you can turn off this option here. -->
 	<preprocessor check="1" memory="littleMemory" preprocessJob="checkUniqueHeaders" checkAssemblyHub="1" active="1"/>

--- a/src/cactus/preprocessor/checkUniqueHeaders.py
+++ b/src/cactus/preprocessor/checkUniqueHeaders.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python3
 """Checks headers are all unique.
 """
-from sonLib.bioio import fastaRead
+from Bio import SeqIO
+from Bio.SeqRecord import SeqRecord
 
 def checkUniqueHeaders(inputFile, checkAlphaNumeric=False, checkUCSC=False, checkAssemblyHub=True):
     """Check that headers are unique and meet certain requirements."""
     seen = set()
-    for header, seq in fastaRead(inputFile):
+    for seq_record in SeqIO.parse(inputFile, 'fasta'):
+        header = seq_record.description
+        seq = seq_record.seq
         if " " in header or "\t" in header:
             raise RuntimeError("The fasta header '%s' contains spaces or tabs. These characters will cause issues in space-separated formats like MAF, and may not function properly when viewed in a browser. Please remove these characters from the input headers and try again." % header)
         mungedHeader = header.split()[0]

--- a/src/cactus/preprocessor/cutHeaders.py
+++ b/src/cactus/preprocessor/cutHeaders.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Cut prefixes or suffixes from fasta headeres
+"""
+
+
+import os
+import re
+import sys
+import shutil
+
+from Bio import SeqIO
+from Bio.SeqRecord import SeqRecord
+
+from cactus.shared.common import RoundedJob
+from toil.realtimeLogger import RealtimeLogger
+
+class CutHeadersJob(RoundedJob):
+    def __init__(self, fastaID, cutBefore, cutAfter):
+        disk = 2*(fastaID.size)
+        RoundedJob.__init__(self, disk=disk, preemptable=True)
+        self.fastaID = fastaID
+        self.cutBefore = cutBefore
+        self.cutAfter = cutAfter
+
+    def run(self, fileStore):
+        """
+        Cut before cutBefore and after cutAfter
+        
+        If cutBefore is # then something like
+        >HG02055#1#h1tg000001l
+        would become 
+        >h1tg000001l
+
+        If cutAfter is a whitespace, then something like 
+        >chr1  AC:CM000663.2  gi:568336023  LN:248956422  rl:Chromosome  M5:6aef897c3d6ff0c78aff06
+        would become
+        >chr1
+        """
+        work_dir = fileStore.getLocalTempDir()
+        input_path = os.path.join(work_dir, 'seq.fa')
+        fileStore.readGlobalFile(self.fastaID, input_path)
+        output_path = os.path.join(work_dir, 'seq.cut.fa')
+
+        with open(input_path, 'r') as in_file, open(output_path, 'w') as out_file:
+            for seq_record in SeqIO.parse(in_file, 'fasta'):
+                header = seq_record.description
+                if self.cutBefore:
+                    pos = max(header.rfind(c) for c in self.cutBefore)
+                    if pos >= 0:
+                        if pos < len(header) - 1:
+                            header = header[pos + 1:]
+                        else:
+                            header = ""
+                if self.cutAfter:
+                    pos_list = [header.find(c) for c in self.cutAfter if header.find(c) >= 0]
+                    if pos_list:
+                        pos = min(pos_list)
+                        header = header[0:pos]
+
+                if not header:
+                    raise RuntimeError("Error: applying cutHeaders preprocessor removes entire header: {}".format(seq_record.description))
+                seq_record.description = header
+                seq_record.id = header
+                SeqIO.write(seq_record, out_file, 'fasta')
+
+        return fileStore.writeGlobalFile(output_path)


### PR DESCRIPTION
Cactus makes some pretty heavy assumptions about fasta headers.  They are enforced by default via the `CheckUniqueHeaders` preprocessor.  In addition to most non-alphanumeric characters, common things like spaces are rejected (usually it's safe to ignore everything after the first space).  There are good historical reasons for all this. But it can be a bit onerous to have to manually rename 100's of gigs if fasta just to meet the naming conventions.  This is the position I'm in at the moment with a bunch of human genomes with headers that can look like:
```
>chr1
>chr1  AC:CM000663.2  gi:568336023  LN:248956422  rl:Chromosome  M5:6aef897c3d6ff0c78aff06ac189178dd  AS:GRCh38
>HG02055#1#h1tg000001l
```

So I've added a `cutHeaders` preprocessor.  It cuts prefixes and suffixes that occur before or after specified characters.  So setting `cutBefore="#"` would transform `>HG02055#1#h1tg000001l` into `h1tg000001l`.  And setting `cutAfter= " "` would transform `>chr1  AC:CM000663.2  gi:568336023  LN:248956422  rl:Chromosome` to `chr1`.

I've turned this on by default (with `cutBefore` off and `cutAfter` set to space and tab).  So now anything after a space in the header will get trimmed out automatically instead of causing a fatal error.  If this trimming causes something to not be unique, it should still get caught....
