### PR TITLE
More self-contained static builder script

### DIFF
--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -84,7 +84,12 @@ cd ${pangenomeBuildDir}
 wget -q https://github.com/samtools/samtools/releases/download/1.11/samtools-1.11.tar.bz2
 tar -xf samtools-1.11.tar.bz2
 cd samtools-1.11
-./configure --without-curses --disable-libcurl --enable-configure-htslib
+SAMTOOLS_CONFIG_OPTS=""
+if [[ $STATIC_CHECK -eq 1 ]]
+then
+	 SAMTOOLS_CONFIG_OPTS="--disable-shared --enable-static"
+fi
+./configure --without-curses --disable-libcurl --enable-configure-htslib $SAMTOOLS_CONFIG_OPTS
 make -j ${numcpu}
 if [[ $STATIC_CHECK -ne 1 || $(ldd samtools | grep so | wc -l) -eq 0 ]]
 then
@@ -93,7 +98,8 @@ else
 	 exit 1
 fi
 cd htslib-1.11
-make -j ${numcpu}
+make -j ${numcpu} tabix
+make -j ${numcpu} bgzip
 if [[ $STATIC_CHECK -ne 1 || $(ldd tabix | grep so | wc -l) -eq 0 ]]
 then
 	 mv tabix ${binDir}

--- a/build-tools/makeBinRelease
+++ b/build-tools/makeBinRelease
@@ -19,7 +19,7 @@ set -x
 rm -rf ${binBuildDir}
 mkdir -p ${binBuildDir}
 cd ${binBuildDir}
-git clone --recursive https://github.com/ComparativeGenomicsToolkit/cactus.git
+git clone https://github.com/ComparativeGenomicsToolkit/cactus.git
 cd cactus
 git fetch --tags origin
 
@@ -39,6 +39,31 @@ fi
 export CFLAGS="-march=${CACTUS_ARCH} -static"
 export CXXFLAGS="-march=${CACTUS_ARCH} -static"
 export LDFLAGS="-march=${CACTUS_ARCH} -static"
+
+# build a couple dependencies from source because versions from awk don't support static linking
+pushd .
+cd ${binBuildDir}
+mkdir -p deps ; cd deps
+DEP_PREFIX=$(pwd)
+# hdf5
+wget -q https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5-1_10_2.tar.gz
+tar -zxf hdf5-1_10_2.tar.gz
+cd  hdf5-hdf5-1_10_2
+./configure --enable-cxx --enable-static --disable-parallel --disable-shared --prefix=${DEP_PREFIX}
+make -j $(nproc)
+make install
+export PATH=${DEP_PREFIX}/bin:$PATH
+# libxml2
+cd ${DEP_PREFIX}
+wget -q http://xmlsoft.org/sources/libxml2-2.7.2.tar.gz
+tar -zxf libxml2-2.7.2.tar.gz
+cd libxml2-2.7.2
+./configure --enable-static --disable-shared --prefix=${DEP_PREFIX}
+make -j $(nproc)
+make install
+export CACTUS_STATIC_LINK_FLAGS="-L${DEP_PREFIX}/lib -lz -lpthread -lm -llzma"
+export CACTUS_LIBXML2_INCLUDE_PATH=${DEP_PREFIX}/include/libxml2
+popd
 
 # install Phast and enable halPhyloP compilation
 build-tools/downloadPhast

--- a/include.mk
+++ b/include.mk
@@ -39,7 +39,10 @@ include ${sonLibRootDir}/include.mk
 CFLAGS += -UNDEBUG
 
 # Hack to include xml2
-CFLAGS+= -I/usr/include/libxml2
+ifeq (${CACTUS_LIBXML2_INCLUDE_PATH},)
+CACTUS_LIBXML2_INCLUDE_PATH = /usr/include/libxml2
+endif
+CFLAGS+= -I${CACTUS_LIBXML2_INCLUDE_PATH}
 
 ifndef TARGETOS
   TARGETOS := $(shell uname -s)
@@ -65,5 +68,6 @@ CPPFLAGS += ${inclDirs:%=-I${rootPath}/%} -I${LIBDIR} -I${rootPath}/include
 cactusLibs = ${LIBDIR}/stCaf.a ${LIBDIR}/stReference.a ${LIBDIR}/cactusBarLib.a ${LIBDIR}/cactusBlastAlignment.a ${LIBDIR}/cactusLib.a
 sonLibLibs = ${sonLibDir}/sonLib.a ${sonLibDir}/cuTest.a
 
-LDLIBS += ${cactusLibs} ${sonLibLibs} ${LIBS} -L${rootPath}/lib -Wl,-rpath,${rootPath}/lib -labpoa -lz -lbz2 -lpthread -lm -lstdc++ -lm -lxml2
+# note: the CACTUS_STATIC_LINK_FLAGS below can generally be empty -- it's used by the static builder script only
+LDLIBS += ${cactusLibs} ${sonLibLibs} ${LIBS} -L${rootPath}/lib -Wl,-rpath,${rootPath}/lib -labpoa -lz -lbz2 -lpthread -lm -lstdc++ -lm -lxml2 ${CACTUS_STATIC_LINK_FLAGS}
 LIBDEPENDS = ${sonLibDir}/sonLib.a ${sonLibDir}/cuTest.a


### PR DESCRIPTION
libxml2 threw a bit of a wrench in the static binaries building procedure, which was already tricky due to hdf5.  This PR scripts out all the hacking I needed to do, so hopefully it will be much easier going forward. 

@diekhans you were talking about doing this in Docker at some point.  In theory (I haven't tested, of course) now it should be trivially doable in any Ubuntu 18-based image (such as Cactus) by running [the apt install command from the Dockerfile](https://github.com/ComparativeGenomicsToolkit/cactus/blob/c489c085ada05763905f789933cb3d81debe866f/Dockerfile#L4) followed by `make binRelease`