### PR TITLE
Add optional normalization to graphmap-join

### DIFF
--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -84,6 +84,8 @@ def main():
                         "rather than pulling one from quay.io")
     parser.add_argument("--binariesMode", choices=["docker", "local", "singularity"],
                         help="The way to run the Cactus binaries", default=None)
+    parser.add_argument("--normalizeIterations", type=int, default=None,
+                        help="Run this many iterations of normamlization (shared prefix zipping)")
 
     options = parser.parse_args()
 
@@ -211,9 +213,16 @@ def clip_vg(job, options, config, vg_path, vg_id):
         # that don't appear in a non-minigraph path
         graph_event = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap"), "assemblyName", default="_MINIGRAPH_")
         cmd += ['-d', graph_event]
+
+    cmd = [cmd]
+
+    # optional normalization.  this will (in theory) correct a lot of small underalignments due to cactus bugs
+    # by zipping up redundant nodes 
+    if options.normalizeIterations:
+        cmd.append(['vg', 'mod', '-U', str(options.normalizeIterations), '-'])
         
     # sort while we're at it
-    cmd = [cmd, ['vg', 'ids', '-s', '-']]
+    cmd.append(['vg', 'ids', '-s', '-'])
         
     cactus_call(parameters=cmd, outfile=out_path)
 


### PR DESCRIPTION
The pangenome graphs coming out of cactus have lots of small gaps.  In this msa these show up like
```
AA-A
A-AA
```
In the graph, they are bubbles that contain redundant traversals (often just a single-base node that is duplicated).  Some large-scale versions of this are inherited from underalignments out of minigraph.  But many of the small ones seem due to cactus's stitching aka reconciling code in bar.  

[GFAffix](https://github.com/danydoerr/GFAffix/) is a cool new tool that can quantify and correct such cases.  As far as I know, its algorithm is effectively similar to `vg mod --normalize`.  Since vg's already in the pipeline, I'm adding an option to use it for normalizing.  I've had trouble with it in the past, but I'm hoping it was due to underlying libbdsg bugs that have since been ironed out while developing `clip-vg`.  Will test shortly.

The majority of the gaps are coming at minigraph node boundaries.  I'll patch this soon, but I think the normalization (if it works) will still be a good idea as it's unlikely the patch will fix 100% of cases. 

    