### PR TITLE
enable poa seeding by default (except in pangenome mode)

### DIFF
--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -176,7 +176,7 @@
    <!-- partialOrderAlignmentGapExtensionPenalty1 abpoa gap extension penalty -->
    <!-- partialOrderAlignmentGapOpenPenalty2 abpoa second gap open penalty (convex mode takes the minimum of both gap models, 0 disables convex) -->
    <!-- partialOrderAlignmentGapExtensionPenalty abpoa second gap extension penalty (convex mode takes the minimum of both gap models) -->
-   <!-- partialOrderAlignmentDisableSeeding abpoa disable minimizer seeding. -->
+   <!-- partialOrderAlignmentDisableSeeding abpoa disable minimizer seeding. toggling this on will slightly increase accuracy at the cost of speed -->
    <!-- partialOrderAlignmentMinimizerK abpoa kmer size for minimizer seeding. -->
    <!-- partialOrderAlignmentMinimizerW abpoa window size for minimizer seeding. -->
    <!-- partialOrderAlignmentMinimizerMinW abpoa minimum window size. -->
@@ -215,7 +215,7 @@
 		partialOrderAlignmentGapExtensionPenalty1="30"
 		partialOrderAlignmentGapOpenPenalty2="1200"
 		partialOrderAlignmentGapExtensionPenalty2="1"
-		partialOrderAlignmentDisableSeeding="1"
+		partialOrderAlignmentDisableSeeding="0"
 		partialOrderAlignmentMinimizerK="19"
 		partialOrderAlignmentMinimizerW="10"
 		partialOrderAlignmentMinimizerMinW="50"

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -376,6 +376,8 @@ def make_align_job(options, toil):
         findRequiredNode(configWrapper.xmlRoot, "bar").attrib["minimumBlockDegree"] = "1"
         # turn on POA
         findRequiredNode(configWrapper.xmlRoot, "bar").attrib["partialOrderAlignment"] = "1"
+        # turn off POA seeding
+        findRequiredNode(configWrapper.xmlRoot, "bar").attrib["partialOrderAlignmentDisableSeeding"] = "1"
         # save it
         if not options.batch:
             pg_file = options.outHal + ".pg-conf.xml"


### PR DESCRIPTION
With seeding enabled, abpoa uses minimizers to find anchors to speed up alignment.  This works well in practice and comes at a very minimal cost in accuracy, so it's probably best on by default.  

I'm leaving it off in `--pangenome` mode for now, though, where runtime is less of an issue.  