### PR TITLE
Fix corner case where large private insertion can be clipped

### DIFF
--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -147,7 +147,7 @@ fi
 cd ${pangenomeBuildDir}
 git clone https://github.com/ComparativeGenomicsToolkit/cactus-gfa-tools.git
 cd cactus-gfa-tools
-git checkout fb984a271cc11352d1561005e6f701ef07429ad1
+git checkout 9dbcb8c941b6871301a40e10cbae1326247de166
 make -j 4
 if [[ $STATIC_CHECK -ne 1 || $(ldd paf2lastz | grep so | wc -l) -eq 0 ]]
 then
@@ -188,7 +188,7 @@ fi
 
 # hal2vg
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.10/hal2vg
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.11/hal2vg
 chmod +x hal2vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd hal2vg | grep so | wc -l) -eq 0 ]]
 then
@@ -198,7 +198,7 @@ else
 fi
 # clip-vg
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.10/clip-vg
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.11/clip-vg
 chmod +x clip-vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd clip-vg | grep so | wc -l) -eq 0 ]]
 then
@@ -208,7 +208,7 @@ else
 fi
 # halRemoveDupes
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.10/halRemoveDupes
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.11/halRemoveDupes
 chmod +x halRemoveDupes
 if [[ $STATIC_CHECK -ne 1 || $(ldd halRemoveDupes | grep so | wc -l) -eq 0 ]]
 then
@@ -218,7 +218,7 @@ else
 fi
 # halMergeChroms
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.10/halMergeChroms
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.11/halMergeChroms
 chmod +x halMergeChroms
 if [[ $STATIC_CHECK -ne 1 || $(ldd halMergeChroms | grep so | wc -l) -eq 0 ]]
 then

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -310,12 +310,12 @@
 		 useMinimapPAF="1"
 		 />
 	<!-- hal2vg options -->
-	<!-- includeMinigraph: include minigraph node sequences as paths in output -->
+	<!-- includeMinigraph: include minigraph node sequences as paths in output (note that cactus-graphmap-join will still remove them by default) -->
 	<!-- includeAncestor: include ancestral reference sequences as paths in output -->
 	<!-- prependGenomeNames: prepend each output path with the genome name -->	
 	<!-- hal2vgOptions: options to use in every hal2vg command -->
 	<hal2vg
-		 includeMinigraph="0"
+		 includeMinigraph="1"
 		 includeAncestor="0"
 		 prependGenomeNames="1"
 		 hal2vgOptions="--progress --inMemory"		 

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -205,7 +205,13 @@ def clip_vg(job, options, config, vg_path, vg_id):
         cmd += ['-r', rs]
     if options.reference:
         cmd += ['-e', options.reference]
-
+    
+    if getOptionalAttrib(findRequiredNode(config.xmlRoot, "hal2vg"), "includeMinigraph", typeFn=bool, default=False):
+        # our vg file has minigraph sequences -- we'll filter them out, along with any nodes
+        # that don't appear in a non-minigraph path
+        graph_event = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap"), "assemblyName", default="_MINIGRAPH_")
+        cmd += ['-d', graph_event]
+        
     # sort while we're at it
     cmd = [cmd, ['vg', 'ids', '-s', '-']]
         


### PR DESCRIPTION
The pangenome pipeline uses softmasking to blacklist regions from the graph by first not aligning them, then clipping them out at the end.  For the final clipping, bed files can be used, but it's simplest just to cut unaligned stuff out of the vg.  But say there's a large insertion in the minigraph, and exactly one sample aligns to it, it will still get clipped out as minigraph paths get dropped coming out of HAL.  This PR changes it to keep the minigraph paths around until a bit later, so they will count as alignments when clipping.  tldr: a larger insertion present in the minigraph and in exactly one sample will now make it into the final graph output.  