### PR TITLE
Experiment: try moving bar mask filter inside abpoa

### DIFF
--- a/bar/inc/poaBarAligner.h
+++ b/bar/inc/poaBarAligner.h
@@ -67,6 +67,7 @@ void msa_print(Msa *msa, FILE *f);
  * @param seq_lens An array giving the string lengths
  * @param seq_no The number of strings
  * @param window_size Sliding window size which limits length of poa sub-alignments.  Memory usage is quardatic in this. 
+ * @param mask_filter mask input sequences if encountering this many consecutive soft of hard masked bases (0 = disabled)
  * @param poa_parameters abpoa parameters
  * @return An msa of the strings.
  */
@@ -74,6 +75,7 @@ Msa *msa_make_partial_order_alignment(char **seqs,
                                       int *seq_lens,
                                       int64_t seq_no,
                                       int64_t window_size,
+                                      int64_t mask_filter,
                                       abpoa_para_t *poa_parameters);
 
 /**
@@ -95,12 +97,13 @@ Msa *msa_make_partial_order_alignment(char **seqs,
  * @param right_end_row_indexes For each string, the index of the row of its reverse complement
  * @param overlaps For each prefix string, the length of the overlap with its reverse complement adjacency
  * @param window_size Sliding window size which limits length of poa sub-alignments.  Memory usage is quardatic in this. 
+ * @param mask_filter mask input sequences if encountering this many consecutive soft of hard masked bases (0 = disabled)
  * @param poa_parameters abpoa parameters
  * @return A consistent Msa for each end
  */
 Msa **make_consistent_partial_order_alignments(int64_t end_no, int64_t *end_lengths, char ***end_strings,
         int **end_string_lengths, int64_t **right_end_indexes, int64_t **right_end_row_indexes, int64_t **overlaps,
-        int64_t window_size, abpoa_para_t *poa_parameters);
+        int64_t window_size, int64_t mask_filter, abpoa_para_t *poa_parameters);
 
 /**
  * Represents a gapless alignment of a set of sequences.

--- a/bar/tests/poaBarTest.c
+++ b/bar/tests/poaBarTest.c
@@ -59,7 +59,7 @@ void test_make_partial_order_alignment(CuTest *testCase) {
             }
 
             // generate the alignment
-            Msa *msa = msa_make_partial_order_alignment(seqs, seq_lens, seq_no, poa_window_size, abpt);
+            Msa *msa = msa_make_partial_order_alignment(seqs, seq_lens, seq_no, poa_window_size, 0, abpt);
 
             // print the msa
             msa_print(msa, stderr);
@@ -135,7 +135,7 @@ void test_make_consistent_partial_order_alignments_two_ends(CuTest *testCase) {
 
         // generate the alignments
         Msa **msas = make_consistent_partial_order_alignments(end_no, end_lengths, end_strings, end_string_lengths,
-                                                              right_end_indexes, right_end_row_indexes, overlaps, 1000000, abpt);
+                                                              right_end_indexes, right_end_row_indexes, overlaps, 1000000, 0, abpt);
 
         // print the msas
         for(int64_t i=0; i<end_no; i++) {

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -157,7 +157,7 @@ fi
 cd ${pangenomeBuildDir}
 git clone https://github.com/ComparativeGenomicsToolkit/cactus-gfa-tools.git
 cd cactus-gfa-tools
-git checkout 9dbcb8c941b6871301a40e10cbae1326247de166
+git checkout a852026a7d9b0b6eb743f7139184d1db81e6b585
 make -j ${numcpu}
 if [[ $STATIC_CHECK -ne 1 || $(ldd paf2lastz | grep so | wc -l) -eq 0 ]]
 then
@@ -192,6 +192,12 @@ fi
 if [[ $STATIC_CHECK -ne 1 || $(ldd pafmask | grep so | wc -l) -eq 0 ]]
 then
 	 mv pafmask ${binDir}
+else
+	 exit 1
+fi
+if [[ $STATIC_CHECK -ne 1 || $(ldd paf2stable | grep so | wc -l) -eq 0 ]]
+then
+	 mv paf2stable ${binDir}
 else
 	 exit 1
 fi

--- a/src/cactus/refmap/cactus_graphmap_split.py
+++ b/src/cactus/refmap/cactus_graphmap_split.py
@@ -402,6 +402,9 @@ def split_minimap_fallback(job, options, config, seqIDMap, output_id_map):
     """ take the output table from gather_fas, pull out the ambiguous sequences, remap them to the reference, and 
     add them to the events where possible"""
 
+    if not getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_split"), "remap", typeFn=bool, default=False):
+        return None, None
+    
     # can't do anything without a reference
     if not options.reference:
         logger.info("Skipping minimap2 fallback as --reference was not specified")

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -511,11 +511,10 @@ def mask_and_convert_paf(job, cactusWorkflowArguments, pafSecondaries, mask_bed_
     if mask_bed_id:
         paf_to_lastz_disk += mask_bed_id.size
     if paf_to_stable:
-        paf_to_lastz_disk += cactusWorkflowArguments.alignmentsID.size * 10
+        paf_to_lastz_disk += cactusWorkflowArguments.alignmentsID.size * 6
     paf_to_lastz_job = job.addChildJobFn(paf_to_lastz, cactusWorkflowArguments.alignmentsID, sort_secondaries=True,
                                          mask_bed_id=mask_bed_id, paf_to_stable=paf_to_stable,
-                                         disk=paf_to_lastz_disk,
-                                         memory=paf_to_lastz_disk)
+                                         disk=paf_to_lastz_disk)
     cactusWorkflowArguments.alignmentsID = paf_to_lastz_job.rv(0)
     cactusWorkflowArguments.secondaryAlignmentsID = paf_to_lastz_job.rv(1) if pafSecondaries else None
     return cactusWorkflowArguments

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -272,6 +272,26 @@ def make_align_job(options, toil):
     if options.pafMaskFilter and not options.pafInput:
         raise RuntimeError("--pafMaskFilter can only be run with --pafInput")
 
+    paf_to_stable = False
+    if options.pafInput:
+        # remove minigraph event from input seqfile
+        # TODO: this could be an option if someone wanted to keep it around for some reason,
+        # otherwise, best to never add it in the first place
+        seqFile = SeqFile(options.seqFile)
+        configNode = ET.parse(options.configFile).getroot()
+        graph_event = getOptionalAttrib(findRequiredNode(configNode, "graphmap"), "assemblyName", default="_MINIGRAPH_")
+        if graph_event in seqFile.pathMap:
+            del seqFile.pathMap[graph_event]
+            tree = MultiCactusTree(seqFile.tree)
+            seqFile.tree.removeLeaf(tree.getNodeId(graph_event))
+            override_seq = os.path.join(options.cactusDir, 'seqFile.override')
+            with open(override_seq, 'w') as out_sf:
+                out_sf.write(str(seqFile))
+            options.seqFile = override_seq
+            # toggling this on will put the input paf through paf2stable which will replace all minigraph targets
+            # with query sequences using transitive mapping
+            paf_to_stable = True
+            
     #to be consistent with all-in-one cactus, we make sure the project
     #isn't limiting itself to the subtree (todo: parameterize so root can
     #be passed through from prepare to blast/align)
@@ -425,11 +445,12 @@ def make_align_job(options, toil):
                               doGFA=options.outGFA,
                               eventNameAsID=options.eventNameAsID,
                               referenceEvent=options.reference,
-                              pafMaskFilter=options.pafMaskFilter)
+                              pafMaskFilter=options.pafMaskFilter,
+                              paf2Stable=paf_to_stable)
     return align_job
 
 def run_cactus_align(job, configWrapper, cactusWorkflowArguments, project, checkpointInfo, doRenaming, pafInput, pafSecondaries, doVG, doGFA, delay=0,
-                     eventNameAsID=False, referenceEvent=None, pafMaskFilter=None):
+                     eventNameAsID=False, referenceEvent=None, pafMaskFilter=None, paf2Stable=False):
     
     head_job = Job()
     job.addChild(head_job)
@@ -453,7 +474,7 @@ def run_cactus_align(job, configWrapper, cactusWorkflowArguments, project, check
     if pafInput:
         # convert the paf input to lastz format, splitting out into primary and secondary files
         # optionally apply the masking
-        cur_job = cur_job.addFollowOnJobFn(mask_and_convert_paf, cactusWorkflowArguments, pafSecondaries, mask_bed_id)        
+        cur_job = cur_job.addFollowOnJobFn(mask_and_convert_paf, cactusWorkflowArguments, pafSecondaries, mask_bed_id, paf2Stable)
         cactusWorkflowArguments = cur_job.rv()
     
     if no_ingroup_coverage:
@@ -484,9 +505,17 @@ def run_cactus_align(job, configWrapper, cactusWorkflowArguments, project, check
         
     return hal_export_job.rv(), vg_file_id, gfa_file_id
 
-def mask_and_convert_paf(job, cactusWorkflowArguments, pafSecondaries, mask_bed_id):
+def mask_and_convert_paf(job, cactusWorkflowArguments, pafSecondaries, mask_bed_id, paf_to_stable):
     """ convert to lastz and run masking.  just wraps paf_to_lastz, but resolves the workflow promise on the way """
-    paf_to_lastz_job = job.addChildJobFn(paf_to_lastz, cactusWorkflowArguments.alignmentsID, True, mask_bed_id)
+    paf_to_lastz_disk = cactusWorkflowArguments.alignmentsID.size * 2
+    if mask_bed_id:
+        paf_to_lastz_disk += mask_bed_id.size
+    if paf_to_stable:
+        paf_to_lastz_disk += cactusWorkflowArguments.alignmentsID.size * 10
+    paf_to_lastz_job = job.addChildJobFn(paf_to_lastz, cactusWorkflowArguments.alignmentsID, sort_secondaries=True,
+                                         mask_bed_id=mask_bed_id, paf_to_stable=paf_to_stable,
+                                         disk=paf_to_lastz_disk,
+                                         memory=paf_to_lastz_disk)
     cactusWorkflowArguments.alignmentsID = paf_to_lastz_job.rv(0)
     cactusWorkflowArguments.secondaryAlignmentsID = paf_to_lastz_job.rv(1) if pafSecondaries else None
     return cactusWorkflowArguments


### PR DESCRIPTION
The current mask filter just cuts off sequences after a run of bases.  I'm worried that's [not playing nice with recoverable chains, though]((https://github.com/ComparativeGenomicsToolkit/cactus/pull/551#issuecomment-889360595).  What if CAF pulls apart a bunch of blocks after a masked region -- they won't be found again.  

This PR is to test a little hack where the mask filter is run by hardmasking regions but still sending them through abpoa (and making sure the score matrix sends Ns to gaps) .  In theory, if we have a nice alignment after long masked regions, abpoa should be able to pick it up like this.  