### PR TITLE
Rejig CAF parameters

### DIFF
--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -81,8 +81,8 @@
 		minimumMapQValue="0.0"
 		maxAlignmentsPerSite="5"
 
-		trim="3"
-		blockTrim="2"
+		trim="0 0"
+		blockTrim="8"
 		annealingRounds="64"
 		deannealingRounds="2 4 8"
 		minimumTreeCoverage="0.0"


### PR DESCRIPTION
Some CAF paramters were [recently changed](https://github.com/ComparativeGenomicsToolkit/cactus/commit/3acf03c4ced50145963bbb12fad77fbf02246f71) in order to be able to toggle off realign by default.  

It seemed to work well enough, but one of these changes (going from `trim="0 0"` to `trim="3"`) mysteriously increases CAF running time from 7 hours to 57 hours on a mouse/rat + outrgoup alignment.  The running time hit comes from giant blocks of only mouse inside `containsMoreThanOneEvent()` when filtering secondary alignments.  Is this a coincidence? a bug?  I don't know, but it's very reproducible.  

So here I'm making the minimal change that keeps our (overtrained on) evolver test passing while setting trim back to 0. 