### PR TITLE
Fix typo in singleMachine name check

### DIFF
--- a/src/cactus/progressive/cactus_progressive.py
+++ b/src/cactus/progressive/cactus_progressive.py
@@ -382,7 +382,7 @@ def main():
     enableDumpStack()
 
     # Try to juggle --maxCores and --consCores to give some reasonable defaults where possible
-    if options.batchSystem.lower() in ['single_machine', 'singleMachine']:
+    if options.batchSystem.lower() in ['single_machine', 'singlemachine']:
         if options.maxCores is not None:
             if int(options.maxCores) <= 0:
                 raise RuntimeError('Cactus requires --maxCores >= 1')

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -111,7 +111,7 @@ def main():
             raise RuntimeError('same number of values must be passed to --pathOverrides and --pathOverrideNames')
 
     # Try to juggle --maxCores and --consCores to give some reasonable defaults where possible
-    if options.batchSystem.lower() in ['single_machine', 'singleMachine']:
+    if options.batchSystem.lower() in ['single_machine', 'singlemachine']:
         if options.maxCores is not None:
             if int(options.maxCores) <= 0:
                 raise RuntimeError('Cactus requires --maxCores >= 1')


### PR DESCRIPTION
New option `--consCores` required for non-single-machine batch systems.  But check to enforce this had typo when comparing against old toil naming