### PR TITLE
cactus-graphmap-join cleanup

### DIFF
--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -60,7 +60,7 @@ def main():
     Job.Runner.addToilOptions(parser)
     addCactusWorkflowOptions(parser)
 
-    parser.add_argument("--vg", nargs='+',  help = "Input vg files")
+    parser.add_argument("--vg", required=True, nargs='+',  help = "Input vg files")
     parser.add_argument("--outDir", required=True, type=str, help = "Output directory")
     parser.add_argument("--outName", required=True, type=str, help = "Basename of all output files")
     parser.add_argument("--reference", required=True, type=str, help = "Reference event name")
@@ -98,7 +98,7 @@ def main():
     runCactusGraphMapJoin(options)
     end_time = timeit.default_timer()
     run_time = end_time - start_time
-    logger.info("cactus-graphmap-split has finished after {} seconds".format(run_time))
+    logger.info("cactus-graphmap-join has finished after {} seconds".format(run_time))
 
 def runCactusGraphMapJoin(options):
     with Toil(options) as toil:
@@ -117,6 +117,7 @@ def runCactusGraphMapJoin(options):
             # load up the vgs
             vg_ids = []
             for vg_path in options.vg:
+                logger.info("Importing {}".format(vg_path))
                 vg_ids.append(toil.importFile(makeURL(vg_path)))
 
             # run the workflow
@@ -173,6 +174,9 @@ def clip_vg(job, options, config, vg_path, vg_id):
         cmd += ['-r', rs]
     if options.reference:
         cmd += ['-e', options.reference]
+
+    # sort while we're at it
+    cmd = [cmd, ['vg', 'ids', '-s', '-']]
         
     cactus_call(parameters=cmd, outfile=out_path)
 

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -252,7 +252,7 @@ def vg_indexes(job, options, config, gfa_ids):
 
     # make the snarls
     snarls_path = os.path.join(work_dir, 'merged.snarls')
-    cactus_call(parameters=['vg', 'snarls', xg_path, '-t', str(job.cores)], outfile=snarls_path)
+    cactus_call(parameters=['vg', 'snarls', xg_path, '-T', '-t', str(job.cores)], outfile=snarls_path)
 
     # make the vcf
     vcf_path = os.path.join(work_dir, 'merged.vcf.gz')

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -256,7 +256,8 @@ def vg_indexes(job, options, config, gfa_ids):
 
     # make the vcf
     vcf_path = os.path.join(work_dir, 'merged.vcf.gz')
-    cactus_call(parameters=[['vg', 'deconstruct', xg_path, '-a', '-r', snarls_path, '-g', gbwt_path, '-T', trans_path, '-t', str(job.cores)],
+    cactus_call(parameters=[['vg', 'deconstruct', xg_path, '-P', options.reference, '-a', '-r', snarls_path, '-g', gbwt_path,
+                             '-T', trans_path, '-t', str(job.cores)],
                             ['bgzip', '--threads', str(job.cores)]],
                 outfile=vcf_path)
     cactus_call(parameters=['tabix', '-p', 'vcf', vcf_path])

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -272,7 +272,7 @@ def vg_indexes(job, options, config, gfa_ids):
              'xg' : job.fileStore.writeGlobalFile(xg_path),
              'snarls' : job.fileStore.writeGlobalFile(snarls_path),
              'vcf.gz' : job.fileStore.writeGlobalFile(vcf_path),
-             'vcf.tbi' : job.fileStore.writeGlobalFile(vcf_path + '.tbi') }
+             'vcf.gz.tbi' : job.fileStore.writeGlobalFile(vcf_path + '.tbi') }
 
 def export_join_data(toil, options, clip_ids, idx_map):
     """ download all the output data

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -159,7 +159,7 @@ def graphmap_join_workflow(job, options, config, vg_ids):
     # merge up the gfas and make the various vg indexes
     gfa_merge_job = gfa_root_job.addFollowOnJobFn(vg_indexes, options, config, clipped_gfa_ids,
                                                   cores=options.indexCores,
-                                                  disk=sum(f.size for f in vg_ids) * 10)
+                                                  disk=sum(f.size for f in vg_ids) * 5)
     
     return clipped_vg_ids, gfa_merge_job.rv()
 

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -260,15 +260,19 @@ def vg_indexes(job, options, config, gfa_ids):
                             ['bgzip', '--threads', str(job.cores)]],
                 outfile=vcf_path)
     cactus_call(parameters=['tabix', '-p', 'vcf', vcf_path])
+
+    # compress the trans
+    cactus_call(parameters=['bgzip', trans_path, '--threads', str(job.cores)])
+    trans_path += '.gz'                            
                             
     return { 'gfa.gz' : job.fileStore.writeGlobalFile(gfa_path),
              'gbwt' : job.fileStore.writeGlobalFile(gbwt_path),
              'gg' : job.fileStore.writeGlobalFile(gg_path),
-             'trans' : job.fileStore.writeGlobalFile(trans_path),
+             'trans.gz' : job.fileStore.writeGlobalFile(trans_path),
              'xg' : job.fileStore.writeGlobalFile(xg_path),
              'snarls' : job.fileStore.writeGlobalFile(snarls_path),
              'vcf.gz' : job.fileStore.writeGlobalFile(vcf_path),
-             'tbi' : job.fileStore.writeGlobalFile(vcf_path + '.tbi') }
+             'vcf.tbi' : job.fileStore.writeGlobalFile(vcf_path + '.tbi') }
 
 def export_join_data(toil, options, clip_ids, idx_map):
     """ download all the output data

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -66,8 +66,8 @@ def main():
     parser.add_argument("--reference", required=True, type=str, help = "Reference event name")
     parser.add_argument("--rename", nargs='+', default = [], help = "Path renaming, each of form src>dest (see clip-vg -r)")
     parser.add_argument("--clipLength", type=int, default=0, help = "clip out unaligned sequences longer than this")
-    parser.add_argument("--wline-sep", type=str, help = "wline separator for vg convert")
-    parser.add_argument("--index-cores", type=int, default=1, help = "cores for indexing processes")
+    parser.add_argument("--wlineSep", type=str, help = "wline separator for vg convert")
+    parser.add_argument("--indexCores", type=int, default=1, help = "cores for indexing processes")
     
     #Progressive Cactus Options
     parser.add_argument("--configFile", dest="configFile",
@@ -158,7 +158,7 @@ def graphmap_join_workflow(job, options, config, vg_ids):
 
     # merge up the gfas and make the various vg indexes
     gfa_merge_job = gfa_root_job.addFollowOnJobFn(vg_indexes, options, config, clipped_gfa_ids,
-                                                  cores=options.index_cores,
+                                                  cores=options.indexCores,
                                                   disk=sum(f.size for f in vg_ids) * 10)
     
     return clipped_vg_ids, gfa_merge_job.rv()
@@ -210,8 +210,8 @@ def vg_to_gfa(job, options, config, vg_path, vg_id):
     out_path = vg_path + '.gfa'
 
     cmd = ['vg', 'convert', '-f', '-Q', options.reference, vg_path, '-B']
-    if options.wline_sep:
-        cmd += ['-w', options.wline_sep]
+    if options.wlineSep:
+        cmd += ['-w', options.wlineSep]
 
     cactus_call(parameters=cmd, outfile=out_path)
 

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -256,7 +256,7 @@ def vg_indexes(job, options, config, gfa_ids):
 
     # make the vcf
     vcf_path = os.path.join(work_dir, 'merged.vcf.gz')
-    cactus_call(parameters=[['vg', 'deconstruct', xg_path, '-r', snarls_path, '-g', gbwt_path, '-T', trans_path, '-t', str(job.cores)],
+    cactus_call(parameters=[['vg', 'deconstruct', xg_path, '-a', '-r', snarls_path, '-g', gbwt_path, '-T', trans_path, '-t', str(job.cores)],
                             ['bgzip', '--threads', str(job.cores)]],
                 outfile=vcf_path)
     cactus_call(parameters=['tabix', '-p', 'vcf', vcf_path])


### PR DESCRIPTION
A few small fixes from having run it through a few times on full data sets. 

Note the vcf export relies on functionality not yet in a vg release, so it won't yet work in any Cactus Docker images or binary releases. 