### PR TITLE
Reduce default recoverable chains length from 500k to 10k

### DIFF
--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -157,7 +157,7 @@
 		 maximumMedianSequenceLengthBetweenLinkedEnds="1000"
 		 removeRecoverableChains="unequalNumberOfIngroupCopies"
 		 maxRecoverableChainsIterations="5"
-		 maxRecoverableChainLength="500000"
+		 maxRecoverableChainLength="10000"
 		 minimumBlockDegreeToCheckSupport="10"
 		 minimumBlockHomologySupport="0.05"
 	/>

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -399,8 +399,6 @@ def make_align_job(options, toil):
         cafNode.attrib["runMapQFiltering"] = "0"
         # more iterations here helps quite a bit to reduce underalignment
         cafNode.attrib["maxRecoverableChainsIterations"] = "50"
-        # pulling apart a recoverable chain bigger than the poa window is counterproductive
-        cafNode.attrib["maxRecoverableChainLength"] = "10000"
         # turn down minimum block degree to get a fat ancestor
         barNode.attrib["minimumBlockDegree"] = "1"
         # turn on POA


### PR DESCRIPTION
The intuition behind this is that it is risky to pull apart anything bigger than the POA window size (default=10k), as it's unclear if it will be properly realigned.  

This helps enormously on the 90-human pangenome graphs (with minigraph contigs dropped).  But it also seems to help (marginally) for an interspecies test.  Here are results from "Anc10" of the 12-way test alignment from the paper (Human/Chimp with Rhesus, Tree_shrew and Horse outgroups):

Old (`maxRecoverableChainLength = 500000`): 
```
(Human:0.006969,Chimp:0.009727)Anc10;

GenomeName, NumChildren, Length, NumSequences, NumTopSegments, NumBottomSegments
Anc10, 2, 2802279959, 7714, 0, 67198078
Human, 0, 3209286105, 455, 71725179, 0
Chimp, 0, 3050398082, 4346, 69855999, 0
 ```
New  (`maxRecoverableChainLength = 10000`):
```
GenomeName, NumChildren, Length, NumSequences, NumTopSegments, NumBottomSegments
Anc10, 2, 2802595942, 7743, 0, 67651706
Human, 0, 3209286105, 455, 72595120, 0
Chimp, 0, 3050398082, 4346, 70379814, 0
``` 
Ancestor length increases by `315983`

