### PR TITLE
Hack in option to fine-tune fasta header cutting

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,10 @@
+# Release 2.0.2
+
+Changelog:
+- Use latest abpoa, which fixes bug where aligning >1024 sequences would lead to a segfault
+- Update to Toil 5.4.0
+- More consistently apply filters to minimap2 output in the fallback stage of graphmap-split
+
 # Release 2.0.1   2021-06-19
 
 This a patch release that fixes an issue where the new `--consCores` option could not be used with `--maxCores` (Thanks @RenzoTale88).  It also reverts some last minute CAF parameter changes to something more tested (though known to be slow in some cases with large numbers of secondary alignments)

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -11,6 +11,7 @@
 	<!-- The preprocessor tags are used to modify/check the input sequences before alignment -->
 	<!-- The cutHeaders preprocess modifies fastsa sequence names to help them pass checkUniqueHeaders. -->
 	<!-- cutBefore: all characters up to and including the last occurrence of a character in this string are clipped out -->
+	<!-- cutBeforeOcc: (if specified and > 0) only consider the first maxOcc occurences of a character in cutBefore filter -->
 	<!-- cutAfter: all characters after and including the first occurrence of a character in this string are clipped out -->
 	<preprocessor memory="littleMemory" preprocessJob="cutHeaders" cutBefore="" cutAfter=" 	" active="1"/>
 	<!-- The first preprocessor tag checks that the first word of every fasta header is unique, as this is required for HAL. It throws errors if this is not the case -->

--- a/src/cactus/preprocessor/cactus_preprocessor.py
+++ b/src/cactus/preprocessor/cactus_preprocessor.py
@@ -47,7 +47,7 @@ class PreprocessorOptions:
                  preprocessJob, checkAssemblyHub=None, lastzOptions=None, minPeriod=None,
                  gpuLastz=False, dnabrnnOpts=None,
                  dnabrnnAction=None, eventName=None, minLength=None,
-                 cutBefore=None, cutAfter=None, inputBedID=None):
+                 cutBefore=None, cutBeforeOcc=None, cutAfter=None, inputBedID=None):
         self.chunkSize = chunkSize
         self.memory = memory
         self.cpu = cpu
@@ -68,6 +68,7 @@ class PreprocessorOptions:
         self.eventName = eventName
         self.minLength = minLength        
         self.cutBefore = cutBefore
+        self.cutBeforeOcc = cutBeforeOcc
         self.cutAfter = cutAfter
         self.inputBedID = inputBedID
 
@@ -155,6 +156,7 @@ class PreprocessSequence(RoundedJob):
         elif self.prepOptions.preprocessJob == "cutHeaders":
             return CutHeadersJob(inChunkID,
                                  cutBefore=self.prepOptions.cutBefore,
+                                 cutBeforeOcc=self.prepOptions.cutBeforeOcc,
                                  cutAfter=self.prepOptions.cutAfter)
         elif self.prepOptions.preprocessJob == 'maskFile':
             return FileMaskingJob(inChunkID,
@@ -253,6 +255,7 @@ class BatchPreprocessor(RoundedJob):
                                               eventName = getOptionalAttrib(prepNode, "eventName", typeFn=str, default=None),
                                               minLength = getOptionalAttrib(prepNode, "minLength", typeFn=int, default=1),
                                               cutBefore = getOptionalAttrib(prepNode, "cutBefore", typeFn=str, default=None),
+                                              cutBeforeOcc = getOptionalAttrib(prepNode, "cutBeforeOcc", typeFn=int, default=None),
                                               cutAfter = getOptionalAttrib(prepNode, "cutAfter", typeFn=str, default=None),
                                               inputBedID = getOptionalAttrib(prepNode, "inputBedID", typeFn=str, default=None))
 

--- a/src/cactus/preprocessor/cutHeaders.py
+++ b/src/cactus/preprocessor/cutHeaders.py
@@ -15,11 +15,12 @@ from cactus.shared.common import RoundedJob
 from toil.realtimeLogger import RealtimeLogger
 
 class CutHeadersJob(RoundedJob):
-    def __init__(self, fastaID, cutBefore, cutAfter):
+    def __init__(self, fastaID, cutBefore, cutBeforeOcc, cutAfter):
         disk = 2*(fastaID.size)
         RoundedJob.__init__(self, disk=disk, preemptable=True)
         self.fastaID = fastaID
         self.cutBefore = cutBefore
+        self.cutBeforeOcc = cutBeforeOcc
         self.cutAfter = cutAfter
 
     def run(self, fileStore):
@@ -31,10 +32,17 @@ class CutHeadersJob(RoundedJob):
         would become 
         >h1tg000001l
 
+        If cutBeforeOcc is specified, it will only cut up to cutBeforeOcc characters
+        so cutBefore # with cutBeforeOcc = 2 would change
+        >HG02055#1#h1tg000001l#EBV
+        into
+        >h1tg000001l#EBV
+
         If cutAfter is a whitespace, then something like 
         >chr1  AC:CM000663.2  gi:568336023  LN:248956422  rl:Chromosome  M5:6aef897c3d6ff0c78aff06
         would become
         >chr1
+
         """
         work_dir = fileStore.getLocalTempDir()
         input_path = os.path.join(work_dir, 'seq.fa')
@@ -45,12 +53,17 @@ class CutHeadersJob(RoundedJob):
             for seq_record in SeqIO.parse(in_file, 'fasta'):
                 header = seq_record.description
                 if self.cutBefore:
-                    pos = max(header.rfind(c) for c in self.cutBefore)
-                    if pos >= 0:
-                        if pos < len(header) - 1:
-                            header = header[pos + 1:]
+                    occs = [i for i, c in enumerate(header) if c in self.cutBefore]
+                    if occs:
+                        if not self.cutBeforeOcc:
+                            pos = occs[-1]
                         else:
-                            header = ""
+                            pos = occs[min(len(occs), self.cutBeforeOcc) - 1]
+                        if pos >= 0:
+                            if pos < len(header) - 1:
+                                header = header[pos + 1:]
+                            else:
+                                header = ""
                 if self.cutAfter:
                     pos_list = [header.find(c) for c in self.cutAfter if header.find(c) >= 0]
                     if pos_list:

--- a/src/cactus/refmap/cactus_graphmap_split.py
+++ b/src/cactus/refmap/cactus_graphmap_split.py
@@ -457,7 +457,7 @@ def minimap_map(job, config, minimap_index_id, event, fa_id, fa_name):
 
     # call minimap2 and stick our unique identifiers on the output right away to be consistent
     # with cactus-graphmap's paf output
-    cmd = [['minimap2', idx_path, fa_path, '-c', '-x', 'asm5'],
+    cmd = [['minimap2', idx_path, fa_path, '-c', '-x', 'asm5', '--secondary=no'],
            ['awk', 'BEGIN {{OFS="\t"}} $1="id={}|"$1'.format(event)]]
     
     min_mapq = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap"), "minMAPQ")

--- a/src/cactus/refmap/cactus_graphmap_split.py
+++ b/src/cactus/refmap/cactus_graphmap_split.py
@@ -427,7 +427,7 @@ def split_minimap_fallback(job, options, config, seqIDMap, output_id_map):
     paf_ids = []
     ambiguous_seq_id_map = {}
     for event, fa_id in output_id_map[amb_name]['fa'].items():
-        paf_job = mm_map_root_job.addChildJobFn(minimap_map, mm_index_job.rv(), event, fa_id, seqIDMap[event][0],
+        paf_job = mm_map_root_job.addChildJobFn(minimap_map, config, mm_index_job.rv(), event, fa_id, seqIDMap[event][0],
                                                 disk=ref_id.size * 3, memory=mm_mem)
         paf_ids.append(paf_job.rv())
         ambiguous_seq_id_map[event] = (seqIDMap[event][0], fa_id)
@@ -446,7 +446,7 @@ def minimap_index(job, ref_name, ref_id):
 
     return job.fileStore.writeGlobalFile(idx_path)
 
-def minimap_map(job, minimap_index_id, event, fa_id, fa_name):
+def minimap_map(job, config, minimap_index_id, event, fa_id, fa_name):
     """ run minimap2 """
     work_dir = job.fileStore.getLocalTempDir()
     idx_path = os.path.join(work_dir, "minmap2.idx")
@@ -457,6 +457,14 @@ def minimap_map(job, minimap_index_id, event, fa_id, fa_name):
 
     # call minimap2 and stick our unique identifiers on the output right away to be consistent
     # with cactus-graphmap's paf output
+    cmd = [['minimap2', idx_path, fa_path, '-c', '-x', 'asm5'],
+           ['awk', 'BEGIN {{OFS="\t"}} $1="id={}|"$1'.format(event)]]
+    
+    min_mapq = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap"), "minMAPQ")
+    if min_mapq:
+        # add mapq filter used in mzgaf2paf
+        cmd.append(['awk', '$12<{}'.format(min_mapq)])
+
     cactus_call(parameters=[['minimap2', idx_path, fa_path, '-c', '-x', 'asm5'],
                             ['awk', 'BEGIN {{OFS="\t"}} $1="id={}|"$1'.format(event)]],
                 outfile=paf_path)

--- a/src/cactus/refmap/cactus_graphmap_split.py
+++ b/src/cactus/refmap/cactus_graphmap_split.py
@@ -465,9 +465,7 @@ def minimap_map(job, config, minimap_index_id, event, fa_id, fa_name):
         # add mapq filter used in mzgaf2paf
         cmd.append(['awk', '$12<{}'.format(min_mapq)])
 
-    cactus_call(parameters=[['minimap2', idx_path, fa_path, '-c', '-x', 'asm5'],
-                            ['awk', 'BEGIN {{OFS="\t"}} $1="id={}|"$1'.format(event)]],
-                outfile=paf_path)
+    cactus_call(parameters=cmd, outfile=paf_path)
 
     return job.fileStore.writeGlobalFile(paf_path)    
     

--- a/src/cactus/refmap/cactus_graphmap_split.py
+++ b/src/cactus/refmap/cactus_graphmap_split.py
@@ -463,7 +463,7 @@ def minimap_map(job, config, minimap_index_id, event, fa_id, fa_name):
     min_mapq = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap"), "minMAPQ")
     if min_mapq:
         # add mapq filter used in mzgaf2paf
-        cmd.append(['awk', '$12<{}'.format(min_mapq)])
+        cmd.append(['awk', '$12>={}'.format(min_mapq)])
 
     cactus_call(parameters=cmd, outfile=paf_path)
 


### PR DESCRIPTION
So now something like
```
<preprocessor memory="littleMemory" preprocessJob="cutHeaders" cutBefore="#" cutBeforeOcc="2" cutAfter="#" active="1"/>
```
can be used to transform `>HG01109#2#JAHEOZ010000001.1#MT` into `>JAHEOZ010000001.1`

(the old logic with just cutBefore="#" would have given `>MT`)