### PR TITLE
Disable abpoa anchoring (and sync with master)

### DIFF
--- a/bar/impl/bar.c
+++ b/bar/impl/bar.c
@@ -152,7 +152,6 @@ void bar(stList *flowers, CactusParams *params, CactusDisk *cactusDisk, stList *
         stPinchIterator_destruct(pinchIterator);
         if(usePoa) {
             stList_destruct(alignments);
-            abpoa_free_para(poaParameters);
         }
         else {
             stSortedSet_destruct(alignments);
@@ -169,6 +168,10 @@ void bar(stList *flowers, CactusParams *params, CactusDisk *cactusDisk, stList *
     //stList_destruct(flowers);
     pairwiseAlignmentBandingParameters_destruct(pairwiseAlignmentParameters);
     stateMachine_destruct(sM);
+
+    if (poaParameters) {
+        abpoa_free_para(poaParameters);
+    }
 
     /*if (bedRegions != NULL) {
         // Clean up our mapping.

--- a/bar/impl/bar.c
+++ b/bar/impl/bar.c
@@ -153,8 +153,6 @@ void bar(stList *flowers, CactusParams *params, CactusDisk *cactusDisk, stList *
         if(usePoa) {
             stList_destruct(alignments);
             abpoa_free_para(poaParameters);
-            // in debug mode, cactus uses the dreaded -Wall -Werror combo.  This line is a hack to allow compilation with these flags
-            if (false) SIMDMalloc(0, 0);
         }
         else {
             stSortedSet_destruct(alignments);

--- a/bar/impl/poaBarAligner.c
+++ b/bar/impl/poaBarAligner.c
@@ -523,9 +523,6 @@ Msa *msa_make_partial_order_alignment(char **seqs, int *seq_lens, int64_t seq_no
     abpoa_free(ab);
     abpoa_free_para(abpt);
 
-    // in debug mode, cactus uses the dreaded -Wall -Werror combo.  This line is a hack to allow compilation with these flags
-    if (false) SIMDMalloc(0, 0);
-
     return output_msa;
 }
 

--- a/bar/impl/poaBarAligner.c
+++ b/bar/impl/poaBarAligner.c
@@ -307,12 +307,7 @@ Msa *msa_make_partial_order_alignment(char **seqs, int *seq_lens, int64_t seq_no
 
     // abpoa can write to these, so we make a copy to be safe
     abpoa_para_t *abpt = copy_abpoa_params(poa_parameters);
-    
-    if (abpt->disable_seeding == 0) {
-        // windowing logic works well enough to keep around for now, but we disable it unless seeding is disabled in abpoa
-        window_size = INT64_MAX;
-    }
-    
+        
     // we overlap the sliding window, and use the trimming logic to find the best cut point between consecutive windows
     // todo: cli-facing parameter
     float window_overlap_frac = 0.5;

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -221,7 +221,7 @@
 		partialOrderAlignmentGapExtensionPenalty1="2"
 		partialOrderAlignmentGapOpenPenalty2="24"
 		partialOrderAlignmentGapExtensionPenalty2="1"
-		partialOrderAlignmentDisableSeeding="0"
+		partialOrderAlignmentDisableSeeding="1"
 		partialOrderAlignmentMinimizerK="19"
 		partialOrderAlignmentMinimizerW="10"
 		partialOrderAlignmentMinimizerMinW="50"		

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -168,7 +168,7 @@
         else eventually -->
    <!-- bandingLimit is the maximum sequence size fed into the multiple aligner.  Sequences longer than this are trimmed accordingly -->
    <!-- partialOrderAlignment toggles between cPecan and abpoa for the core multiple alignment algorithm.  abpoa is much faster but not as reliable for divered sequences -->
-   <!-- partialOrderAlignmentWindow a sliding window approach (with hardcoded 50% overlap) is used to perform abpoa alignments (only if partialOrderAlignmentDisableSeeding==1).  memory is quadratic in this.  it is applied after bandingLimit -->
+   <!-- partialOrderAlignmentWindow a sliding window approach (with hardcoded 50% overlap) is used to perform abpoa alignments.  memory is quadratic in this.  it is applied after bandingLimit -->
    <!-- partialOrderAlignmentMaskFilter trim input sequences as soon as more than this many soft or hard masked bases are encountered (-1=disabled) -->
    <!-- partialOrderAlignmentBand abpoa adaptive band size is <partialOrderAlignmentBand> + <partialOrderAlignmentBandFraction>*<Length>.  Negative value here disables adaptive banding -->
    <!-- partialOrderAlignmentBandFraction abpoa adaptibe band second parameter (see above) -->
@@ -180,7 +180,7 @@
    <!-- partialOrderAlignmentGapExtensionPenalty1 abpoa gap extension penalty -->
    <!-- partialOrderAlignmentGapOpenPenalty2 abpoa second gap open penalty (convex mode takes the minimum of both gap models) -->
    <!-- partialOrderAlignmentGapExtensionPenalty abpoa second gap extension penalty (convex mode takes the minimum of both gap models) -->
-   <!-- partialOrderAlignmentDisableSeeding abpoa disable minimizer seeding.  if true, the partialOrderAlignmentWindow option will take effect -->
+   <!-- partialOrderAlignmentDisableSeeding abpoa disable minimizer seeding. -->
    <!-- partialOrderAlignmentMinimizerK abpoa kmer size for minimizer seeding. -->
    <!-- partialOrderAlignmentMinimizerW abpoa window size for minimizer seeding. -->
    <!-- partialOrderAlignmentMinimizerMinW abpoa minimum window size. -->

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -814,7 +814,7 @@ def align_toil(job, chrom, seq_file_id, paf_file_id, config_id, options):
 
     log_file = os.path.join(work_dir, '{}.hal.log'.format(chrom))
 
-    cmd = ['cactus-align', js, seq_file, paf_file, out_file, '--logFile', log_file] + options.alignOptions.split()
+    cmd = ['cactus-align', js, seq_file, paf_file, out_file, '--logFile', log_file, '--configFile', config_file] + options.alignOptions.split()
 
     cactus_call(parameters=cmd)
 


### PR DESCRIPTION
abpoa anchoring crashes on the full pangenome, even when using the same stitching/window size logic as before in bar.  This PR disables it by default in the config.  