### PR TITLE
drop minigraph event when reading paf in cactus-align

### DIFF
--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -157,7 +157,7 @@ fi
 cd ${pangenomeBuildDir}
 git clone https://github.com/ComparativeGenomicsToolkit/cactus-gfa-tools.git
 cd cactus-gfa-tools
-git checkout 9dbcb8c941b6871301a40e10cbae1326247de166
+git checkout a852026a7d9b0b6eb743f7139184d1db81e6b585
 make -j ${numcpu}
 if [[ $STATIC_CHECK -ne 1 || $(ldd paf2lastz | grep so | wc -l) -eq 0 ]]
 then
@@ -192,6 +192,12 @@ fi
 if [[ $STATIC_CHECK -ne 1 || $(ldd pafmask | grep so | wc -l) -eq 0 ]]
 then
 	 mv pafmask ${binDir}
+else
+	 exit 1
+fi
+if [[ $STATIC_CHECK -ne 1 || $(ldd paf2stable | grep so | wc -l) -eq 0 ]]
+then
+	 mv paf2stable ${binDir}
 else
 	 exit 1
 fi

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -511,11 +511,10 @@ def mask_and_convert_paf(job, cactusWorkflowArguments, pafSecondaries, mask_bed_
     if mask_bed_id:
         paf_to_lastz_disk += mask_bed_id.size
     if paf_to_stable:
-        paf_to_lastz_disk += cactusWorkflowArguments.alignmentsID.size * 10
+        paf_to_lastz_disk += cactusWorkflowArguments.alignmentsID.size * 6
     paf_to_lastz_job = job.addChildJobFn(paf_to_lastz, cactusWorkflowArguments.alignmentsID, sort_secondaries=True,
                                          mask_bed_id=mask_bed_id, paf_to_stable=paf_to_stable,
-                                         disk=paf_to_lastz_disk,
-                                         memory=paf_to_lastz_disk)
+                                         disk=paf_to_lastz_disk)
     cactusWorkflowArguments.alignmentsID = paf_to_lastz_job.rv(0)
     cactusWorkflowArguments.secondaryAlignmentsID = paf_to_lastz_job.rv(1) if pafSecondaries else None
     return cactusWorkflowArguments

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -272,6 +272,26 @@ def make_align_job(options, toil):
     if options.pafMaskFilter and not options.pafInput:
         raise RuntimeError("--pafMaskFilter can only be run with --pafInput")
 
+    paf_to_stable = False
+    if options.pafInput:
+        # remove minigraph event from input seqfile
+        # TODO: this could be an option if someone wanted to keep it around for some reason,
+        # otherwise, best to never add it in the first place
+        seqFile = SeqFile(options.seqFile)
+        configNode = ET.parse(options.configFile).getroot()
+        graph_event = getOptionalAttrib(findRequiredNode(configNode, "graphmap"), "assemblyName", default="_MINIGRAPH_")
+        if graph_event in seqFile.pathMap:
+            del seqFile.pathMap[graph_event]
+            tree = MultiCactusTree(seqFile.tree)
+            seqFile.tree.removeLeaf(tree.getNodeId(graph_event))
+            override_seq = os.path.join(options.cactusDir, 'seqFile.override')
+            with open(override_seq, 'w') as out_sf:
+                out_sf.write(str(seqFile))
+            options.seqFile = override_seq
+            # toggling this on will put the input paf through paf2stable which will replace all minigraph targets
+            # with query sequences using transitive mapping
+            paf_to_stable = True
+            
     #to be consistent with all-in-one cactus, we make sure the project
     #isn't limiting itself to the subtree (todo: parameterize so root can
     #be passed through from prepare to blast/align)
@@ -425,11 +445,12 @@ def make_align_job(options, toil):
                               doGFA=options.outGFA,
                               eventNameAsID=options.eventNameAsID,
                               referenceEvent=options.reference,
-                              pafMaskFilter=options.pafMaskFilter)
+                              pafMaskFilter=options.pafMaskFilter,
+                              paf2Stable=paf_to_stable)
     return align_job
 
 def run_cactus_align(job, configWrapper, cactusWorkflowArguments, project, checkpointInfo, doRenaming, pafInput, pafSecondaries, doVG, doGFA, delay=0,
-                     eventNameAsID=False, referenceEvent=None, pafMaskFilter=None):
+                     eventNameAsID=False, referenceEvent=None, pafMaskFilter=None, paf2Stable=False):
     
     head_job = Job()
     job.addChild(head_job)
@@ -453,7 +474,7 @@ def run_cactus_align(job, configWrapper, cactusWorkflowArguments, project, check
     if pafInput:
         # convert the paf input to lastz format, splitting out into primary and secondary files
         # optionally apply the masking
-        cur_job = cur_job.addFollowOnJobFn(mask_and_convert_paf, cactusWorkflowArguments, pafSecondaries, mask_bed_id)        
+        cur_job = cur_job.addFollowOnJobFn(mask_and_convert_paf, cactusWorkflowArguments, pafSecondaries, mask_bed_id, paf2Stable)
         cactusWorkflowArguments = cur_job.rv()
     
     if no_ingroup_coverage:
@@ -484,9 +505,17 @@ def run_cactus_align(job, configWrapper, cactusWorkflowArguments, project, check
         
     return hal_export_job.rv(), vg_file_id, gfa_file_id
 
-def mask_and_convert_paf(job, cactusWorkflowArguments, pafSecondaries, mask_bed_id):
+def mask_and_convert_paf(job, cactusWorkflowArguments, pafSecondaries, mask_bed_id, paf_to_stable):
     """ convert to lastz and run masking.  just wraps paf_to_lastz, but resolves the workflow promise on the way """
-    paf_to_lastz_job = job.addChildJobFn(paf_to_lastz, cactusWorkflowArguments.alignmentsID, True, mask_bed_id)
+    paf_to_lastz_disk = cactusWorkflowArguments.alignmentsID.size * 2
+    if mask_bed_id:
+        paf_to_lastz_disk += mask_bed_id.size
+    if paf_to_stable:
+        paf_to_lastz_disk += cactusWorkflowArguments.alignmentsID.size * 10
+    paf_to_lastz_job = job.addChildJobFn(paf_to_lastz, cactusWorkflowArguments.alignmentsID, sort_secondaries=True,
+                                         mask_bed_id=mask_bed_id, paf_to_stable=paf_to_stable,
+                                         disk=paf_to_lastz_disk,
+                                         memory=paf_to_lastz_disk)
     cactusWorkflowArguments.alignmentsID = paf_to_lastz_job.rv(0)
     cactusWorkflowArguments.secondaryAlignmentsID = paf_to_lastz_job.rv(1) if pafSecondaries else None
     return cactusWorkflowArguments


### PR DESCRIPTION
Sending the minigraph nodes into Cactus as contigs can cause problems (#544).  Using stable coordinates from minigraph to get around this was [even worse](https://github.com/ComparativeGenomicsToolkit/cactus/pull/544#issuecomment-885155823).  

This PR works directly on the PAF input given to `cactus-align`, where all target sequences get replaced with query sequences that map to them.  In doing so, it avoids introducing conflicts from the graph annotation, all event name hassles, as well as changes to `cactus-graphmap-split` which, being upstream, can keep making use of minigraph node ids.  

On chr20 for the 90-way pangenome, the conversion takes `3min` and `800M` RAM.  The output PAF is `1.1G` vs `179M` for the input, so I think this should scale up to chr1 (and probably some low-hanging fruit to improve speed a bit if needed).  

Still a bit of minor cleanup to do to either make minigraph removable togglable in the config, as well as to review how its used in postprocessing.   
