### PR TITLE
Read max size from config

### DIFF
--- a/bar/impl/bar.c
+++ b/bar/impl/bar.c
@@ -52,8 +52,8 @@ void bar(stList *flowers, CactusParams *params, CactusDisk *cactusDisk, stList *
     // Hardcoded parameters
     int64_t chainLengthForBigFlower = 1000000;
     int64_t longChain = 2;
-    int64_t maximumLength = 1500;
 
+    int64_t maximumLength = cactusParams_get_int(params, 2, "bar", "bandingLimit");
     int64_t spanningTrees = cactusParams_get_int(params, 2, "bar", "spanningTrees");
     bool useProgressiveMerging = cactusParams_get_int(params, 2, "bar", "useProgressiveMerging");
     float matchGamma = cactusParams_get_float(params, 2, "bar", "matchGamma");


### PR DESCRIPTION
Reading the maximum sequence length for bar (from "bandingLimit", as was previously done) as opposed to hardcoding fixes the `make evolver_test_poa_local` gitlab test.  