### PR TITLE
Add GFAffix option to smooth out pangenome graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Cactus uses many different algorithms and individual code contributions, princip
 - Sneha Goenka and Yatish Turakhia for [SegAlign](https://github.com/gsneha26/SegAlign), the GPU-accelerated version of LastZ.
 - Yan Gao et al. for [abPOA](https://github.com/yangao07/abPOA)
 - Heng Li for [minigraph](https://github.com/lh3/minigraph), [minimap2](https://github.com/lh3/minimap2), [gfatools](https://github.com/lh3/gfatools) and [dna-brnn](https://github.com/lh3/dna-rnn)
+- Dany Doerr for [GFAffix](https://github.com/marschall-lab/GFAffix), used to optionally clean pangenome graphs.
 
 ## Setup
 

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -38,7 +38,7 @@ mkdir -p ${binDir}
 cd ${pangenomeBuildDir}
 git clone https://github.com/lh3/minimap2.git
 cd minimap2
-git checkout c9874e2dc50e32bbff4ded01cf5ec0e9be0a53dd
+git checkout 581f2d7123f651d04c9e103b1c7ea8f7051e909a
 # hack in flags support
 sed -i Makefile -e 's/CFLAGS=/CFLAGS+=/'
 make -j ${numcpu}

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -251,6 +251,18 @@ else
 	 exit 1
 fi	 
 
+# gfaffix
+cd ${pangenomeBuildDir}
+wget -q https://github.com/marschall-lab/GFAffix/releases/download/0.1.2/GFAffix-0.1.2_linux_x86_64.tar.gz
+tar xzf GFAffix-0.1.2_linux_x86_64.tar.gz
+chmod +x GFAffix-0.1.2/gfaffix
+if [[ $STATIC_CHECK -ne 1 || $(ldd GFAffix-0.1.2/gfaffix | grep so | wc -l) -eq 0 ]]
+then
+	 mv GFAffix-0.1.2/gfaffix ${binDir}
+else
+	 exit 1
+fi
+
 cd ${CWD}
 rm -rf ${pangenomeBuildDir}
 


### PR DESCRIPTION
[GFAffix](https://github.com/marschall-lab/GFAffix) is a tool that merges away redundant graph nodes, much in the same way as `vg mod -U`.  This PR adds it as a postprocessing option in `cactus-graphmap-join`.  It'll let us run tests to see if using it instead of mod  helps in practice  