### PR TITLE
Use avx2 instead of sse4.1 when building abpoa

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,10 @@ RUN apt-get update && apt-get install -y build-essential git python3 python3-dev
 RUN mkdir -p /home/cactus
 COPY . /home/cactus
 
-# Make sure abpoa doesn't build with -march=native, but rather the hopefully more portable -msse4.1
-ENV sse41 1
+# Make sure abpoa doesn't build with -march=native, but something more portable
+# Todo: It would be more portable to use "sse41", but that leads to segfaults in rare cases
+# https://github.com/yangao07/abPOA/issues/26
+ENV avx2 1
 
 # install Phast and enable halPhyloP compilation
 RUN cd /home/cactus && ./build-tools/downloadPhast

--- a/build-tools/makeBinRelease
+++ b/build-tools/makeBinRelease
@@ -29,7 +29,10 @@ git submodule update --init --recursive
 
 if [ -z ${CACTUS_LEGACY_ARCH+x} ]
 then
-	 export sse41=1
+# Make sure abpoa doesn't build with -march=native, but something more portable
+# Todo: It would be more portable to use "sse41", but that leads to segfaults in rare cases
+# https://github.com/yangao07/abPOA/issues/26
+	 export avx2=1
 else
 	 export sse2=1
 	 # haven't tested abpoa on older architectures, turn it off by default


### PR DESCRIPTION
This seems to resolve a segfault that's come up in the pangenomes. 

It's a bit of a shame to bump up the minimum requirements for cactus releases like this given the current build works on almost all cases, but better to have something stable.  Hopefully the underlying issue gets fixed in abpoa and we can go back to sse4.1