### PR TITLE
Revert last-minute caf parameter tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ There are many different ways to install and run Cactus:
 
 #### Docker Image
 
-Cactus docker images are hosted on [quay](https://quay.io/repository/comparative-genomics-toolkit/cactus).  The image for the latest release is listed on the [Releases Page](https://github.com/ComparativeGenomicsToolkit/cactus/releases).  Here is an command line to run the included evolver mammals example with release 2.0.0
+Cactus docker images are hosted on [quay](https://quay.io/repository/comparative-genomics-toolkit/cactus).  The image for the latest release is listed on the [Releases Page](https://github.com/ComparativeGenomicsToolkit/cactus/releases).  Here is an command line to run the included evolver mammals example with release 2.0.1
 ```
 wget https://raw.githubusercontent.com/ComparativeGenomicsToolkit/cactus/master/examples/evolverMammals.txt
-docker run -v $(pwd):/data --rm -it quay.io/comparative-genomics-toolkit/cactus:v2.0.0 cactus /data/jobStore /data/evolverMammals.txt /data/evolverMammals.hal --root mr --binariesMode local
+docker run -v $(pwd):/data --rm -it quay.io/comparative-genomics-toolkit/cactus:v2.0.1 cactus /data/jobStore /data/evolverMammals.txt /data/evolverMammals.hal --root mr --binariesMode local
 
 ```
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,4 +1,12 @@
-# Release 2.0.0
+# Release 2.0.1   2021-06-19
+
+This a patch release that fixes an issue where the new `--consCores` option could not be used with `--maxCores` (Thanks @RenzoTale88).
+
+Changelog:
+- Fix bug where `cactus` doesn't work when both `--maxCores` and `--consCores` are specified.
+- Static binaries script more portable. 
+
+# Release 2.0.0   2021-06-18
 
 This release includes a major update to the Cactus workflow which should dramatically improve both speed and robustness. Previously, Cactus used a multiprocess architecture for all cactus graph operations (everything after the "blast" phase).  Each process was run in its own Toil job, and they would communicate via the CactusDisk database that ran as its own separate service process (ktserver by default). Writing to and from the database was often a bottleneck, and it would fail sporadically on larger inputs with frustrating "network errors". This has all now been changed to run as a single multithreaded executable, `cactus_consolidated`.  Apart from saving on database I/O, `cactus_consolidated` now uses the much-faster, SIMD-accelerated abPOA by default instead of cPecan for performing multiple sequence alignments within the BAR phase.
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,10 +1,11 @@
 # Release 2.0.1   2021-06-19
 
-This a patch release that fixes an issue where the new `--consCores` option could not be used with `--maxCores` (Thanks @RenzoTale88).
+This a patch release that fixes an issue where the new `--consCores` option could not be used with `--maxCores` (Thanks @RenzoTale88).  It also reverts some last minute CAF parameter changes to something more tested (though known to be slow in some cases with large numbers of secondary alignments)
 
 Changelog:
 - Fix bug where `cactus` doesn't work when both `--maxCores` and `--consCores` are specified.
-- Static binaries script more portable. 
+- Static binaries script more portable.
+- Revert CAF trimming parameters to their previous defaults. 
 
 # Release 2.0.0   2021-06-18
 

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -84,7 +84,12 @@ cd ${pangenomeBuildDir}
 wget -q https://github.com/samtools/samtools/releases/download/1.11/samtools-1.11.tar.bz2
 tar -xf samtools-1.11.tar.bz2
 cd samtools-1.11
-./configure --without-curses --disable-libcurl --enable-configure-htslib
+SAMTOOLS_CONFIG_OPTS=""
+if [[ $STATIC_CHECK -eq 1 ]]
+then
+	 SAMTOOLS_CONFIG_OPTS="--disable-shared --enable-static"
+fi
+./configure --without-curses --disable-libcurl --enable-configure-htslib $SAMTOOLS_CONFIG_OPTS
 make -j ${numcpu}
 if [[ $STATIC_CHECK -ne 1 || $(ldd samtools | grep so | wc -l) -eq 0 ]]
 then
@@ -93,7 +98,8 @@ else
 	 exit 1
 fi
 cd htslib-1.11
-make -j ${numcpu}
+make -j ${numcpu} tabix
+make -j ${numcpu} bgzip
 if [[ $STATIC_CHECK -ne 1 || $(ldd tabix | grep so | wc -l) -eq 0 ]]
 then
 	 mv tabix ${binDir}

--- a/build-tools/makeBinRelease
+++ b/build-tools/makeBinRelease
@@ -19,7 +19,7 @@ set -x
 rm -rf ${binBuildDir}
 mkdir -p ${binBuildDir}
 cd ${binBuildDir}
-git clone --recursive https://github.com/ComparativeGenomicsToolkit/cactus.git
+git clone https://github.com/ComparativeGenomicsToolkit/cactus.git
 cd cactus
 git fetch --tags origin
 
@@ -39,6 +39,31 @@ fi
 export CFLAGS="-march=${CACTUS_ARCH} -static"
 export CXXFLAGS="-march=${CACTUS_ARCH} -static"
 export LDFLAGS="-march=${CACTUS_ARCH} -static"
+
+# build a couple dependencies from source because versions from awk don't support static linking
+pushd .
+cd ${binBuildDir}
+mkdir -p deps ; cd deps
+DEP_PREFIX=$(pwd)
+# hdf5
+wget -q https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5-1_10_2.tar.gz
+tar -zxf hdf5-1_10_2.tar.gz
+cd  hdf5-hdf5-1_10_2
+./configure --enable-cxx --enable-static --disable-parallel --disable-shared --prefix=${DEP_PREFIX}
+make -j $(nproc)
+make install
+export PATH=${DEP_PREFIX}/bin:$PATH
+# libxml2
+cd ${DEP_PREFIX}
+wget -q http://xmlsoft.org/sources/libxml2-2.7.2.tar.gz
+tar -zxf libxml2-2.7.2.tar.gz
+cd libxml2-2.7.2
+./configure --enable-static --disable-shared --prefix=${DEP_PREFIX}
+make -j $(nproc)
+make install
+export CACTUS_STATIC_LINK_FLAGS="-L${DEP_PREFIX}/lib -lz -lpthread -lm -llzma"
+export CACTUS_LIBXML2_INCLUDE_PATH=${DEP_PREFIX}/include/libxml2
+popd
 
 # install Phast and enable halPhyloP compilation
 build-tools/downloadPhast

--- a/include.mk
+++ b/include.mk
@@ -39,7 +39,10 @@ include ${sonLibRootDir}/include.mk
 CFLAGS += -UNDEBUG
 
 # Hack to include xml2
-CFLAGS+= -I/usr/include/libxml2
+ifeq (${CACTUS_LIBXML2_INCLUDE_PATH},)
+CACTUS_LIBXML2_INCLUDE_PATH = /usr/include/libxml2
+endif
+CFLAGS+= -I${CACTUS_LIBXML2_INCLUDE_PATH}
 
 ifndef TARGETOS
   TARGETOS := $(shell uname -s)
@@ -65,5 +68,6 @@ CPPFLAGS += ${inclDirs:%=-I${rootPath}/%} -I${LIBDIR} -I${rootPath}/include
 cactusLibs = ${LIBDIR}/stCaf.a ${LIBDIR}/stReference.a ${LIBDIR}/cactusBarLib.a ${LIBDIR}/cactusBlastAlignment.a ${LIBDIR}/cactusLib.a
 sonLibLibs = ${sonLibDir}/sonLib.a ${sonLibDir}/cuTest.a
 
-LDLIBS += ${cactusLibs} ${sonLibLibs} ${LIBS} -L${rootPath}/lib -Wl,-rpath,${rootPath}/lib -labpoa -lz -lbz2 -lpthread -lm -lstdc++ -lm -lxml2
+# note: the CACTUS_STATIC_LINK_FLAGS below can generally be empty -- it's used by the static builder script only
+LDLIBS += ${cactusLibs} ${sonLibLibs} ${LIBS} -L${rootPath}/lib -Wl,-rpath,${rootPath}/lib -labpoa -lz -lbz2 -lpthread -lm -lstdc++ -lm -lxml2 ${CACTUS_STATIC_LINK_FLAGS}
 LIBDEPENDS = ${sonLibDir}/sonLib.a ${sonLibDir}/cuTest.a

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -81,8 +81,8 @@
 		minimumMapQValue="0.0"
 		maxAlignmentsPerSite="5"
 
-		trim="0 0"
-		blockTrim="8"
+		trim="3"
+		blockTrim="2"
 		annealingRounds="64"
 		deannealingRounds="2 4 8"
 		minimumTreeCoverage="0.0"

--- a/src/cactus/progressive/cactus_progressive.py
+++ b/src/cactus/progressive/cactus_progressive.py
@@ -388,15 +388,15 @@ def main():
                 raise RuntimeError('Cactus requires --maxCores >= 1')
         if options.consCores is None:
             if options.maxCores is not None:
-                options.consCores = options.maxCores
+                options.consCores = int(options.maxCores)
             else:
                 options.consCores = cpu_count()
-        elif options.maxCores is not None and options.consCores < options.maxCores:
+        elif options.maxCores is not None and options.consCores > int(options.maxCores):
             raise RuntimeError('--consCores must be <= --maxCores')
     else:
         if not options.consCores:
             raise RuntimeError('--consCores required for non single_machine batch systems')
-    if options.maxCores is not None and options.consCores > options.maxCores:
+    if options.maxCores is not None and options.consCores > int(options.maxCores):
         raise RuntimeError('--consCores must be <= --maxCores')
 
     # Mess with some toil options to create useful defaults.

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -117,15 +117,15 @@ def main():
                 raise RuntimeError('Cactus requires --maxCores >= 1')
         if options.consCores is None:
             if options.maxCores is not None:
-                options.consCores = options.maxCores
+                options.consCores = int(options.maxCores)
             else:
                 options.consCores = cpu_count()
-        elif options.maxCores is not None and options.consCores < options.maxCores:
+        elif options.maxCores is not None and options.consCores > int(options.maxCores):
             raise RuntimeError('--consCores must be <= --maxCores')
     else:
         if not options.consCores:
             raise RuntimeError('--consCores required for non single_machine batch systems')
-    if options.maxCores is not None and options.consCores > options.maxCores:
+    if options.maxCores is not None and options.consCores > int(options.maxCores):
         raise RuntimeError('--consCores must be <= --maxCores')
 
     options.buildHal = True

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -381,7 +381,7 @@ def getDockerImage():
 
 def getDockerRelease(gpu=False):
     """Get the most recent docker release."""
-    r = "quay.io/comparative-genomics-toolkit/cactus:v2.0.0"
+    r = "quay.io/comparative-genomics-toolkit/cactus:v2.0.1"
     if gpu:
         r += "-gpu"
     return r


### PR DESCRIPTION
I'd [changed the trimming parameters](https://github.com/ComparativeGenomicsToolkit/cactus/commit/79763f2b8b246d3188e98281ac0182b8817a5580) right before making release 2.0.0 as it worked okay on small tests and fixed a case where mouse/rat was getting bogged down in a trivial CAF filter. 

But, the new parameters crashed out while building pangenome chr4, so I'm reverting back to the previous defaults.  These are more tested, but have the known issue of being slow in some cases (for unknown reasons) while filtering secondary alignments.  

The fact that the program is so sensitive to these parameters in terms of both crashes and running time is definitely cause for concern and needs to be looked into asap.  