### PR TITLE
HAL merging option in cactus-graphmap-join

### DIFF
--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -182,7 +182,7 @@ fi
 
 # hal2vg
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.8/hal2vg
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.9/hal2vg
 chmod +x hal2vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd hal2vg | grep so | wc -l) -eq 0 ]]
 then
@@ -192,7 +192,7 @@ else
 fi
 # clip-vg
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.8/clip-vg
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.9/clip-vg
 chmod +x clip-vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd clip-vg | grep so | wc -l) -eq 0 ]]
 then
@@ -202,7 +202,7 @@ else
 fi
 # halRemoveDupes
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.8/halRemoveDupes
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.9/halRemoveDupes
 chmod +x halRemoveDupes
 if [[ $STATIC_CHECK -ne 1 || $(ldd halRemoveDupes | grep so | wc -l) -eq 0 ]]
 then
@@ -210,7 +210,16 @@ then
 else
 	 exit 1
 fi
-
+# halMergeChroms
+cd ${pangenomeBuildDir}
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.9/halMergeChroms
+chmod +x halMergeChroms
+if [[ $STATIC_CHECK -ne 1 || $(ldd halMergeChroms | grep so | wc -l) -eq 0 ]]
+then
+	 mv halMergeChroms ${binDir}
+else
+	 exit 1
+fi
 
 # vg
 cd ${pangenomeBuildDir}

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -181,8 +181,8 @@ def graphmap_join_workflow(job, options, config, vg_ids, hal_ids):
                                                   disk=sum(f.size for f in vg_ids) * 5)
 
     if hal_ids:
-        merge_hal_id = root_job.addChildJobFn(merge_hal, options, hal_ids,
-                                              disk=sum(f.size for f in hal_ids) * 2).rv()
+        merge_hal_id = job.addChildJobFn(merge_hal, options, hal_ids,
+                                         disk=sum(f.size for f in hal_ids) * 2).rv()
     else:
         merge_hal_id = None
     


### PR DESCRIPTION
This allows to produce a single, whole-genome HAL at the end of the pangenome pipeline by merging up the chromosomal HALs that it currently outputs. 