### PR TITLE
Dust off preprocessor contig-clipping

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,11 @@
+# Release 2.1.0
+
+This release features improvements to the pangenome pipeline.
+
+- Turn recoverable chains length down to 10kb to prevent CAF from pulling apart more than BAR can realign in a single POA window
+- Automatically strip minigraph contigs out of input to `cactus-align`.  This leads to bigger blocks and smoother graphs (but requires above change)
+- Fix up clipping option in the preprocessor to work with `--fileMask` option, as well as to produce fasta contig names that `hal2vg` accepts (and the browser allows).  Clipping is now to be preferred over the various `--maskFilter and --barMaskFilter` options used to ignore softmasked sequence.
+
 # Release 2.0.3
 
 This release fixes some issues in pangenome normalization and CAF running time.

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -204,7 +204,7 @@ fi
 
 # hal2vg
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.11/hal2vg
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.14/hal2vg
 chmod +x hal2vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd hal2vg | grep so | wc -l) -eq 0 ]]
 then
@@ -214,7 +214,7 @@ else
 fi
 # clip-vg
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.11/clip-vg
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.14/clip-vg
 chmod +x clip-vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd clip-vg | grep so | wc -l) -eq 0 ]]
 then
@@ -224,7 +224,7 @@ else
 fi
 # halRemoveDupes
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.11/halRemoveDupes
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.14/halRemoveDupes
 chmod +x halRemoveDupes
 if [[ $STATIC_CHECK -ne 1 || $(ldd halRemoveDupes | grep so | wc -l) -eq 0 ]]
 then
@@ -234,7 +234,7 @@ else
 fi
 # halMergeChroms
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.11/halMergeChroms
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.14/halMergeChroms
 chmod +x halMergeChroms
 if [[ $STATIC_CHECK -ne 1 || $(ldd halMergeChroms | grep so | wc -l) -eq 0 ]]
 then

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -157,7 +157,7 @@ fi
 cd ${pangenomeBuildDir}
 git clone https://github.com/ComparativeGenomicsToolkit/cactus-gfa-tools.git
 cd cactus-gfa-tools
-git checkout 9dbcb8c941b6871301a40e10cbae1326247de166
+git checkout a852026a7d9b0b6eb743f7139184d1db81e6b585
 make -j ${numcpu}
 if [[ $STATIC_CHECK -ne 1 || $(ldd paf2lastz | grep so | wc -l) -eq 0 ]]
 then
@@ -192,6 +192,12 @@ fi
 if [[ $STATIC_CHECK -ne 1 || $(ldd pafmask | grep so | wc -l) -eq 0 ]]
 then
 	 mv pafmask ${binDir}
+else
+	 exit 1
+fi
+if [[ $STATIC_CHECK -ne 1 || $(ldd paf2stable | grep so | wc -l) -eq 0 ]]
+then
+	 mv paf2stable ${binDir}
 else
 	 exit 1
 fi

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -398,7 +398,9 @@ def make_align_job(options, toil):
         # turn off mapq filtering
         cafNode.attrib["runMapQFiltering"] = "0"
         # more iterations here helps quite a bit to reduce underalignment
-        cafNode.attrib["maxRecoverableChainsIterations"] = "50"                
+        cafNode.attrib["maxRecoverableChainsIterations"] = "50"
+        # pulling apart a recoverable chain bigger than the poa window is counterproductive
+        cafNode.attrib["maxRecoverableChainLength"] = "10000"
         # turn down minimum block degree to get a fat ancestor
         barNode.attrib["minimumBlockDegree"] = "1"
         # turn on POA

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -511,11 +511,10 @@ def mask_and_convert_paf(job, cactusWorkflowArguments, pafSecondaries, mask_bed_
     if mask_bed_id:
         paf_to_lastz_disk += mask_bed_id.size
     if paf_to_stable:
-        paf_to_lastz_disk += cactusWorkflowArguments.alignmentsID.size * 10
+        paf_to_lastz_disk += cactusWorkflowArguments.alignmentsID.size * 6
     paf_to_lastz_job = job.addChildJobFn(paf_to_lastz, cactusWorkflowArguments.alignmentsID, sort_secondaries=True,
                                          mask_bed_id=mask_bed_id, paf_to_stable=paf_to_stable,
-                                         disk=paf_to_lastz_disk,
-                                         memory=paf_to_lastz_disk)
+                                         disk=paf_to_lastz_disk)
     cactusWorkflowArguments.alignmentsID = paf_to_lastz_job.rv(0)
     cactusWorkflowArguments.secondaryAlignmentsID = paf_to_lastz_job.rv(1) if pafSecondaries else None
     return cactusWorkflowArguments

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -272,6 +272,26 @@ def make_align_job(options, toil):
     if options.pafMaskFilter and not options.pafInput:
         raise RuntimeError("--pafMaskFilter can only be run with --pafInput")
 
+    paf_to_stable = False
+    if options.pafInput:
+        # remove minigraph event from input seqfile
+        # TODO: this could be an option if someone wanted to keep it around for some reason,
+        # otherwise, best to never add it in the first place
+        seqFile = SeqFile(options.seqFile)
+        configNode = ET.parse(options.configFile).getroot()
+        graph_event = getOptionalAttrib(findRequiredNode(configNode, "graphmap"), "assemblyName", default="_MINIGRAPH_")
+        if graph_event in seqFile.pathMap:
+            del seqFile.pathMap[graph_event]
+            tree = MultiCactusTree(seqFile.tree)
+            seqFile.tree.removeLeaf(tree.getNodeId(graph_event))
+            override_seq = os.path.join(options.cactusDir, 'seqFile.override')
+            with open(override_seq, 'w') as out_sf:
+                out_sf.write(str(seqFile))
+            options.seqFile = override_seq
+            # toggling this on will put the input paf through paf2stable which will replace all minigraph targets
+            # with query sequences using transitive mapping
+            paf_to_stable = True
+            
     #to be consistent with all-in-one cactus, we make sure the project
     #isn't limiting itself to the subtree (todo: parameterize so root can
     #be passed through from prepare to blast/align)
@@ -425,11 +445,12 @@ def make_align_job(options, toil):
                               doGFA=options.outGFA,
                               eventNameAsID=options.eventNameAsID,
                               referenceEvent=options.reference,
-                              pafMaskFilter=options.pafMaskFilter)
+                              pafMaskFilter=options.pafMaskFilter,
+                              paf2Stable=paf_to_stable)
     return align_job
 
 def run_cactus_align(job, configWrapper, cactusWorkflowArguments, project, checkpointInfo, doRenaming, pafInput, pafSecondaries, doVG, doGFA, delay=0,
-                     eventNameAsID=False, referenceEvent=None, pafMaskFilter=None):
+                     eventNameAsID=False, referenceEvent=None, pafMaskFilter=None, paf2Stable=False):
     
     head_job = Job()
     job.addChild(head_job)
@@ -453,7 +474,7 @@ def run_cactus_align(job, configWrapper, cactusWorkflowArguments, project, check
     if pafInput:
         # convert the paf input to lastz format, splitting out into primary and secondary files
         # optionally apply the masking
-        cur_job = cur_job.addFollowOnJobFn(mask_and_convert_paf, cactusWorkflowArguments, pafSecondaries, mask_bed_id)        
+        cur_job = cur_job.addFollowOnJobFn(mask_and_convert_paf, cactusWorkflowArguments, pafSecondaries, mask_bed_id, paf2Stable)
         cactusWorkflowArguments = cur_job.rv()
     
     if no_ingroup_coverage:
@@ -484,9 +505,17 @@ def run_cactus_align(job, configWrapper, cactusWorkflowArguments, project, check
         
     return hal_export_job.rv(), vg_file_id, gfa_file_id
 
-def mask_and_convert_paf(job, cactusWorkflowArguments, pafSecondaries, mask_bed_id):
+def mask_and_convert_paf(job, cactusWorkflowArguments, pafSecondaries, mask_bed_id, paf_to_stable):
     """ convert to lastz and run masking.  just wraps paf_to_lastz, but resolves the workflow promise on the way """
-    paf_to_lastz_job = job.addChildJobFn(paf_to_lastz, cactusWorkflowArguments.alignmentsID, True, mask_bed_id)
+    paf_to_lastz_disk = cactusWorkflowArguments.alignmentsID.size * 2
+    if mask_bed_id:
+        paf_to_lastz_disk += mask_bed_id.size
+    if paf_to_stable:
+        paf_to_lastz_disk += cactusWorkflowArguments.alignmentsID.size * 10
+    paf_to_lastz_job = job.addChildJobFn(paf_to_lastz, cactusWorkflowArguments.alignmentsID, sort_secondaries=True,
+                                         mask_bed_id=mask_bed_id, paf_to_stable=paf_to_stable,
+                                         disk=paf_to_lastz_disk,
+                                         memory=paf_to_lastz_disk)
     cactusWorkflowArguments.alignmentsID = paf_to_lastz_job.rv(0)
     cactusWorkflowArguments.secondaryAlignmentsID = paf_to_lastz_job.rv(1) if pafSecondaries else None
     return cactusWorkflowArguments

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -1116,3 +1116,13 @@ def write_s3(local_path, s3_path, region=None):
             s3.create_bucket(Bucket=bucket_name)
 
     s3.upload_file(local_path, bucket_name, name_prefix)
+
+def get_faidx_subpath_rename_cmd():
+    """
+    transform chr1:10-15 (1-based inclusive) into chr1_sub_9_15 (0-based end open)
+    this is a format that contains no special characters in order to make assembly hubs
+    happy.  But it does require conversion going into vg which wants chr[9-15] and
+    hal2vg is updated to do this autmatically
+    """
+    return ['sed', '-e', 's/\([^:]*\):\([0-9]*\)-\([0-9]*\)/echo "\\1_sub_$((\\2-1))_\\3"/e']
+


### PR DESCRIPTION
(Includes #551)

The pangenome pipeline doesn't work great yet on centromeres, so it's best to mask them out in the preprocessor.  Way back at the beginning, I was clipping them out entirely, and putting the fasta pieces through cactus.  But then I switched to softmasking them, and having Cactus ignore them (`--maskFilter option in `cactus-graphmap` and `cactus-graphmap-split`, then `--barMaskFilter` option in `cactus-align`). They could be removed later with `cactus-graphmap-join --clipLength`

The advantages: original sequences are preserved, intact, in the HAL

The disadvantages: It's a hassle to pass through the masking information at every step.  Especially in BAR, where I wonder if masked sequences at the edges of recoverable chains aren't leading to underalignment. 

So I'm going to try going back to clipping, and this PR cleans up a few things to get it working again.  It also makes sure that clipped sequences get suffixes of the form  `_sub_10_100` (which `hal2vg` translates into something vg understands), as opposed to the vg-style or samtools-style suffixes which aren't compatible with the browser. 

Both options (clipping/softmasking) should work going forward.   