### PR TITLE
Update to abpoa 1.2.0

### DIFF
--- a/bar/impl/poaBarAligner.c
+++ b/bar/impl/poaBarAligner.c
@@ -461,7 +461,7 @@ Msa *msa_make_partial_order_alignment(char **seqs, int *seq_lens, int64_t seq_no
     free(row_overlaps);
     stList_destruct(msa_windows);
 
-    abpoa_free(ab, abpt);
+    abpoa_free(ab);
     abpoa_free_para(abpt);
 
     // in debug mode, cactus uses the dreaded -Wall -Werror combo.  This line is a hack to allow compilation with these flags

--- a/bar/impl/poaBarAligner.c
+++ b/bar/impl/poaBarAligner.c
@@ -344,6 +344,7 @@ Msa *msa_make_partial_order_alignment(char **seqs, int *seq_lens, int64_t seq_no
         }
 
         // perform abpoa-msa
+        ab->abs->n_seq = 0; // To re-use ab, n_seq needs to be set as 0        
         abpoa_msa(ab, abpt, msa->seq_no, NULL, msa->seq_lens, bseqs, NULL, NULL, NULL, NULL, NULL,
                   &(msa->msa_seq), &(msa->column_no));
 


### PR DESCRIPTION
abPOA 1.2.0 [can align longer sequences via minimizer-based seeding](https://github.com/yangao07/abPOA/issues/14#issuecomment-841636128).  This is very interesting for Cactus which presently relies on some repurporsed stitching code for >10kb alignments that is a suspected sources of misalignments in some complex regions.  

In Cactus, this logic is controlled by `partialOrderAlignmentWindow`, so increasing it should be a good test of what this improves.  

Speaking of the config, now is also probably a good time to add all the abPOA parameters for scoring and seeding so they can overridden if desired.   
