### PR TITLE
WIP: Stable minigraph coordinates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,9 @@ evolver_test_refmap_local: all bin/mafComparator
 evolver_test_graphmap_local: all bin/mafComparator
 	PYTHONPATH="" CACTUS_BINARIES_MODE=local CACTUS_DOCKER_MODE=0 ${PYTHON} -m pytest ${pytestOpts} -s test/evolverTest.py::TestCase::testEvolverMinigraphLocal
 
+evolver_test_graphmap_stable_local: all bin/mafComparator
+	PYTHONPATH="" CACTUS_BINARIES_MODE=local CACTUS_DOCKER_MODE=0 ${PYTHON} -m pytest ${pytestOpts} -s test/evolverTest.py::TestCase::testEvolverMinigraphStableLocal
+
 ##
 # clean targets
 ##

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ There are many different ways to install and run Cactus:
 
 #### Docker Image
 
-Cactus docker images are hosted on [quay](https://quay.io/repository/comparative-genomics-toolkit/cactus).  The image for the latest release is listed on the [Releases Page](https://github.com/ComparativeGenomicsToolkit/cactus/releases).  Here is an command line to run the included evolver mammals example with release 2.0.2
+Cactus docker images are hosted on [quay](https://quay.io/repository/comparative-genomics-toolkit/cactus).  The image for the latest release is listed on the [Releases Page](https://github.com/ComparativeGenomicsToolkit/cactus/releases).  Here is an command line to run the included evolver mammals example with release 2.1.0
 ```
 wget https://raw.githubusercontent.com/ComparativeGenomicsToolkit/cactus/master/examples/evolverMammals.txt
-docker run -v $(pwd):/data --rm -it quay.io/comparative-genomics-toolkit/cactus:v2.0.2 cactus /data/jobStore /data/evolverMammals.txt /data/evolverMammals.hal --root mr --binariesMode local
+docker run -v $(pwd):/data --rm -it quay.io/comparative-genomics-toolkit/cactus:v2.1.0 cactus /data/jobStore /data/evolverMammals.txt /data/evolverMammals.hal --root mr --binariesMode local
 
 ```
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,6 +4,7 @@ Changelog:
 - Option to use stable minigraph coordinates.  This obviates need for phony mingraph genome, whose small contigs can lead to stitching woes in BAR.  
 - Fix cactus-preprocess to work on zipped fasta inputs even when not running dna-brnn.
 - Do centromere clipping using softmasked regions in pangenome pipeline (which means using hash graph instead of packed graph before clipping)
+- Update to abPOA v1.2.5
 
 # Release 2.0.2   2021-07-07
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,4 +1,11 @@
-# Release 2.0.2
+# Release 2.1.0
+
+Changelog:
+- Option to use stable minigraph coordinates.  This obviates need for phony mingraph genome, whose small contigs can lead to stitching woes in BAR.  
+- Fix cactus-preprocess to work on zipped fasta inputs even when not running dna-brnn.
+- Do centromere clipping using softmasked regions in pangenome pipeline (which means using hash graph instead of packed graph before clipping)
+
+# Release 2.0.2   2021-07-07
 
 This release primarily addresses stability issues during pangenome construction.
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,7 +1,12 @@
 # Release 2.1.0
 
+This release adds the `--fastaHeaderTable` option to `cactus-preprocess` and `cactus-graphmap`.  It allows the pangenome pipeline to *not* incorporate sequences from minigraph nodes as contigs in the cactus graph.  It's cleaner to not need the phony minigraph genome, but also avoids cutting up BAR alignments too much due to the small contig sizes, which should prevent a lot of the spurious gaps we have been seeing around minigraph node boundaries.
+
+This release should also finally properly fix an issue that's been coming up since version 2.0.0, where CAF could take days just running the secondary alignment filter.  
+
 Changelog:
-- Option to use stable minigraph coordinates.  This obviates need for phony mingraph genome, whose small contigs can lead to stitching woes in BAR.  
+- Option to use stable minigraph coordinates.  This obviates need for phony mingraph genome, whose small contigs can lead to stitching woes in BAR.
+- Fix new regression that caused CAF's secondary filter to sometimes take forever.  This code has been causing occaisional slowdowns for some time, but should finally be fixed once and for all.
 - Fix cactus-preprocess to work on zipped fasta inputs even when not running dna-brnn.
 - Do centromere clipping using softmasked regions in pangenome pipeline (which means using hash graph instead of packed graph before clipping)
 - Update to abPOA v1.2.5

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -157,7 +157,7 @@ fi
 cd ${pangenomeBuildDir}
 git clone https://github.com/ComparativeGenomicsToolkit/cactus-gfa-tools.git
 cd cactus-gfa-tools
-git checkout af50c877b86f8c430cae3f24cf62b7ea31d43aaf
+git checkout e76210f9834fc0ddf54892211c067ac954b5ffaa
 make -j ${numcpu}
 if [[ $STATIC_CHECK -ne 1 || $(ldd paf2lastz | grep so | wc -l) -eq 0 ]]
 then

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -198,7 +198,7 @@ fi
 
 # hal2vg
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.11/hal2vg
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.12/hal2vg
 chmod +x hal2vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd hal2vg | grep so | wc -l) -eq 0 ]]
 then
@@ -208,7 +208,7 @@ else
 fi
 # clip-vg
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.11/clip-vg
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.12/clip-vg
 chmod +x clip-vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd clip-vg | grep so | wc -l) -eq 0 ]]
 then
@@ -218,7 +218,7 @@ else
 fi
 # halRemoveDupes
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.11/halRemoveDupes
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.12/halRemoveDupes
 chmod +x halRemoveDupes
 if [[ $STATIC_CHECK -ne 1 || $(ldd halRemoveDupes | grep so | wc -l) -eq 0 ]]
 then
@@ -228,7 +228,7 @@ else
 fi
 # halMergeChroms
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.11/halMergeChroms
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.12/halMergeChroms
 chmod +x halMergeChroms
 if [[ $STATIC_CHECK -ne 1 || $(ldd halMergeChroms | grep so | wc -l) -eq 0 ]]
 then

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -157,7 +157,7 @@ fi
 cd ${pangenomeBuildDir}
 git clone https://github.com/ComparativeGenomicsToolkit/cactus-gfa-tools.git
 cd cactus-gfa-tools
-git checkout e76210f9834fc0ddf54892211c067ac954b5ffaa
+git checkout 1ca2f3ae644cbf2f13783e65cd73d468f598738e
 make -j ${numcpu}
 if [[ $STATIC_CHECK -ne 1 || $(ldd paf2lastz | grep so | wc -l) -eq 0 ]]
 then
@@ -192,6 +192,12 @@ fi
 if [[ $STATIC_CHECK -ne 1 || $(ldd pafmask | grep so | wc -l) -eq 0 ]]
 then
 	 mv pafmask ${binDir}
+else
+	 exit 1
+fi
+if [[ $STATIC_CHECK -ne 1 || $(ldd paf2stable | grep so | wc -l) -eq 0 ]]
+then
+	 mv paf2stable ${binDir}
 else
 	 exit 1
 fi

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -204,7 +204,7 @@ fi
 
 # hal2vg
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.12/hal2vg
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.13/hal2vg
 chmod +x hal2vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd hal2vg | grep so | wc -l) -eq 0 ]]
 then
@@ -214,7 +214,7 @@ else
 fi
 # clip-vg
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.12/clip-vg
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.13/clip-vg
 chmod +x clip-vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd clip-vg | grep so | wc -l) -eq 0 ]]
 then
@@ -224,7 +224,7 @@ else
 fi
 # halRemoveDupes
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.12/halRemoveDupes
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.13/halRemoveDupes
 chmod +x halRemoveDupes
 if [[ $STATIC_CHECK -ne 1 || $(ldd halRemoveDupes | grep so | wc -l) -eq 0 ]]
 then
@@ -234,7 +234,7 @@ else
 fi
 # halMergeChroms
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.12/halMergeChroms
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.13/halMergeChroms
 chmod +x halMergeChroms
 if [[ $STATIC_CHECK -ne 1 || $(ldd halMergeChroms | grep so | wc -l) -eq 0 ]]
 then

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -157,7 +157,7 @@ fi
 cd ${pangenomeBuildDir}
 git clone https://github.com/ComparativeGenomicsToolkit/cactus-gfa-tools.git
 cd cactus-gfa-tools
-git checkout 1ca2f3ae644cbf2f13783e65cd73d468f598738e
+git checkout 5cf4d470aa0277a07b711ee545952ff52461a971
 make -j ${numcpu}
 if [[ $STATIC_CHECK -ne 1 || $(ldd paf2lastz | grep so | wc -l) -eq 0 ]]
 then

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -157,7 +157,7 @@ fi
 cd ${pangenomeBuildDir}
 git clone https://github.com/ComparativeGenomicsToolkit/cactus-gfa-tools.git
 cd cactus-gfa-tools
-git checkout 581624b02058c2cad18cbb04aeaf04e24398a6d7
+git checkout b87299cabd3b5283914b5dadb45a1830905722c7
 make -j ${numcpu}
 if [[ $STATIC_CHECK -ne 1 || $(ldd paf2lastz | grep so | wc -l) -eq 0 ]]
 then

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -157,7 +157,7 @@ fi
 cd ${pangenomeBuildDir}
 git clone https://github.com/ComparativeGenomicsToolkit/cactus-gfa-tools.git
 cd cactus-gfa-tools
-git checkout b87299cabd3b5283914b5dadb45a1830905722c7
+git checkout af50c877b86f8c430cae3f24cf62b7ea31d43aaf
 make -j ${numcpu}
 if [[ $STATIC_CHECK -ne 1 || $(ldd paf2lastz | grep so | wc -l) -eq 0 ]]
 then

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -38,7 +38,7 @@ mkdir -p ${binDir}
 cd ${pangenomeBuildDir}
 git clone https://github.com/lh3/minimap2.git
 cd minimap2
-git checkout 581f2d7123f651d04c9e103b1c7ea8f7051e909a
+git checkout c9874e2dc50e32bbff4ded01cf5ec0e9be0a53dd
 # hack in flags support
 sed -i Makefile -e 's/CFLAGS=/CFLAGS+=/'
 make -j ${numcpu}

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -157,7 +157,7 @@ fi
 cd ${pangenomeBuildDir}
 git clone https://github.com/ComparativeGenomicsToolkit/cactus-gfa-tools.git
 cd cactus-gfa-tools
-git checkout 9dbcb8c941b6871301a40e10cbae1326247de166
+git checkout 581624b02058c2cad18cbb04aeaf04e24398a6d7
 make -j ${numcpu}
 if [[ $STATIC_CHECK -ne 1 || $(ldd paf2lastz | grep so | wc -l) -eq 0 ]]
 then

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -332,12 +332,12 @@
 	<!-- includeMinigraph: include minigraph node sequences as paths in output (note that cactus-graphmap-join will still remove them by default) -->
 	<!-- includeAncestor: include ancestral reference sequences as paths in output -->
 	<!-- prependGenomeNames: prepend each output path with the genome name -->
-	<!-- hal2vgOptions: options to use in every hal2vg command -->
+	<!-- hal2vgOptions: options to use in every hal2vg command (note we default to HashGraph (hg) output to keep softmasking) -->
 	<hal2vg
-		 includeMinigraph="1"
+		 includeMinigraph="0"
 		 includeAncestor="0"
 		 prependGenomeNames="1"
-		 hal2vgOptions="--progress --inMemory"
+		 hal2vgOptions="--progress --inMemory --outputFormat hg"
 		 />
   	<multi_cactus>
 		<outgroup

--- a/src/cactus/preprocessor/cutHeaders.py
+++ b/src/cactus/preprocessor/cutHeaders.py
@@ -105,9 +105,9 @@ def make_cut_header_table(job, input_fa_ids, config_node, event_names):
     for prep_node in prep_nodes:
         prep_job_name = getOptionalAttrib(prep_node, 'preprocessJob')
         if prep_job_name == 'cutHeaders' and getOptionalAttrib(prep_node, 'active', typeFn=bool):
-            cut_before = getOptionalAttrib(prep_node, 'cutBefore')
-            cut_before_occ = getOptionalAttrib(prep_node, 'cutBeforeOcc')
-            cut_after = getOptionalAttrib(prep_node, 'cutAfter')
+            cut_before = getOptionalAttrib(prep_node, 'cutBefore', typeFn=str, default=None)
+            cut_before_occ = getOptionalAttrib(prep_node, 'cutBeforeOcc', typeFn=int, default=None)
+            cut_after = getOptionalAttrib(prep_node, 'cutAfter', typeFn=str, default=None)
 
     header_table_ids = []
     root_job = Job()

--- a/src/cactus/preprocessor/cutHeaders.py
+++ b/src/cactus/preprocessor/cutHeaders.py
@@ -12,7 +12,9 @@ from Bio import SeqIO
 from Bio.SeqRecord import SeqRecord
 
 from cactus.shared.common import RoundedJob
+from cactus.shared.common import cactus_call
 from toil.realtimeLogger import RealtimeLogger
+from cactus.shared.common import getOptionalAttrib
 
 class CutHeadersJob(RoundedJob):
     def __init__(self, fastaID, cutBefore, cutBeforeOcc, cutAfter):
@@ -51,29 +53,84 @@ class CutHeadersJob(RoundedJob):
 
         with open(input_path, 'r') as in_file, open(output_path, 'w') as out_file:
             for seq_record in SeqIO.parse(in_file, 'fasta'):
-                header = seq_record.description
-                if self.cutBefore:
-                    occs = [i for i, c in enumerate(header) if c in self.cutBefore]
-                    if occs:
-                        if not self.cutBeforeOcc:
-                            pos = occs[-1]
-                        else:
-                            pos = occs[min(len(occs), self.cutBeforeOcc) - 1]
-                        if pos >= 0:
-                            if pos < len(header) - 1:
-                                header = header[pos + 1:]
-                            else:
-                                header = ""
-                if self.cutAfter:
-                    pos_list = [header.find(c) for c in self.cutAfter if header.find(c) >= 0]
-                    if pos_list:
-                        pos = min(pos_list)
-                        header = header[0:pos]
-
-                if not header:
-                    raise RuntimeError("Error: applying cutHeaders preprocessor removes entire header: {}".format(seq_record.description))
+                header = cut_header(seq_record.description, self.cutBefore, self.cutBeforeOcc, self.cutAfter)
                 seq_record.description = header
                 seq_record.id = header
                 SeqIO.write(seq_record, out_file, 'fasta')
 
         return fileStore.writeGlobalFile(output_path)
+
+def cut_header(header, cutBefore, cutBeforeOcc, cutAfter):
+    if cutBefore:
+        occs = [i for i, c in enumerate(header) if c in cutBefore]
+        if occs:
+            if not cutBeforeOcc:
+                pos = occs[-1]
+            else:
+                pos = occs[min(len(occs), cutBeforeOcc) - 1]
+            if pos >= 0:
+                if pos < len(header) - 1:
+                    header = header[pos + 1:]
+                else:
+                    header = ""
+    if cutAfter:
+        pos_list = [header.find(c) for c in cutAfter if header.find(c) >= 0]
+        if pos_list:
+            pos = min(pos_list)
+            header = header[0:pos]
+
+    if not header:
+        raise RuntimeError("Error: applying cutHeaders preprocessor removes entire header: {}".format(seq_record.description))
+
+    return header
+
+def make_cut_header_table(job, input_fa_ids, config_node, event_names):
+    """
+    make a table of <fasta contig name> <cut contig name> <event> <length> for each fasta contig
+    this is a dirty hack, but required to properly parse the minigraph GFA
+    todo: would be best if this happened during the normal preprocessor, but that requires
+    a (much needed) interface cleanup
+    why? It's because we get names like CHM13#chr1 in the fastas, and need to change them
+    into something browser friendly.  the cutHeaders preprocessor will change it into chr1
+    which is fine, but then we lose the link in the minigraph GFA which uses the original 
+    contig names.  So the same transformation needs to be applied to both the GFA and fastas,
+    which is why we need the preprocessor to keep track of every header it cuts in this table.
+    """
+
+    work_dir = job.fileStore.getLocalTempDir()
+
+    prep_nodes = config_node.findall('preprocessor')
+    found_cut_job = False
+    for prep_node in prep_nodes:
+        prep_job_name = getOptionalAttrib(prep_node, 'preprocessJob')
+        if prep_job_name == 'cutHeaders' and getOptionalAttrib(prep_node, 'active', typeFn=bool):
+            if found_cut_job:
+                raise RuntimeError("Error: multiple cutHeaders jobs not supported for GFA inputs")
+            cut_before = getOptionalAttrib(prep_node, 'cutBefore')
+            cut_before_occ = getOptionalAttrib(prep_node, 'cutBeforeOcc')
+            cut_after = getOptionalAttrib(prep_node, 'cutAfter')
+            found_cut_job = True
+
+    header_table = {}
+    for fa_id, event in zip(input_fa_ids, event_names):
+        fa_path = job.fileStore.readGlobalFile(fa_id)
+        with open(fa_path, 'r') as fa_file:
+            for seq_record in SeqIO.parse(fa_file, 'fasta'):
+                header = seq_record.description
+                if found_cut_job:
+                    header = cut_header(seq_record.description, cut_before, cut_before_occ, cut_after)
+                if seq_record.description in header_table:
+                    raise RuntimeError("Error: fasta header {} found in more than one sample.  Headers must be unique to make table".format(
+                        seq_record.description))
+                header_table[seq_record.description] = (header, event, len(seq_record.seq))
+
+    table_path = job.fileStore.getLocalTempFile()
+    with open(table_path, 'w') as table_file:
+        for k,v in header_table.items():
+            table_file.write('{}\t{}\t{}\t{}\n'.format(k, v[0], v[1], v[2]))
+
+    return job.fileStore.writeGlobalFile(table_path)
+    
+        
+
+    

--- a/src/cactus/refmap/cactus_graphmap.py
+++ b/src/cactus/refmap/cactus_graphmap.py
@@ -50,7 +50,8 @@ def main():
     parser.add_argument("minigraphGFA", help = "Minigraph-compatible reference graph in GFA format (can be gzipped)")
     parser.add_argument("outputPAF", type=str, help = "Output pairwise alignment file in PAF format")
     parser.add_argument("--fastaHeaderTable", type=str,
-                        help="Fasta contig information (from cactus-preprocess) required to not use minigraph node sequences")
+                        help="Fasta contig information (from cactus-preprocess) required to not use minigraph node sequences."
+                        " WARNING: Do not use this option if you plan to run cactus-graphmap-split after.  Rather, give the same option to cactus-graphmap-split instead")
     parser.add_argument("--outputFasta", type=str, help = "Output graph sequence file in FASTA format (required if not present in seqFile)")
     parser.add_argument("--maskFilter", type=int, help = "Ignore softmasked sequence intervals > Nbp (overrides config option of same name)")    
     parser.add_argument("--outputGAFDir", type=str, help = "Output GAF alignments (raw minigraph output before PAF conversion) to this directory")

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -159,7 +159,7 @@ def graphmap_join_workflow(job, options, config, vg_ids, hal_ids):
     clipped_vg_ids = []
     for vg_path, vg_id in zip(options.vg, vg_ids):
         clip_job = root_job.addChildJobFn(clip_vg, options, config, vg_path, vg_id,
-                                          disk=vg_id.size * 2, memory=vg_id.size * 4)
+                                          disk=vg_id.size * 5, memory=vg_id.size * 4)
         clipped_vg_ids.append(clip_job.rv())
 
     # join the ids
@@ -199,35 +199,10 @@ def clip_vg(job, options, config, vg_path, vg_id):
     is_decoy = vg_path == options.decoyGraph
     vg_path = os.path.join(work_dir, os.path.basename(vg_path))
     job.fileStore.readGlobalFile(vg_id, vg_path)
-    out_path = vg_path + '.clip'
+    clipped_path = vg_path + '.clip'
+    out_path = vg_path + '.out'
 
-    # optional normalization.  this will (in theory) correct a lot of small underalignments due to cactus bugs
-    # by zipping up redundant nodes. done before clip-vg otherwise ref paths not guaranteed to be forwardized
-    # todo: would be nice if clip-vg worked on stdin
-    if options.normalizeIterations:
-        normalized_path = vg_path + '.normalized'
-        mod_cmd = ['vg', 'mod', '-U', str(options.normalizeIterations), vg_path]
-        if options.reference:
-            mod_cmd += ['-z', options.reference]
-        cactus_call(parameters=mod_cmd, outfile=normalized_path)
-        # worth it
-        cactus_call(parameters=['vg', 'validate', normalized_path])
-        vg_path = normalized_path
-
-    # GFAFfix is a tool written just to normalize graphs, and alters a (faster) alternative to vg
-    # (though requires GFA conversion)
-    if options.gfaffix:
-        normalized_path = vg_path + '.gfaffixed'
-        gfa_in_path = vg_path + '.gfa'
-        gfa_out_path = normalized_path + '.gfa'
-        cactus_call(parameters=['vg', 'convert', '-f', vg_path], outfile=gfa_in_path)
-        fix_cmd = ['gfaffix', gfa_in_path, '--output_refined', gfa_out_path]
-        if options.reference:
-            fix_cmd += ['--dont_collapse', options.reference + '*']
-        cactus_call(parameters=fix_cmd)
-        # GFAFfix doesn't seem to unchop that well, so we do that in vg after
-        cactus_call(parameters=[['vg', 'convert', '-g', '-a', gfa_out_path], ['vg', 'mod', '-u', '-']], outfile=normalized_path)
-    
+    # remove masked unaligned regions with clip-vg
     cmd = ['clip-vg', vg_path, '-f']
     if options.clipLength is not None and not is_decoy:
         cmd += ['-s', '-u', str(options.clipLength)]
@@ -235,16 +210,51 @@ def clip_vg(job, options, config, vg_path, vg_id):
         cmd += ['-r', rs]
     if options.reference:
         cmd += ['-e', options.reference]
+    cactus_call(parameters=cmd, outfile=clipped_path)        
     
     if getOptionalAttrib(findRequiredNode(config.xmlRoot, "hal2vg"), "includeMinigraph", typeFn=bool, default=False):
         # our vg file has minigraph sequences -- we'll filter them out, along with any nodes
         # that don't appear in a non-minigraph path
         graph_event = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap"), "assemblyName", default="_MINIGRAPH_")
         cmd += ['-d', graph_event]
+    
+    # optional normalization.  this will (in theory) correct a lot of small underalignments due to cactus bugs
+    # by zipping up redundant nodes. done before clip-vg otherwise ref paths not guaranteed to be forwardized
+    # todo: would be nice if clip-vg worked on stdin
+    if options.normalizeIterations:
+        normalized_path = clipped_path + '.normalized'
+        mod_cmd = ['vg', 'mod', '-U', str(options.normalizeIterations), clipped_path]
+        if options.reference:
+            mod_cmd += ['-z', options.reference]
+        cactus_call(parameters=mod_cmd, outfile=normalized_path)
+        # worth it
+        cactus_call(parameters=['vg', 'validate', normalized_path])
+        clipped_path = normalized_path
 
+    # GFAFfix is a tool written just to normalize graphs, and alters a (faster) alternative to vg
+    # (though requires GFA conversion)
+    if options.gfaffix:
+        normalized_path = clipped_path + '.gfaffixed'
+        gfa_in_path = vg_path + '.gfa'
+        gfa_out_path = normalized_path + '.gfa'
+        cactus_call(parameters=['vg', 'convert', '-f', clipped_path], outfile=gfa_in_path)
+        fix_cmd = ['gfaffix', gfa_in_path, '--output_refined', gfa_out_path]
+        if options.reference:
+            fix_cmd += ['--dont_collapse', options.reference + '*']
+        cactus_call(parameters=fix_cmd)
+        # GFAFfix doesn't seem to unchop that well, so we do that in vg after
+        cactus_call(parameters=[['vg', 'convert', '-g', '-a', gfa_out_path], ['vg', 'mod', '-u', '-']], outfile=normalized_path)
+        clipped_path = normalized_path
+
+    
     # sort and convert to packed graph while we're at it
     # (we kept in hashgraph till now in order to use softmasked bases while clipping)
-    cmd = [cmd, ['vg', 'convert', '-p' ,'-'], ['vg', 'ids', '-s', '-']]
+    cmd = [['vg', 'convert', '-p', clipped_path], ['vg', 'ids', '-s', '-']]
+
+    # also forwardize just in case
+    if options.reference and (options.normalizeIterations or options.gfaffix):
+        cmd[0][3] = '-'
+        cmd = [['clip-vg', clipped_path, '-e', options.reference]] + cmd
         
     cactus_call(parameters=cmd, outfile=out_path)
 

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -226,11 +226,11 @@ def clip_vg(job, options, config, vg_path, vg_id):
             fix_cmd += ['--dont_collapse', options.reference + '*']
         cactus_call(parameters=fix_cmd)
         # GFAFfix doesn't seem to unchop that well, so we do that in vg after
-        cactus_call(parameters=[['vg', 'convert', '-g', '-p', gfa_out_path], ['vg', 'mod', '-u', '-']], outfile=normalized_path)
+        cactus_call(parameters=[['vg', 'convert', '-g', '-a', gfa_out_path], ['vg', 'mod', '-u', '-']], outfile=normalized_path)
     
     cmd = ['clip-vg', vg_path, '-f']
     if options.clipLength is not None and not is_decoy:
-        cmd += ['-u', str(options.clipLength)]
+        cmd += ['-s', '-u', str(options.clipLength)]
     for rs in options.rename:
         cmd += ['-r', rs]
     if options.reference:
@@ -242,8 +242,9 @@ def clip_vg(job, options, config, vg_path, vg_id):
         graph_event = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap"), "assemblyName", default="_MINIGRAPH_")
         cmd += ['-d', graph_event]
 
-    # sort while we're at it        
-    cmd = [cmd, ['vg', 'ids', '-s', '-']]
+    # sort and convert to packed graph while we're at it
+    # (we kept in hashgraph till now in order to use softmasked bases while clipping)
+    cmd = [cmd, ['vg', 'convert', '-p' ,'-'], ['vg', 'ids', '-s', '-']]
         
     cactus_call(parameters=cmd, outfile=out_path)
 

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -66,6 +66,7 @@ def main():
     parser.add_argument("--vcfReference", type=str, help = "Reference event for VCF (if different from --reference)")
     parser.add_argument("--rename", nargs='+', default = [], help = "Path renaming, each of form src>dest (see clip-vg -r)")
     parser.add_argument("--clipLength", type=int, default=None, help = "clip out unaligned sequences longer than this")
+    parser.add_argument("--clipMaskFrac", type=float, default=0, help = "only apply --clipLength to sequences containing at least this fraction of masked bases")
     parser.add_argument("--wlineSep", type=str, help = "wline separator for vg convert")
     parser.add_argument("--indexCores", type=int, default=1, help = "cores for indexing processes")
     parser.add_argument("--decoyGraph", help= "decoy sequences vg graph to add (PackedGraph or HashGraph format)")
@@ -205,7 +206,9 @@ def clip_vg(job, options, config, vg_path, vg_id):
     # remove masked unaligned regions with clip-vg
     cmd = ['clip-vg', vg_path, '-f']
     if options.clipLength is not None and not is_decoy:
-        cmd += ['-s', '-u', str(options.clipLength)]
+        cmd += ['-u', str(options.clipLength)]
+        if options.clipMaskFrac is not None:
+            cmd += ['-s', str(options.clipMaskFrac)]
     for rs in options.rename:
         cmd += ['-r', rs]
     if options.reference:

--- a/src/cactus/refmap/cactus_graphmap_split.py
+++ b/src/cactus/refmap/cactus_graphmap_split.py
@@ -132,11 +132,11 @@ def runCactusGraphMapSplit(options):
             #import the sequences (that we need to align for the given event, ie leaves and outgroups)
             seqIDMap = {}
             leaves = set([seqFile.tree.getName(node) for node in seqFile.tree.getLeaves()])
-            
+
+            options.post_stable = False
             if graph_event not in leaves:
                 if not options.fastaHeaderTable:
                     raise RuntimeError("Minigraph name {} not found in seqfile".format(graph_event))
-                options.post_stable = False
             elif options.fastaHeaderTable:
                 options.post_stable = True
             if options.reference and options.reference not in leaves:

--- a/src/cactus/refmap/cactus_graphmap_split.py
+++ b/src/cactus/refmap/cactus_graphmap_split.py
@@ -522,7 +522,7 @@ def combine_splits(job, options, config, seq_id_map, original_id_map, remap_id_m
     # hack hack hack
     # the remap/split logic without this doesn't work with stable coordintes
     if options.fastaHeaderTable:
-        findRequiredNode(config.xmlRoot, "graphmap_split").attrib["useMinimapPAF"] = True
+        findRequiredNode(config.xmlRoot, "graphmap_split").attrib["useMinimapPAF"] = "1"
         
     return root_job.addFollowOnJobFn(combine_paf_splits, options, config, seq_id_map, original_id_map, orig_amb_entry,
                                      remap_id_map, amb_name, graph_event).rv()

--- a/src/cactus/refmap/cactus_graphmap_split.py
+++ b/src/cactus/refmap/cactus_graphmap_split.py
@@ -704,8 +704,8 @@ def stablefy_and_filter_paf(job, gfa_id, paf_id, header_table_id, filter_only):
         job.fileStore.readGlobalFile(gfa_id, gfa_path)
         stable_paf_path = paf_path + ".stable"                
         cactus_call(parameters=['paf2stable', gfa_path, header_table_path, paf_path], outfile = stable_paf_path)
-        paf_path = stable_paf_path
-    
+        return job.fileStore.writeGlobalFile(stable_paf_path)
+            
     fixed_path = paf_path + '.remove_unmapped_targets'
     query_set = set()
     with open(paf_path, 'r') as paf_file:
@@ -772,7 +772,7 @@ def export_split_data(toil, input_seq_id_map, output_id_map, split_log_ids, outp
             for event, fa_path in seq_file_map.items():
                 # cactus can't handle empty fastas.  if there are no sequences for a sample for this
                 # contig, just don't add it.
-                if output_id_map[ref_contig]['fa'][event].size > 0 and (not filter_graph_event or event != graph_event):
+                if output_id_map[ref_contig]['fa'][event].size > 0:
                     seq_file.write('{}\t{}\n'.format(event, fa_path))
         if seq_file_path.startswith('s3://'):
             write_s3(seq_file_temp_path, seq_file_path)

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -383,7 +383,7 @@ def getDockerImage():
 
 def getDockerRelease(gpu=False):
     """Get the most recent docker release."""
-    r = "quay.io/comparative-genomics-toolkit/cactus:v2.0.2"
+    r = "quay.io/comparative-genomics-toolkit/cactus:v2.1.0"
     if gpu:
         r += "-gpu"
     return r

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -1065,12 +1065,7 @@ def zip_gzs(job, input_paths, input_ids, list_elems = None):
     zipped_ids = []
     for input_path, input_list in zip(input_paths, input_ids):
         if input_path.endswith('.gz'):
-            try:
-                iter(input_list)
-                is_list = True
-            except:
-                is_list = False
-            if is_list:
+            if isinstance(input_list, list) or isinstance(input_list, tuple):
                 output_list = []
                 for i, elem in enumerate(input_list):
                     if not list_elems or i in list_elems:
@@ -1079,7 +1074,7 @@ def zip_gzs(job, input_paths, input_ids, list_elems = None):
                         output_list.append(elem)
                 zipped_ids.append(output_list)
             else:
-                zipped_ids.append(job.addChildJobFn(zip_gz, input_path, input_id, disk=2*input_id.size).rv())
+                zipped_ids.append(job.addChildJobFn(zip_gz, input_path, input_list, disk=2*input_list.size).rv())
         else:
             zipped_ids.append(input_list)
     return zipped_ids

--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -222,6 +222,7 @@ class TestCase(unittest.TestCase):
 
         # make the reference graph
         mg_cmd = ['minigraph', '-xggs', '-t', '4']
+        ref_event = None
         with open(seq_file_path, 'r') as seq_file:
             for line in seq_file:
                 toks = line.strip().split()
@@ -229,6 +230,8 @@ class TestCase(unittest.TestCase):
                     name = os.path.basename(toks[1])
                     subprocess.check_call(['wget', toks[1]], cwd=self.tempDir)
                     mg_cmd += [os.path.join(self.tempDir, name)]
+                    if not ref_event:
+                        ref_event = toks[0]
         mg_path = os.path.join(self.tempDir, 'refgraph.gfa')
         with open(mg_path, 'w') as mg_file:
             subprocess.check_call(mg_cmd, stdout=mg_file)
@@ -242,8 +245,9 @@ class TestCase(unittest.TestCase):
         # todo: it'd be nice to have an interface for setting tag to something not latest or commit
         if binariesMode == 'docker':
             cactus_opts += ['--latest']
-        
-        subprocess.check_call(['cactus-graphmap', self._job_store(binariesMode), out_seq_file_path, mg_path, paf_path] + cactus_opts + ht_opts)
+
+        gm_opts = ['--refFromGFA', ref_event] if stable else []
+        subprocess.check_call(['cactus-graphmap', self._job_store(binariesMode), out_seq_file_path, mg_path, paf_path] + cactus_opts + ht_opts + gm_opts)
 
         # do the alignment
         subprocess.check_call(['cactus-align', self._job_store(binariesMode), out_seq_file_path, paf_path, self._out_hal(binariesMode),


### PR DESCRIPTION
The cactus-graphmap workflow aligns all input assemblies to a minigraph, then treats the nodes of the minigraph as contigs in a "virtual" genome.  Cactus can then get its input alignment anchors transitively through these nodes, and the mingraph paths can be dropped out of the final outputs, and everything works fine. 

The problem is that in variable regions, the minigraph nodes can be quite small.  These small contigs break up BAR jobs that would otherwise be done together.  And it seems there's a problem with the code that stitches together individual BAR alignments, where it can forget to align bases at the borders.  Having the tiny minigraph contigs exacerbates this issue, leading to lots of spurious little alignment gaps.

So this PR adds the option to work in minigraph's stable coordinates from the get-go.  When aligning an assembly to the graph, we report its mappings to each of the underlying reference sequences rather than the minigraph node itself.  Apart from making the parsing trickier, there are 2 issues:
* The reference contig length needs to be known, but it's not present in the minigraph output
* The contig names in the minigraph output may not be consistent with the fastas used for mapping due to preprocessing to remove browser-incompatible characters

To work around these, the `--fastaHeaderTable` option is added to `cactus-preprocess`, which will save the necessary information from the original fasta inputs.  The same option must be given to `cactus-graphmap` in order for it to work.  If this option isn't given, the old logic of using the minigraph nodes is used. 