### PR TITLE
Harmonize base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM quay.io/glennhickey/cactus-ci-base:latest as builder
+FROM ubuntu:bionic-20210615.1 AS builder
 
 # apt dependencies for build
-RUN apt-get update && apt-get install -y build-essential git python3 python3-dev python3-pip zlib1g-dev wget libbz2-dev pkg-config libhdf5-dev liblzo2-dev libtokyocabinet-dev wget liblzma-dev libxml2-dev libssl-dev libpng-dev uuid-dev
+RUN apt-get update && apt-get install -y build-essential git python3 python3-dev python3-pip zlib1g-dev wget libbz2-dev pkg-config libhdf5-dev liblzo2-dev libtokyocabinet-dev wget liblzma-dev libxml2-dev libssl-dev libpng-dev uuid-dev libcurl4-gnutls-dev python
 
 # build cactus binaries
 RUN mkdir -p /home/cactus
@@ -50,10 +50,7 @@ RUN ln -fs /usr/bin/python3 /usr/bin/python
 RUN mkdir -p /wheels && cd /wheels && python3 -m pip install -U pip && python3 -m pip wheel -r /home/cactus/toil-requirement.txt && python3 -m pip wheel /home/cactus
 
 # Create a thinner final Docker image in which only the binaries and necessary data exist.
-# Use Google's non-rate-limited mirror of Docker Hub to get our base image.
-# This helps automated Travis builds because Travis hasn't built a caching system
-# and exposes pull rate limits to users.
-FROM mirror.gcr.io/library/ubuntu:18.04
+FROM ubuntu:bionic-20210615.1
 
 # apt dependencies for runtime
 RUN apt-get update && apt-get install -y --no-install-recommends git python3 python3-pip python3-distutils zlib1g libbz2-1.0 net-tools libhdf5-100 liblzo2-2 libtokyocabinet9 rsync libkrb5-3 libk5crypto3 time liblzma5 libcurl4 libcurl4-gnutls-dev libxml2 libgomp1


### PR DESCRIPTION
Make sure same base images used for both build stages.

This reverts some hacks to speed up docker builds on gitlab (using base with some preinstalled packages) and not crash on travis (use google mirror).  Something similar can be applied down the road (ideally, using the comparative genomics quay and more consistent images)