### PR TITLE
Add preprocess interface to directly mask by input paf/bed file

### DIFF
--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -76,10 +76,11 @@ else
 fi
 
 #samtools
+cd ${pangenomeBuildDir}
 wget -q https://github.com/samtools/samtools/releases/download/1.11/samtools-1.11.tar.bz2
 tar -xf samtools-1.11.tar.bz2
 cd samtools-1.11
-./configure --without-curses --disable-libcurl
+./configure --without-curses --disable-libcurl --enable-configure-htslib
 make -j 4
 if [[ $STATIC_CHECK -ne 1 || $(ldd samtools | grep so | wc -l) -eq 0 ]]
 then
@@ -87,8 +88,23 @@ then
 else
 	 exit 1
 fi
+cd htslib-1.11
+make -j 4
+if [[ $STATIC_CHECK -ne 1 || $(ldd tabix | grep so | wc -l) -eq 0 ]]
+then
+	 mv tabix ${binDir}
+else
+	 exit 1
+fi
+if [[ $STATIC_CHECK -ne 1 || $(ldd bgzip | grep so | wc -l) -eq 0 ]]
+then
+	 mv bgzip ${binDir}
+else
+	 exit 1
+fi
 
 #bedtools
+cd ${pangenomeBuildDir}
 wget -q https://github.com/arq5x/bedtools2/releases/download/v2.29.1/bedtools-2.29.1.tar.gz
 tar -zxf bedtools-2.29.1.tar.gz
 cd bedtools2
@@ -165,6 +181,7 @@ else
 fi
 
 # hal2vg
+cd ${pangenomeBuildDir}
 wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.8/hal2vg
 chmod +x hal2vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd hal2vg | grep so | wc -l) -eq 0 ]]
@@ -174,7 +191,8 @@ else
 	 exit 1
 fi
 # clip-vg
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.7/clip-vg
+cd ${pangenomeBuildDir}
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.8/clip-vg
 chmod +x clip-vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd clip-vg | grep so | wc -l) -eq 0 ]]
 then
@@ -183,7 +201,8 @@ else
 	 exit 1
 fi
 # halRemoveDupes
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.7/halRemoveDupes
+cd ${pangenomeBuildDir}
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.8/halRemoveDupes
 chmod +x halRemoveDupes
 if [[ $STATIC_CHECK -ne 1 || $(ldd halRemoveDupes | grep so | wc -l) -eq 0 ]]
 then
@@ -194,6 +213,7 @@ fi
 
 
 # vg
+cd ${pangenomeBuildDir}
 wget -q https://github.com/vgteam/vg/releases/download/v1.31.0/vg
 chmod +x vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd vg | grep so | wc -l) -eq 0 ]]

--- a/preprocessor/cactus_softmask2hardmask.c
+++ b/preprocessor/cactus_softmask2hardmask.c
@@ -28,7 +28,7 @@ void usage() {
     fprintf(stderr, "-b --bed:         BED output of soft and hardmasked intervals\n");
 }
 
-static bed = false;
+static bool bed = false;
 
 static void hardmask(void* min_length_p, const char* name, const char* seq, int64_t length) {
     int64_t min_length = *(int64_t*)min_length_p;

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
                             'cactus-blast = cactus.blast.cactus_blast:main',
                             'cactus-refmap = cactus.refmap.cactus_refmap:main',
                             'cactus-graphmap = cactus.refmap.cactus_graphmap:main',
-                            'cactus-graphmap-split = cactus.refmap.cactus_graphmap_split:main',                            
+                            'cactus-graphmap-split = cactus.refmap.cactus_graphmap_split:main',
+                            'cactus-graphmap-join = cactus.refmap.cactus_graphmap_join:main',
                             'cactus-align = cactus.setup.cactus_align:main',
                             'cactus-align-batch = cactus.setup.cactus_align:main_batch']},)

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -24,8 +24,7 @@
 	<!-- unmask: unmask all softmasked bases before running (so only intervals masked by dna-brnn are present at end) -->
 	<!-- action: one of [softmask, hardmask, clip] -->
 	<!-- minLength: only mask intervals > than this length -->
-	<!-- mergeLength: merge up consecutive intervals if they are <= this far apart -->
-	<preprocessor unmask="1" memory="littleMemory" preprocessJob="dna-brnn" dna-brnnOpts='-A' active="0" action="softmask" cpu="2" minLength="100000" mergeLength="100000"/>
+	<preprocessor unmask="1" memory="littleMemory" preprocessJob="dna-brnn" dna-brnnOpts='-A' active="0" action="softmask" cpu="2" minLength="100000"/>
         <!-- Options for trimming ingroups & outgroups using the trim strategy -->
         <!-- Ingroup trim options: -->
         <!-- trimFlanking: The length of flanking sequence to attach

--- a/src/cactus/preprocessor/cactus_preprocessor.py
+++ b/src/cactus/preprocessor/cactus_preprocessor.py
@@ -500,7 +500,7 @@ def main():
 
     assert outSeqPaths
 
-    if options.ignore:
+    if options.ignore and inNames:
         for ignore_event in options.ignore:
             if ignore_event in inNames:
                 del inNames[inNames.index(ignore_event)]

--- a/src/cactus/preprocessor/cactus_preprocessor.py
+++ b/src/cactus/preprocessor/cactus_preprocessor.py
@@ -38,15 +38,16 @@ from cactus.shared.common import cactus_override_toil_options
 from cactus.preprocessor.checkUniqueHeaders import checkUniqueHeaders
 from cactus.preprocessor.lastzRepeatMasking.cactus_lastzRepeatMask import LastzRepeatMaskJob
 from cactus.preprocessor.lastzRepeatMasking.cactus_lastzRepeatMask import RepeatMaskOptions
-from cactus.preprocessor.dnabrnnMasking import DnabrnnMaskJob, loadDnaBrnnModel, computePAFCoverage
+from cactus.preprocessor.dnabrnnMasking import DnabrnnMaskJob, loadDnaBrnnModel
 from cactus.preprocessor.cutHeaders import CutHeadersJob
+from cactus.preprocessor.fileMasking import maskJobOverride, FileMaskingJob
 
 class PreprocessorOptions:
     def __init__(self, chunkSize, memory, cpu, check, proportionToSample, unmask,
                  preprocessJob, checkAssemblyHub=None, lastzOptions=None, minPeriod=None,
-                 gpuLastz=False, dnabrnnOpts=None, dnabrnnLength=None, dnabrnnMerge=None,
-                 dnabrnnAction=None, dnabrnnInputBedID=None, dnabrnnEventName=None,
-                 cutBefore=None, cutAfter=None):
+                 gpuLastz=False, dnabrnnOpts=None,
+                 dnabrnnAction=None, eventName=None, minLength=None,
+                 cutBefore=None, cutAfter=None, inputBedID=None):
         self.chunkSize = chunkSize
         self.memory = memory
         self.cpu = cpu
@@ -62,14 +63,13 @@ class PreprocessorOptions:
         if self.gpuLastz:
             self.chunkSize = 0
         self.dnabrnnOpts = dnabrnnOpts
-        self.dnabrnnLength = dnabrnnLength
-        self.dnabrnnMerge = dnabrnnMerge
         self.dnabrnnAction = dnabrnnAction
         assert dnabrnnAction in ('softmask', 'hardmask', 'clip')
-        self.dnabrnnInputBedID = dnabrnnInputBedID
-        self.dnabrnnEventName = dnabrnnEventName
+        self.eventName = eventName
+        self.minLength = minLength        
         self.cutBefore = cutBefore
         self.cutAfter = cutAfter
+        self.inputBedID = inputBedID
 
 class CheckUniqueHeaders(RoundedJob):
     """
@@ -148,16 +148,18 @@ class PreprocessSequence(RoundedJob):
         elif self.prepOptions.preprocessJob == "dna-brnn":
             return DnabrnnMaskJob(inChunkID,
                                   dnabrnnOpts=self.prepOptions.dnabrnnOpts,
-                                  minLength=self.prepOptions.dnabrnnLength,
-                                  mergeLength=self.prepOptions.dnabrnnMerge,
+                                  minLength=self.prepOptions.minLength,
                                   action=self.prepOptions.dnabrnnAction,
-                                  inputBedID=self.prepOptions.dnabrnnInputBedID,
-                                  eventName=self.prepOptions.dnabrnnEventName,
+                                  eventName=self.prepOptions.eventName,
                                   cpu=self.prepOptions.cpu)
         elif self.prepOptions.preprocessJob == "cutHeaders":
             return CutHeadersJob(inChunkID,
                                  cutBefore=self.prepOptions.cutBefore,
                                  cutAfter=self.prepOptions.cutAfter)
+        elif self.prepOptions.preprocessJob == 'maskFile':
+            return FileMaskingJob(inChunkID,
+                                  inputBedID=self.prepOptions.inputBedID,
+                                  eventName=self.prepOptions.eventName)
         else:
             raise RuntimeError("Unknown preprocess job %s" % self.prepOptions.preprocessJob)
 
@@ -246,13 +248,12 @@ class BatchPreprocessor(RoundedJob):
                                               checkAssemblyHub = getOptionalAttrib(prepNode, "checkAssemblyHub", typeFn=bool, default=False),
                                               gpuLastz = getOptionalAttrib(prepNode, "gpuLastz", typeFn=bool, default=False),
                                               dnabrnnOpts = getOptionalAttrib(prepNode, "dna-brnnOpts", default=""),
-                                              dnabrnnLength = getOptionalAttrib(prepNode, "minLength", typeFn=int, default=1),
-                                              dnabrnnMerge = getOptionalAttrib(prepNode, "mergeLength", typeFn=int, default=0),
                                               dnabrnnAction = getOptionalAttrib(prepNode, "action", typeFn=str, default="softmask"),
-                                              dnabrnnInputBedID = getOptionalAttrib(prepNode, "inputBedID", typeFn=str, default=None),
-                                              dnabrnnEventName = getOptionalAttrib(prepNode, "eventName", typeFn=str, default=None),
+                                              eventName = getOptionalAttrib(prepNode, "eventName", typeFn=str, default=None),
+                                              minLength = getOptionalAttrib(prepNode, "minLength", typeFn=int, default=1),
                                               cutBefore = getOptionalAttrib(prepNode, "cutBefore", typeFn=str, default=None),
-                                              cutAfter = getOptionalAttrib(prepNode, "cutAfter", typeFn=str, default=None))
+                                              cutAfter = getOptionalAttrib(prepNode, "cutAfter", typeFn=str, default=None),
+                                              inputBedID = getOptionalAttrib(prepNode, "inputBedID", typeFn=str, default=None))
 
             if prepOptions.unmask:
                 inSequence = fileStore.readGlobalFile(self.inSequenceID)
@@ -295,8 +296,7 @@ class CactusPreprocessor(RoundedJob):
             for eventName in self.eventNames:
                 conf = copy.deepcopy(self.configNode)
                 for node in conf.findall("preprocessor"):
-                    if getOptionalAttrib(node, "preprocessJob") == 'dna-brnn':
-                        node.attrib["eventName"] = eventName
+                    node.attrib["eventName"] = eventName
                 # if we don't make different configs, the same reference somehow gets passed to mulitple childs below
                 configs.append(conf)
 
@@ -328,8 +328,9 @@ class CactusPreprocessor2(RoundedJob):
             logger.info("Adding child batch_preprocessor target")
             return self.addChild(BatchPreprocessor(prepXmlElems, self.inputSequenceID, 0)).rv()
 
-def stageWorkflow(outputSequenceDir, configFile, inputSequences, toil, restart=False, outputSequences = [], maskAlpha=False, clipAlpha=None,
-                  maskPAF=None, inputEventNames=None, brnnCores=None):
+def stageWorkflow(outputSequenceDir, configFile, inputSequences, toil, restart=False,
+                  outputSequences = [], maskAlpha=False, clipAlpha=None,
+                  maskFile=None, minLength=None, inputEventNames=None, brnnCores=None):
     #Replace any constants
     configNode = ET.parse(configFile).getroot()
     if not outputSequences:
@@ -353,36 +354,37 @@ def stageWorkflow(outputSequenceDir, configFile, inputSequences, toil, restart=F
         for node in configNode.findall("preprocessor"):
             if getOptionalAttrib(node, "preprocessJob") == 'dna-brnn':
                 node.attrib["cpu"] = brnnCores
-        
+    if minLength is not None:
+        for node in configNode.findall("preprocessor"):
+            node.attrib["minLength"] = minLength
     if not restart:
         inputSequenceIDs = []
         for seq in inputSequences:
             logger.info("Importing {}".format(seq))
             inputSequenceIDs.append(toil.importFile(makeURL(seq)))
-        if maskPAF:
-            inputPAFID = toil.importFile(makeURL(maskPAF))
-        else:
-            inputPAFID = None
-        unzip_job = Job.wrapJobFn(unzip_then_pp, configNode, inputSequences, inputSequenceIDs, inputEventNames, maskPAF, inputPAFID)
+        maskFileID = toil.importFile(makeURL(maskFile)) if maskFile else None
+        unzip_job = Job.wrapJobFn(unzip_then_pp, configNode, inputSequences, inputSequenceIDs, inputEventNames,
+                                  maskFile, maskFileID, minLength)
         outputSequenceIDs = toil.start(unzip_job)
     else:
         outputSequenceIDs = toil.restart()
     for seqID, path in zip(outputSequenceIDs, outputSequences):
         try:
             iter(seqID)
-            # dna-brnn will output a couple of bed files.  we scrape those out here
+            # dna-brnn and maskFile will output a couple of bed files.  we scrape those out here
             toil.exportFile(seqID[0], makeURL(path))
             toil.exportFile(seqID[1], makeURL(path) + '.bed')
             toil.exportFile(seqID[2], makeURL(path) + '.mask.bed')
         except:
             toil.exportFile(seqID, makeURL(path))
 
-def unzip_then_pp(job, config_node, input_fa_paths, input_fa_ids, input_event_names, input_paf_path, input_paf_id):
+def unzip_then_pp(job, config_node, input_fa_paths, input_fa_ids, input_event_names, mask_file_path, mask_file_id, min_length):
     """ unzip then preprocess """
     unzip_job = job.addChildJobFn(unzip_gzs, input_fa_paths, input_fa_ids)
-    if input_paf_id is not None:
-        paf_unzip_job = unzip_job.addChildJobFn(unzip_gzs, [input_paf_path], [input_paf_id])
-        config_node = paf_unzip_job.addFollowOnJobFn(computePAFCoverage, config_node, paf_unzip_job.rv(0), disk=input_paf_id.size*20).rv()
+    if mask_file_id is not None:
+        mask_unzip_job = unzip_job.addChildJobFn(unzip_gzs, [mask_file_path], [mask_file_id])
+        config_node = mask_unzip_job.addFollowOnJobFn(maskJobOverride, config_node, mask_file_path, mask_unzip_job.rv(0), min_length,
+                                                      disk=mask_file_id.size*20).rv()
     pp_job = unzip_job.addFollowOn(CactusPreprocessor([unzip_job.rv(i) for i in range(len(input_fa_ids))], config_node, input_event_names))
     zip_job = pp_job.addFollowOnJobFn(zip_gzs, input_fa_paths,  pp_job.rv(), list_elems = [0])
     return zip_job.rv()
@@ -406,7 +408,8 @@ def main():
     parser.add_argument("--maskAlpha", action='store_true', help='Use dna-brnn instead of lastz for repeatmasking')
     parser.add_argument("--clipAlpha", action='store_true', help='use dna-brnn instead of lastz for repeatmasking.  Also, clip sequence using given minimum length instead of softmasking')
     parser.add_argument("--ignore", nargs='*', help='Space-separate list of genomes from inSeqFile to ignore', default=[])
-    parser.add_argument("--maskPAF", type=str, help='Incorporate coverage gaps from given PAF when masking.  Only implemented for dna-brnn masking')
+    parser.add_argument("--maskFile", type=str, help='Add masking from BED or PAF file to sequences, ignoring all other preprocessors')
+    parser.add_argument("--minLength", type=int, help='Minimum interval threshold for masking.  Overrides config')
     parser.add_argument("--brnnCores", type=int, help='Specify number of cores for each dna-brnn job (overriding default value from the config)')
     parser.add_argument("--latest", dest="latest", action="store_true",
                         help="Use the latest version of the docker container "
@@ -440,16 +443,14 @@ def main():
         raise RuntimeError('--maskAlpha and --clipAlpha cannot be used together')
     if options.clipAlpha:
         options.maskAlpha = True
-    if options.maskPAF and not options.inputNames and not options.inSeqFile:
-        raise RuntimeError('--maskPAF requires event names specified wither with an input seqfile or with --inputNames')
     if options.ignore and options.clipAlpha is None:
         raise RuntimeError('--ignore can only be used with --clipAlpha')
-
+    if options.maskFile and options.maskFile.endswith('.paf') and not options.inputNames and not options.inSeqFile:
+        raise RuntimeError('paf masking requires event names specified wither with an input seqfile or with --inputNames')
     
     inSeqPaths = []
     outSeqPaths = []
     inNames = options.inputNames
-    eventNames = []
 
     #load cactus config
     configNode = ET.parse(options.configFile).getroot()
@@ -486,7 +487,6 @@ def main():
             else:
                 inSeqPaths += [inPath]
                 outSeqPaths += [outPath]
-            eventNames.append(inName)
 
         if options.ignore:
             # see comment above
@@ -507,8 +507,9 @@ def main():
                       outputSequences=outSeqPaths,
                       maskAlpha=options.maskAlpha,
                       clipAlpha=options.clipAlpha,
-                      maskPAF=options.maskPAF,
-                      inputEventNames=eventNames,
+                      maskFile=options.maskFile,
+                      minLength=options.minLength,
+                      inputEventNames=inNames,
                       brnnCores=options.brnnCores)
 
 if __name__ == '__main__':

--- a/src/cactus/preprocessor/cactus_preprocessor.py
+++ b/src/cactus/preprocessor/cactus_preprocessor.py
@@ -159,7 +159,8 @@ class PreprocessSequence(RoundedJob):
         elif self.prepOptions.preprocessJob == 'maskFile':
             return FileMaskingJob(inChunkID,
                                   inputBedID=self.prepOptions.inputBedID,
-                                  eventName=self.prepOptions.eventName)
+                                  eventName=self.prepOptions.eventName,
+                                  minLength=self.prepOptions.minLength)
         else:
             raise RuntimeError("Unknown preprocess job %s" % self.prepOptions.preprocessJob)
 

--- a/src/cactus/preprocessor/cactus_preprocessor.py
+++ b/src/cactus/preprocessor/cactus_preprocessor.py
@@ -498,6 +498,13 @@ def main():
         inSeqPaths = options.inPaths
         outSeqPaths = options.outPaths
 
+    assert outSeqPaths
+
+    if options.ignore:
+        for ignore_event in options.ignore:
+            if ignore_event in inNames:
+                del inNames[inNames.index(ignore_event)]
+
     with Toil(options) as toil:
         stageWorkflow(outputSequenceDir=None,
                       configFile=options.configFile,

--- a/src/cactus/preprocessor/fileMasking.py
+++ b/src/cactus/preprocessor/fileMasking.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Pass through an input BED (or PAF) file and mask directly with that, bypassing all usual
+preprocessor functionality.  It's a bit ugly, but currently needed to the pangenome pipeline
+in order to mask coverage gaps (todo: clipping them in the PAF itself would be much cleaner)
+"""
+
+import os
+import re
+import sys
+import shutil
+import xml.etree.ElementTree as ET
+from toil.lib.threading import cpu_count
+
+from Bio import SeqIO
+from Bio.SeqRecord import SeqRecord
+
+from sonLib.bioio import catFiles
+
+from cactus.shared.common import cactus_call
+from cactus.shared.common import RoundedJob
+from cactus.shared.common import getOptionalAttrib
+from cactus.shared.common import makeURL
+
+from toil.realtimeLogger import RealtimeLogger
+
+class FileMaskingJob(RoundedJob):
+    def __init__(self, fastaID, inputBedID=None, eventName=None, minLength=None):
+        disk = 2*(fastaID.size)
+        RoundedJob.__init__(self, disk=disk, preemptable=True)
+        self.fastaID = fastaID
+        self.minLength = minLength
+        self.inputBedID = inputBedID
+        self.eventName = eventName
+
+    def run(self, fileStore):
+        """
+        extract any existing masking, merge it with the input bed, then apply it to the fasta
+        """
+        work_dir = fileStore.getLocalTempDir()
+        fastaFile = os.path.join(work_dir, 'seq.fa')
+        fileStore.readGlobalFile(self.fastaID, fastaFile)
+
+        # download the input bed (which we'll merge in with the bed we compute here)
+        inputBedFile = os.path.join(work_dir, 'input-regions.bed')
+        fileStore.readGlobalFile(self.inputBedID, inputBedFile)
+
+        if self.minLength is None:
+            self.minLength = 0
+
+        RealtimeLogger.info("RUN FILE MASK WITH fastaId={} minLength={} bed={} event={}".format(
+            self.fastaID, self.minLength, self.inputBedID, self.eventName))
+
+        # extract the existing masked regions to merge in
+        bedFile = get_mask_bed_from_fasta(self, self.eventName, None, fastaFile, self.minLength, work_dir)
+
+        # load the fasta sequence information (needed for below clipping and/or bed merging)
+        cactus_call(parameters=['samtools', 'faidx', fastaFile])
+        # load the contig lengths
+        contig_lengths = {}
+        with open(fastaFile + '.fai', 'r') as fai:
+            for line in fai:
+                toks = line.strip().split('\t')
+                contig_lengths[toks[0]] = int(toks[1])
+
+        # merge in the input bed file
+        if inputBedFile:
+            input_line_count = 0
+            with open(inputBedFile, 'r') as inputBedStream, open(bedFile, 'a') as bedStream:
+                if self.eventName:
+                    eventPrefix = 'id={}|'.format(self.eventName)
+                else:
+                    eventPrefix = ''
+                for line in inputBedStream:
+                    toks = line.split('\t')
+                    if toks:
+                        # our PAF file probably has prefixes like id=EVENT| which won't match up to the fasta
+                        # so we strip here:
+                        from_event = toks[0].startswith(eventPrefix)
+                        if from_event:
+                            toks[0] = toks[0][len(eventPrefix):]
+                        # we may have given a whole-genome paf, so filter down our bed to the
+                        # relevant contigs for this fasta (won't change masking output, but bed output will be cleaner)
+                        if toks[0] in contig_lengths:
+                            assert from_event
+                            bedStream.write('\t'.join(toks))
+                            input_line_count += 1
+            RealtimeLogger.info("Merged in {} bed lines from input bed file for eventPrefix=\"{}\"".format(input_line_count, eventPrefix))
+                            
+        # merge up the intervals into a new bed file
+        mergedBedFile = os.path.join(work_dir, 'filtered.bed')
+        merge_cmd = []
+        merge_cmd.append(['awk', '{{if($3-$2 > {}) print}}'.format(self.minLength), bedFile])
+        merge_cmd.append(['bedtools', 'sort', '-i', '-'])
+        merge_cmd.append(['bedtools', 'merge', '-i', '-', '-d', str(self.minLength)])
+        if self.eventName:
+            merge_cmd.append(['sed', '-e', 's/id={}|//g'.format(self.eventName)])
+        cactus_call(outfile=mergedBedFile, parameters=merge_cmd)
+
+        maskedFile = os.path.join(work_dir, 'masked.fa')
+        
+        mask_cmd = ['cactus_fasta_softmask_intervals.py', '--origin=zero', mergedBedFile]
+        if self.minLength:
+            mask_cmd += ['--minLength={}'.format(self.minLength)]
+        # do the softmasking
+        cactus_call(infile=fastaFile, outfile=maskedFile, parameters=mask_cmd)
+        
+        return fileStore.writeGlobalFile(maskedFile), fileStore.writeGlobalFile(bedFile), fileStore.writeGlobalFile(mergedBedFile)
+
+
+def maskJobOverride(job, config_node, mask_file_path, mask_file_id, min_length):
+    """ return a hijacked config file that does just one preprocessing job: mask each fasta sequence with 
+    the given bed file.  if paf_length is specified, the file is treated as a PAF file, and a BED is extracted
+    from it using coverage gaps of at least the given length. 
+    """
+    # this was unzipped upstream
+    if mask_file_path.endswith('.gz'):
+        mask_file_path = mask_file_path[:-3]
+        
+    if mask_file_path.endswith('.paf'):
+        # convert the PAF to BED
+        paf_file = job.fileStore.readGlobalFile(mask_file_id)
+        bed_file = job.fileStore.getLocalTempFile()
+
+        if not min_length:
+            min_length = 1
+
+        cactus_call(parameters=['pafcoverage', paf_file, '-g', '-m', str(min_length)], outfile=bed_file)
+
+        mask_file_id = job.fileStore.writeGlobalFile(bed_file)
+
+    # rewrite the config
+    for node in config_node.findall("preprocessor"):
+        config_node.remove(node)
+        
+    mask_node = ET.SubElement(config_node, 'preprocessor')
+    mask_node.attrib['preprocessJob'] = 'maskFile'
+    mask_node.attrib['inputBedID'] = mask_file_id
+
+    return config_node
+
+def get_mask_bed_from_fasta(job, event, fa_id, fa_path, min_length, work_dir = None):
+    """ make a bed file from one fasta"""
+    return_id = False # hack in a toggle (work_dir) that lets this be called as a job or a function
+    if not work_dir:
+        work_dir = job.fileStore.getLocalTempDir()
+        return_id = True
+    bed_path = os.path.join(work_dir, os.path.basename(fa_path) + '.mask.bed')
+    fa_path = os.path.join(work_dir, os.path.basename(fa_path))
+    is_gz = fa_path.endswith(".gz")
+    if return_id:
+        job.fileStore.readGlobalFile(fa_id, fa_path, mutable=is_gz)
+    if is_gz:
+        cactus_call(parameters=['gzip', '-fd', fa_path])
+        fa_path = fa_path[:-3]
+    with open(bed_path, 'w') as bed_file, open(fa_path, 'r') as fa_file:
+        for seq_record in SeqIO.parse(fa_file, 'fasta'):
+            first_mask = None
+            for i, c in enumerate(seq_record.seq):
+                is_mask = c.islower() or c in ['n', 'N']
+                if (is_mask is False or i == len(seq_record.seq) - 1) and first_mask is not None and i - first_mask >= min_length:
+                    # we're one past an interval: write it
+                    bed_end = i + 1 if is_mask else i
+                    bed_file.write('{}\t{}\t{}\n'.format('id={}|{}'.format(event, seq_record.id), first_mask, bed_end))
+                    first_mask = None
+                elif is_mask is True and first_mask is None:
+                    # we're starting a new interval: remember start position
+                    first_mask = i
+    if return_id:
+        return job.fileStore.writeGlobalFile(bed_path)
+    else:
+        return bed_path

--- a/src/cactus/preprocessor/fileMasking.py
+++ b/src/cactus/preprocessor/fileMasking.py
@@ -26,7 +26,8 @@ from toil.realtimeLogger import RealtimeLogger
 class FileMaskingJob(RoundedJob):
     def __init__(self, fastaID, inputBedID=None, eventName=None, minLength=None):
         disk = 2*(fastaID.size)
-        RoundedJob.__init__(self, disk=disk, preemptable=True)
+        memory = fastaID.size
+        RoundedJob.__init__(self, disk=disk, memory=memory, preemptable=True)
         self.fastaID = fastaID
         self.minLength = minLength
         self.inputBedID = inputBedID

--- a/src/cactus/preprocessor/fileMasking.py
+++ b/src/cactus/preprocessor/fileMasking.py
@@ -91,6 +91,7 @@ class FileMaskingJob(RoundedJob):
         merge_cmd = []
         merge_cmd.append(['awk', '{{if($3-$2 > {}) print}}'.format(self.minLength), bedFile])
         merge_cmd.append(['bedtools', 'sort', '-i', '-'])
+        merge_cmd.append(['awk', '{print $1\"\\t\"$2\"\\t\"$3}'])
         merge_cmd.append(['bedtools', 'merge', '-i', '-', '-d', str(self.minLength)])
         if self.eventName:
             merge_cmd.append(['sed', '-e', 's/id={}|//g'.format(self.eventName)])
@@ -155,6 +156,7 @@ def get_mask_bed_from_fasta(job, event, fa_id, fa_path, min_length, work_dir = N
     with open(bed_path, 'w') as bed_file, open(fa_path, 'r') as fa_file:
         for seq_record in SeqIO.parse(fa_file, 'fasta'):
             first_mask = None
+            # todo: this is way too slow.  should be done in C
             for i, c in enumerate(seq_record.seq):
                 is_mask = c.islower() or c in ['n', 'N']
                 if (is_mask is False or i == len(seq_record.seq) - 1) and first_mask is not None and i - first_mask >= min_length:

--- a/src/cactus/preprocessor/fileMasking.py
+++ b/src/cactus/preprocessor/fileMasking.py
@@ -47,9 +47,6 @@ class FileMaskingJob(RoundedJob):
         if self.minLength is None:
             self.minLength = 0
 
-        RealtimeLogger.info("RUN FILE MASK WITH fastaId={} minLength={} bed={} event={}".format(
-            self.fastaID, self.minLength, self.inputBedID, self.eventName))
-
         # extract the existing masked regions to merge in
         bedFile = get_mask_bed_from_fasta(self, self.eventName, None, fastaFile, self.minLength, work_dir)
 
@@ -89,9 +86,8 @@ class FileMaskingJob(RoundedJob):
         # merge up the intervals into a new bed file
         mergedBedFile = os.path.join(work_dir, 'filtered.bed')
         merge_cmd = []
-        merge_cmd.append(['awk', '{{if($3-$2 > {}) print}}'.format(self.minLength), bedFile])
+        merge_cmd.append(['awk', '{{if($3-$2 > {}) print $1\"\\t\"$2\"\\t\"$3}}'.format(self.minLength), bedFile])
         merge_cmd.append(['bedtools', 'sort', '-i', '-'])
-        merge_cmd.append(['awk', '{print $1\"\\t\"$2\"\\t\"$3}'])
         merge_cmd.append(['bedtools', 'merge', '-i', '-', '-d', str(self.minLength)])
         if self.eventName:
             merge_cmd.append(['sed', '-e', 's/id={}|//g'.format(self.eventName)])

--- a/src/cactus/refmap/cactus_graphmap.py
+++ b/src/cactus/refmap/cactus_graphmap.py
@@ -255,7 +255,7 @@ def minigraph_map_all(job, config, gfa_id, fa_id_map, graph_event, keep_gaf):
 
     # convert to paf
     if paf_per_genome:
-        paf_job = top_job.addFollowOnJobFn(merge_pafs, paf_id_map)
+        paf_job = top_job.addFollowOnJobFn(merge_pafs, paf_id_map, disk=sum([pi for pi in paf_id_map.values()]))
     else:
         paf_job = top_job.addFollowOnJobFn(merge_gafs_into_paf, config, gaf_id_map)
 

--- a/src/cactus/refmap/cactus_graphmap.py
+++ b/src/cactus/refmap/cactus_graphmap.py
@@ -255,7 +255,7 @@ def minigraph_map_all(job, config, gfa_id, fa_id_map, graph_event, keep_gaf):
 
     # convert to paf
     if paf_per_genome:
-        paf_job = top_job.addFollowOnJobFn(merge_pafs, paf_id_map, disk=sum([pi for pi in paf_id_map.values()]))
+        paf_job = top_job.addFollowOnJobFn(merge_pafs, paf_id_map)
     else:
         paf_job = top_job.addFollowOnJobFn(merge_gafs_into_paf, config, gaf_id_map)
 

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -33,8 +33,6 @@ from cactus.progressive.multiCactusTree import MultiCactusTree
 from cactus.shared.common import setupBinaries, importSingularityImage
 from cactus.progressive.multiCactusProject import MultiCactusProject
 from cactus.shared.experimentWrapper import ExperimentWrapper
-from cactus.progressive.schedule import Schedule
-from cactus.progressive.projectWrapper import ProjectWrapper
 from cactus.shared.common import cactusRootPath
 from cactus.shared.configWrapper import ConfigWrapper
 from cactus.pipeline.cactus_workflow import CactusWorkflowArguments
@@ -178,6 +176,9 @@ def clip_vg(job, options, config, vg_path, vg_id):
         
     cactus_call(parameters=cmd, outfile=out_path)
 
+    # worth it
+    cactus_call(parameters=['vg', 'validate', out_path])
+
     return job.fileStore.writeGlobalFile(out_path)
 
 def join_vg(job, options, config, clipped_vg_ids):
@@ -239,6 +240,9 @@ def vg_indexes(job, options, config, gfa_ids):
     # make the xg
     xg_path = os.path.join(work_dir, 'merged.xg')
     cactus_call(parameters=['vg', 'convert', gg_path, '-b', gbwt_path, '-x'], outfile=xg_path)
+
+    # worth it
+    cactus_call(parameters=['vg', 'validate', xg_path])
 
     # make the snarls
     snarls_path = os.path.join(work_dir, 'merged.snarls')

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -232,6 +232,10 @@ def vg_indexes(job, options, config, gfa_ids):
     trans_path = os.path.join(work_dir, 'merged.trans')
     cactus_call(parameters=['vg', 'gbwt', '-G', merge_gfa_path, '-o', gbwt_path, '-g', gg_path, '--translation', trans_path])
 
+    # zip the gfa
+    cactus_call(parameters=['bgzip', merge_gfa_path])
+    gfa_path = merge_gfa_path + '.gz'
+
     # make the xg
     xg_path = os.path.join(work_dir, 'merged.xg')
     cactus_call(parameters=['vg', 'convert', gg_path, '-b', gbwt_path, '-x'], outfile=xg_path)
@@ -245,10 +249,6 @@ def vg_indexes(job, options, config, gfa_ids):
     cactus_call(parameters=[['vg', 'deconstruct', xg_path, '-r', snarls_path, '-g', gbwt_path, '-T', trans_path], ['bgzip']],
                 outfile=vcf_path)
     cactus_call(parameters=['tabix', '-p', 'vcf', vcf_path])
-
-    # zip the gfa
-    cactus_call(parameters=['bgzip', merge_gfa_path])
-    gfa_path = merge_gfa_path + '.gz'
                             
     return { 'gfa.gz' : job.fileStore.writeGlobalFile(gfa_path),
              'gbwt' : job.fileStore.writeGlobalFile(gbwt_path),

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+
+"""This script will take the output of cactus-align-batch (which was run on the output of cactus-graphmap-split).  This would be
+a set of .vg files, one for each chromosome.  It will do the following in order to make a single output graph
+- clip unmapped regions out of each graph
+- join the ids of the clipped graph
+- convert each clipped graph to gfa
+- merge the gfas into a whole-genome graph
+- convert the gfa into a gbwt/gbwt-graph pair
+- export the gbwt to xg
+- export the xg/gbwt to vcf
+
+so the final output will be
+- set of clipped vg graphs
+- graph.gfa.gz
+- graph.gbwt
+- graph.gg
+- graph.xg
+- graph.snarls
+- graph.vcf.gz
+- graph.vcf.gz.tbi
+"""
+import os
+from argparse import ArgumentParser
+import xml.etree.ElementTree as ET
+import copy
+import timeit
+
+from operator import itemgetter
+
+from cactus.progressive.seqFile import SeqFile
+from cactus.progressive.multiCactusTree import MultiCactusTree
+from cactus.shared.common import setupBinaries, importSingularityImage
+from cactus.progressive.multiCactusProject import MultiCactusProject
+from cactus.shared.experimentWrapper import ExperimentWrapper
+from cactus.progressive.schedule import Schedule
+from cactus.progressive.projectWrapper import ProjectWrapper
+from cactus.shared.common import cactusRootPath
+from cactus.shared.configWrapper import ConfigWrapper
+from cactus.pipeline.cactus_workflow import CactusWorkflowArguments
+from cactus.pipeline.cactus_workflow import addCactusWorkflowOptions
+from cactus.pipeline.cactus_workflow import CactusTrimmingBlastPhase
+from cactus.shared.common import makeURL, catFiles
+from cactus.shared.common import enableDumpStack
+from cactus.shared.common import cactus_override_toil_options
+from cactus.shared.common import cactus_call
+from cactus.shared.common import getOptionalAttrib, findRequiredNode
+from cactus.shared.common import unzip_gz, write_s3
+from cactus.preprocessor.fileMasking import get_mask_bed_from_fasta
+from toil.job import Job
+from toil.common import Toil
+from toil.lib.bioio import logger
+from toil.lib.bioio import setLoggingFromOptions
+from toil.realtimeLogger import RealtimeLogger
+from toil.lib.threading import cpu_count
+
+from sonLib.nxnewick import NXNewick
+from sonLib.bioio import getTempDirectory, getTempFile, catFiles
+
+def main():
+    parser = ArgumentParser()
+    Job.Runner.addToilOptions(parser)
+    addCactusWorkflowOptions(parser)
+
+    parser.add_argument("--vg", nargs='+',  help = "Input vg files")
+    parser.add_argument("--outDir", required=True, type=str, help = "Output directory")
+    parser.add_argument("--outName", required=True, type=str, help = "Basename of all output files")
+    parser.add_argument("--reference", required=True, type=str, help = "Reference event name")
+    parser.add_argument("--rename", nargs='+', default = [], help = "Path renaming, each of form src>dest (see clip-vg -r)")
+    parser.add_argument("--clipLength", type=int, default=0, help = "clip out unaligned sequences longer than this")
+    parser.add_argument("--wline-sep", type=str, help = "wline separator for vg convert")
+    
+    #Progressive Cactus Options
+    parser.add_argument("--configFile", dest="configFile",
+                        help="Specify cactus configuration file",
+                        default=os.path.join(cactusRootPath(), "cactus_progressive_config.xml"))
+    parser.add_argument("--latest", dest="latest", action="store_true",
+                        help="Use the latest version of the docker container "
+                        "rather than pulling one matching this version of cactus")
+    parser.add_argument("--containerImage", dest="containerImage", default=None,
+                        help="Use the the specified pre-built containter image "
+                        "rather than pulling one from quay.io")
+    parser.add_argument("--binariesMode", choices=["docker", "local", "singularity"],
+                        help="The way to run the Cactus binaries", default=None)
+
+    options = parser.parse_args()
+
+    setupBinaries(options)
+    setLoggingFromOptions(options)
+    enableDumpStack()
+
+    if options.outDir and not options.outDir.startswith('s3://'):
+        if not os.path.isdir(options.outDir):
+            os.makedirs(options.outDir)
+        
+    # Mess with some toil options to create useful defaults.
+    cactus_override_toil_options(options)
+
+    start_time = timeit.default_timer()
+    runCactusGraphMapJoin(options)
+    end_time = timeit.default_timer()
+    run_time = end_time - start_time
+    logger.info("cactus-graphmap-split has finished after {} seconds".format(run_time))
+
+def runCactusGraphMapJoin(options):
+    with Toil(options) as toil:
+        importSingularityImage(options)
+        #Run the workflow
+        if options.restart:
+            wf_output = toil.restart()
+        else:
+            options.cactusDir = getTempDirectory()
+
+            #load cactus config
+            configNode = ET.parse(options.configFile).getroot()
+            config = ConfigWrapper(configNode)
+            config.substituteAllPredefinedConstantsWithLiterals()
+
+            # load up the vgs
+            vg_ids = []
+            for vg_path in options.vg:
+                vg_ids.append(toil.importFile(makeURL(vg_path)))
+
+            # run the workflow
+            wf_output = toil.start(Job.wrapJobFn(graphmap_join_workflow, options, config, vg_ids))
+                
+        #export the split data
+        export_join_data(toil, options, wf_output[0], wf_output[1])
+
+def graphmap_join_workflow(job, options, config, vg_ids):
+
+    root_job = Job()
+    job.addChild(root_job)
+
+    # run clip-vg on each input
+    clipped_vg_ids = []
+    for vg_path, vg_id in zip(options.vg, vg_ids):
+        clip_job = root_job.addChildJobFn(clip_vg, options, config, vg_path, vg_id,
+                                          disk=vg_id.size * 2, memory=vg_id.size * 4)
+        clipped_vg_ids.append(clip_job.rv())
+
+    # join the ids
+    join_job = root_job.addFollowOnJobFn(join_vg, options, config, clipped_vg_ids,
+                                         disk=sum([f.size for f in vg_ids]))
+    clipped_vg_ids = join_job.rv()
+
+    # make a gfa for each
+    gfa_root_job = Job()
+    join_job.addFollowOn(gfa_root_job)
+    clipped_gfa_ids = []
+    for i in range(len(options.vg)):
+        vg_path = options.vg[i]
+        clipped_id = join_job.rv(i)
+        vg_id = vg_ids[i]
+        gfa_job = gfa_root_job.addChildJobFn(vg_to_gfa, options, config, vg_path, clipped_id,
+                                             disk=vg_id.size * 5)
+        clipped_gfa_ids.append(gfa_job.rv())
+
+    # merge up the gfas and make the various vg indexes
+    gfa_merge_job = gfa_root_job.addFollowOnJobFn(vg_indexes, options, config, clipped_gfa_ids,
+                                                  disk=sum(f.size for f in vg_ids) * 10)
+    
+    return clipped_vg_ids, gfa_merge_job.rv()
+
+def clip_vg(job, options, config, vg_path, vg_id):
+    """ run clip-vg 
+    """
+    work_dir = job.fileStore.getLocalTempDir()
+    vg_path = os.path.join(work_dir, os.path.basename(vg_path))
+    job.fileStore.readGlobalFile(vg_id, vg_path)
+    out_path = vg_path + '.clip'
+
+    cmd = ['clip-vg', vg_path, '-u', str(options.clipLength), '-f']
+    for rs in options.rename:
+        cmd += ['-r', rs]
+    if options.reference:
+        cmd += ['-e', options.reference]
+        
+    cactus_call(parameters=cmd, outfile=out_path)
+
+    return job.fileStore.writeGlobalFile(out_path)
+
+def join_vg(job, options, config, clipped_vg_ids):
+    """ run vg ids -j
+    """
+    work_dir = job.fileStore.getLocalTempDir()
+    vg_paths = []
+
+    for vg_path, vg_id in zip(options.vg, clipped_vg_ids):
+        vg_path = os.path.join(work_dir, os.path.basename(vg_path))
+        job.fileStore.readGlobalFile(vg_id, vg_path, mutable=True)
+        vg_paths.append(vg_path)
+        
+    cactus_call(parameters=['vg', 'ids', '-j'] + vg_paths)
+
+    return [job.fileStore.writeGlobalFile(f) for f in vg_paths]
+
+def vg_to_gfa(job, options, config, vg_path, vg_id):
+    """ run gfa conversion """
+    work_dir = job.fileStore.getLocalTempDir()
+    vg_path = os.path.join(work_dir, os.path.basename(vg_path))
+    job.fileStore.readGlobalFile(vg_id, vg_path)
+    out_path = vg_path + '.gfa'
+
+    cmd = ['vg', 'convert', '-f', '-Q', options.reference, vg_path, '-B']
+    if options.wline_sep:
+        cmd += ['-w', options.wline_sep]
+
+    cactus_call(parameters=cmd, outfile=out_path)
+
+    return job.fileStore.writeGlobalFile(out_path)
+
+def vg_indexes(job, options, config, gfa_ids):
+    """ merge of the gfas, then make gbwt / xg / snarls / vcf 
+    """ 
+    work_dir = job.fileStore.getLocalTempDir()
+    vg_paths = []
+    merge_gfa_path = os.path.join(work_dir, 'merged.gfa')
+    with open(merge_gfa_path, 'w') as merge_gfa_file:
+        merge_gfa_file.write('H\tVN:Z:1.0\n')
+
+    # merge the gfas
+    for vg_path, gfa_id in zip(options.vg, gfa_ids):
+        gfa_path = os.path.join(work_dir, os.path.basename(vg_path) +  '.gfa')
+        job.fileStore.readGlobalFile(gfa_id, gfa_path, mutable=True)
+        cactus_call(parameters=['grep', '-v', '^H', gfa_path], outfile=merge_gfa_path, outappend=True)
+        os.remove(gfa_path)
+
+    # make the gbwt
+    gbwt_path = os.path.join(work_dir, 'merged.gbwt')
+    gg_path = os.path.join(work_dir, 'merged.gg')
+    trans_path = os.path.join(work_dir, 'merged.trans')
+    cactus_call(parameters=['vg', 'gbwt', '-G', merge_gfa_path, '-o', gbwt_path, '-g', gg_path, '--translation', trans_path])
+
+    # make the xg
+    xg_path = os.path.join(work_dir, 'merged.xg')
+    cactus_call(parameters=['vg', 'convert', gg_path, '-b', gbwt_path, '-x'], outfile=xg_path)
+
+    # make the snarls
+    snarls_path = os.path.join(work_dir, 'merged.snarls')
+    cactus_call(parameters=['vg', 'snarls', xg_path], outfile=snarls_path)
+
+    # make the vcf
+    vcf_path = os.path.join(work_dir, 'merged.vcf.gz')
+    cactus_call(parameters=[['vg', 'deconstruct', xg_path, '-r', snarls_path, '-g', gbwt_path, '-T', trans_path], ['bgzip']],
+                outfile=vcf_path)
+    cactus_call(parameters=['tabix', '-p', 'vcf', vcf_path])
+
+    # zip the gfa
+    cactus_call(parameters=['bgzip', merge_gfa_path])
+    gfa_path = merge_gfa_path + '.gz'
+                            
+    return { 'gfa.gz' : job.fileStore.writeGlobalFile(gfa_path),
+             'gbwt' : job.fileStore.writeGlobalFile(gbwt_path),
+             'gg' : job.fileStore.writeGlobalFile(gg_path),
+             'trans' : job.fileStore.writeGlobalFile(trans_path),
+             'xg' : job.fileStore.writeGlobalFile(xg_path),
+             'snarls' : job.fileStore.writeGlobalFile(snarls_path),
+             'vcf.gz' : job.fileStore.writeGlobalFile(vcf_path),
+             'tbi' : job.fileStore.writeGlobalFile(vcf_path + '.tbi') }
+
+def export_join_data(toil, options, clip_ids, idx_map):
+    """ download all the output data
+    """
+
+    # download the clip vgs
+    clip_base = os.path.join(options.outDir, 'clip')
+    if not clip_base.startswith('s3://'):
+        os.makedirs(clip_base)
+
+    for vg_path, vg_id in zip(options.vg, clip_ids):
+        toil.exportFile(vg_id, makeURL(os.path.join(clip_base, os.path.basename(vg_path))))
+
+    # download everything else
+    for ext, idx_id in idx_map.items():
+        toil.exportFile(idx_id, makeURL(os.path.join(options.outDir, '{}.{}'.format(options.outName, ext))))
+    
+        
+if __name__ == "__main__":
+    main()

--- a/src/cactus/refmap/cactus_graphmap_split.py
+++ b/src/cactus/refmap/cactus_graphmap_split.py
@@ -91,7 +91,7 @@ def runCactusGraphMapSplit(options):
         importSingularityImage(options)
         #Run the workflow
         if options.restart:
-            split_id_map = toil.restart()
+            wf_output = toil.restart()
         else:
             options.cactusDir = getTempDirectory()
 

--- a/src/cactus/refmap/cactus_graphmap_split.py
+++ b/src/cactus/refmap/cactus_graphmap_split.py
@@ -10,9 +10,6 @@ import timeit
 
 from operator import itemgetter
 
-from Bio import SeqIO
-from Bio.SeqRecord import SeqRecord
-
 from cactus.progressive.seqFile import SeqFile
 from cactus.progressive.multiCactusTree import MultiCactusTree
 from cactus.shared.common import setupBinaries, importSingularityImage
@@ -31,6 +28,7 @@ from cactus.shared.common import cactus_override_toil_options
 from cactus.shared.common import cactus_call
 from cactus.shared.common import getOptionalAttrib, findRequiredNode
 from cactus.shared.common import unzip_gz, write_s3
+from cactus.preprocessor.fileMasking import get_mask_bed_from_fasta
 from toil.job import Job
 from toil.common import Toil
 from toil.lib.bioio import logger
@@ -215,30 +213,6 @@ def get_mask_bed(job, seq_id_map, min_length):
         fa_path, fa_id = seq_id_map[event]
         beds.append(job.addChildJobFn(get_mask_bed_from_fasta, event, fa_id, fa_path, min_length, disk=fa_id.size * 5).rv())
     return job.addFollowOnJobFn(cat_beds, beds).rv()
-
-def get_mask_bed_from_fasta(job, event, fa_id, fa_path, min_length):
-    """ make a bed file from one fasta"""
-    work_dir = job.fileStore.getLocalTempDir()    
-    bed_path = os.path.join(work_dir, os.path.basename(fa_path) + '.mask.bed')
-    fa_path = os.path.join(work_dir, os.path.basename(fa_path))
-    is_gz = fa_path.endswith(".gz")
-    job.fileStore.readGlobalFile(fa_id, fa_path, mutable=is_gz)
-    if is_gz:
-        cactus_call(parameters=['gzip', '-fd', fa_path])
-        fa_path = fa_path[:-3]
-    with open(bed_path, 'w') as bed_file, open(fa_path, 'r') as fa_file:
-        for seq_record in SeqIO.parse(fa_file, 'fasta'):
-            first_mask = None
-            for i, c in enumerate(seq_record.seq):
-                is_mask = c.islower() or c in ['n', 'N']
-                if (is_mask is False or i == len(seq_record.seq) - 1) and first_mask is not None and i - first_mask >= min_length:
-                    # we're one past an interval: write it
-                    bed_file.write('{}\t{}\t{}\n'.format('id={}|{}'.format(event, seq_record.id), first_mask, i))
-                    first_mask = None
-                elif is_mask is True and first_mask is None:
-                    # we're starting a new interval: remember start position
-                    first_mask = i
-    return job.fileStore.writeGlobalFile(bed_path)
 
 def cat_beds(job, bed_ids):
     in_beds = [job.fileStore.readGlobalFile(bed_id) for bed_id in bed_ids]


### PR DESCRIPTION
In the pangenome pipeline, I want to (at least for now) mask out centromeres using both dna-brnn, as well as gaps in the minigraph minimizers.  Unfortunately, the sequences softmasked by both approaches requires running the preprocessor (or mapping) twice.  This PR adds the `--maskFile` option that allows something like:
* preprocess with dna-brnn
* map with graphmap
* preprocess with paf from graphmap to add in gaps

The alternative is
* map with graphmap
* preprocess with dna-brnn and paf
* map with graphmap again (to make sure no dna-brnn'd regions in paf)

Both ways are ugly, but I like the first one a little more as it means less dna-brnning over repeated runs.  

I think bar can deal directly with minimizer gaps (as opposed to needing masked sequence) just be using the max-length cutoff.  But I worry that things pulled apart by caf can confound this a little, so am using the sequences to be sure for now. 