### PR TITLE
Revert abpoa tweaks and stop using -march

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,8 @@ RUN apt-get update && apt-get install -y build-essential git python3 python3-dev
 RUN mkdir -p /home/cactus
 COPY . /home/cactus
 
-# compile with nehalem architecture target to improve portablity
-ENV CACTUS_ARCH=nehalem
-ENV CFLAGS -march=nehalem
-ENV CXXFLAGS -march=nehalem
-ENV LDFLAGS -march=nehalem
+# Make sure abpoa doesn't build with -march=native, but rather the hopefully more portable -msse4.1
+ENV sse41 1
 
 # install Phast and enable halPhyloP compilation
 RUN cd /home/cactus && ./build-tools/downloadPhast

--- a/bar/Makefile
+++ b/bar/Makefile
@@ -22,7 +22,8 @@ ${BINDIR}/cactus_barTests : ${libTests} tests/*.h ${LIBDIR}/cactusBarLib.a ${stB
 	${CC} ${CPPFLAGS} ${CFLAGS} ${LDFLAGS} -Wno-error -o ${BINDIR}/cactus_barTests ${libTests} ${LIBDIR}/cactusBarLib.a ${LDLIBS}
 
 ${LIBDIR}/cactusBarLib.a : ${libSources} ${libHeaders} ${stBarDependencies}
-	${CC} ${CPPFLAGS} ${CFLAGS} -c ${libSources} 
+# the -Wno-unused-function is required to include abpoa.h with CGL_DEBUG defined
+	${CC} ${CPPFLAGS} ${CFLAGS} -c ${libSources} -Wno-unused-function 
 	${AR} rc cactusBarLib.a *.o
 	${RANLIB} cactusBarLib.a 
 	mv cactusBarLib.a ${LIBDIR}/

--- a/build-tools/makeBinRelease
+++ b/build-tools/makeBinRelease
@@ -29,16 +29,16 @@ git submodule update --init --recursive
 
 if [ -z ${CACTUS_LEGACY_ARCH+x} ]
 then
-	 export CACTUS_ARCH="nehalem"
+	 export sse41=1
 else
-	 export CACTUS_ARCH="nocona"
-	 # abpoa will not work realiably on architectures older than haswell, so make sure it's off by default
+	 export sse2=1
+	 # haven't tested abpoa on older architectures, turn it off by default
 	 sed -i src/cactus/cactus_progressive_config.xml -e 's/partialOrderAlignment="1"/partialOrderAlignment="0"/g'
 fi
 
-export CFLAGS="-march=${CACTUS_ARCH} -static"
-export CXXFLAGS="-march=${CACTUS_ARCH} -static"
-export LDFLAGS="-march=${CACTUS_ARCH} -static"
+export CFLAGS="-static"
+export CXXFLAGS="-static"
+export LDFLAGS="-static"
 
 # build a couple dependencies from source because versions from awk don't support static linking
 pushd .

--- a/pipeline/Makefile
+++ b/pipeline/Makefile
@@ -16,7 +16,8 @@ ${BINDIR}/stPipelineTests : ${libTests} ${LIBDIR}/cactusLib.a ${LIBDEPENDS}
 	${CC} ${CPPFLAGS} ${CFLAGS} -o ${BINDIR}/stPipelineTests ${libTests} ${LIBDIR}/cactusLib.a ${LDLIBS}
 
 ${BINDIR}/cactus_consolidated : cactus_consolidated.c ${LIBDEPENDS} ${commonCafLibs} ${libSources} ${libHeaders}
-	${CC} ${CPPFLAGS} ${CFLAGS} -o ${BINDIR}/cactus_consolidated cactus_consolidated.c ${libSources} ${commonCafLibs} ${LDLIBS}
+# the -Wno-unused-function is required to include abpoa.h with CGL_DEBUG defined
+	${CC} ${CPPFLAGS} ${CFLAGS} -o ${BINDIR}/cactus_consolidated cactus_consolidated.c ${libSources} ${commonCafLibs} ${LDLIBS} -Wno-unused-function
 
 ${BINDIR}/docker_test_script : docker_test_script.py
 	cp docker_test_script.py ${BINDIR}/docker_test_script


### PR DESCRIPTION
By default, abpoa will compile its simd code with `-march=native`.  This leads to non-portable binaries and is inappropriate for the binary and docker releases.  

I'd gotten around this by taking a page out of vg's playbook and using `-march=nehalem` everywhere ,abpoa included.  But now I'm running into obscure segfaults in the abpoa simd code that only happen with the releases.  

So out of desperation, I'm trying to simplify things a bit by:
* never using `-march` (I think by default it should make something very portable for x86 64)
* using variables abpoa expects in order to build it with `-msse41`
* not modifying abpoa in anyway (keeping local fork identical to upstream).  this means reverting little makefile hacks I'd used previously, as well as changes to make it compile without warning.  Will force it to pass `CGL_DEBUG=1 -Wall -Werror` tests on the client side. 
