### PR TITLE
Pangenome updates

### DIFF
--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -157,7 +157,7 @@ fi
 cd ${pangenomeBuildDir}
 git clone https://github.com/ComparativeGenomicsToolkit/cactus-gfa-tools.git
 cd cactus-gfa-tools
-git checkout f7c8ef3159cf5ee9b84c3e53b02e5f6164be60df
+git checkout a4b25ae0b6f15e5b112ea1297e8483393f063463
 make -j ${numcpu}
 if [[ $STATIC_CHECK -ne 1 || $(ldd paf2lastz | grep so | wc -l) -eq 0 ]]
 then

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -157,7 +157,7 @@ fi
 cd ${pangenomeBuildDir}
 git clone https://github.com/ComparativeGenomicsToolkit/cactus-gfa-tools.git
 cd cactus-gfa-tools
-git checkout a852026a7d9b0b6eb743f7139184d1db81e6b585
+git checkout f7c8ef3159cf5ee9b84c3e53b02e5f6164be60df
 make -j ${numcpu}
 if [[ $STATIC_CHECK -ne 1 || $(ldd paf2lastz | grep so | wc -l) -eq 0 ]]
 then

--- a/preprocessor/cactus_softmask2hardmask.c
+++ b/preprocessor/cactus_softmask2hardmask.c
@@ -25,45 +25,41 @@
 void usage() {
     fprintf(stderr, "cactus_softmask2hardmask [fastaFile]\n");
     fprintf(stderr, "-m --minLength N: Only mask intervals > Nbp\n");
-    fprintf(stderr, "-c --minContig N: Only mask contigs in fasta > Nbp\n");
     fprintf(stderr, "-b --bed:         BED output of soft and hardmasked intervals\n");
 }
 
 static bool bed = false;
 
-static void hardmask(void* min_length_pair, const char* name, const char* seq, int64_t length) {
-    int64_t min_length = ((int64_t*)min_length_pair)[0];
-    int64_t min_contig_length = ((int64_t*)min_length_pair)[1];
+static void hardmask(void* min_length_p, const char* name, const char* seq, int64_t length) {
+    int64_t min_length = *(int64_t*)min_length_p;
     char* uc_seq = (char*)seq;
     int64_t start = -1;
-    if (length > min_contig_length) {
-        for (int64_t i = 0; i < length; ++i) {
-            bool lower = islower(uc_seq[i]) || (bed && uc_seq[i] == 'N');
-            if (lower) {
-                if (start == -1) {
-                    start = i;
-                }
+    for (int64_t i = 0; i < length; ++i) {
+        bool lower = islower(uc_seq[i]) || (bed && uc_seq[i] == 'N');
+        if (lower) {
+            if (start == -1) {
+                start = i;
             }
-            if (start != -1) {
-                int64_t end = -1;
-                if (!lower) {
-                    end = i - 1;
-                } else if (i == length - 1) {
-                    end = i;
-                }
-                if (end > start + min_length - 1) {
-                    if (bed) {
-                        fprintf(stdout, "%s\t%" PRIi64 "\t%" PRIi64 "\tfrom-softmask\n", name, start, end + 1);
-                    } else {
-                        for (int64_t j = start; j <= end; ++j) {
-                            assert(islower(uc_seq[j]));
-                            uc_seq[j] = 'N';
-                        }
+        }
+        if (start != -1) {
+            int64_t end = -1;
+            if (!lower) {
+                end = i - 1;
+            } else if (i == length - 1) {
+                end = i;
+            }
+            if (end > start + min_length - 1) {
+                if (bed) {
+                    fprintf(stdout, "%s\t%" PRIi64 "\t%" PRIi64 "\tfrom-softmask\n", name, start, end + 1);
+                } else {
+                    for (int64_t j = start; j <= end; ++j) {
+                        assert(islower(uc_seq[j]));
+                        uc_seq[j] = 'N';
                     }
                 }
-                if (end != -1) {
-                    start = -1;
-                }
+            }
+            if (end != -1) {
+                start = -1;
             }
         }
     }
@@ -75,17 +71,15 @@ static void hardmask(void* min_length_pair, const char* name, const char* seq, i
 int main(int argc, char *argv[]) {
 
     int64_t min_length = 0;
-    int64_t min_contig_length = 0;
     
     while (1) {
         static struct option long_options[] = { { "minLength", required_argument, 0, 'm' },
-                                                { "minContigLength", required_argument, 0, 'c' },
                                                 { "bed", no_argument, 0, 'b' },
                                                 { 0, 0, 0, 0 } };
 
         int option_index = 0;
 
-        int key = getopt_long(argc, argv, "m:c:b", long_options, &option_index);
+        int key = getopt_long(argc, argv, "m:b", long_options, &option_index);
         int i = 0;
 
         if (key == -1) {
@@ -97,10 +91,6 @@ int main(int argc, char *argv[]) {
             i = sscanf(optarg, "%" PRIi64 "", &min_length);
             assert(i == 1);
             break;
-        case 'c':
-            i = sscanf(optarg, "%" PRIi64 "", &min_contig_length);
-            assert(i == 1);
-            break;            
         case 'b':
             bed = true;
             break;
@@ -115,8 +105,6 @@ int main(int argc, char *argv[]) {
         return 0;
     }
 
-    int64_t min_length_pair[2] = {min_length, min_contig_length};
-    
     for (int64_t j = optind; j < argc; j++) {
         FILE *fileHandle;
         if (strcmp(argv[j], "-") == 0) {
@@ -127,7 +115,7 @@ int main(int argc, char *argv[]) {
                 st_errnoAbort("Could not open input file %s", argv[j]);
             }
         }
-        fastaReadToFunction(fileHandle, &min_length_pair[0], hardmask);
+        fastaReadToFunction(fileHandle, &min_length, hardmask);
     }
 
     return 0;

--- a/preprocessor/cactus_softmask2hardmask.c
+++ b/preprocessor/cactus_softmask2hardmask.c
@@ -25,41 +25,45 @@
 void usage() {
     fprintf(stderr, "cactus_softmask2hardmask [fastaFile]\n");
     fprintf(stderr, "-m --minLength N: Only mask intervals > Nbp\n");
+    fprintf(stderr, "-c --minContig N: Only mask contigs in fasta > Nbp\n");
     fprintf(stderr, "-b --bed:         BED output of soft and hardmasked intervals\n");
 }
 
 static bool bed = false;
 
-static void hardmask(void* min_length_p, const char* name, const char* seq, int64_t length) {
-    int64_t min_length = *(int64_t*)min_length_p;
+static void hardmask(void* min_length_pair, const char* name, const char* seq, int64_t length) {
+    int64_t min_length = ((int64_t*)min_length_pair)[0];
+    int64_t min_contig_length = ((int64_t*)min_length_pair)[1];
     char* uc_seq = (char*)seq;
     int64_t start = -1;
-    for (int64_t i = 0; i < length; ++i) {
-        bool lower = islower(uc_seq[i]) || (bed && uc_seq[i] == 'N');
-        if (lower) {
-            if (start == -1) {
-                start = i;
-            }
-        }
-        if (start != -1) {
-            int64_t end = -1;
-            if (!lower) {
-                end = i - 1;
-            } else if (i == length - 1) {
-                end = i;
-            }
-            if (end > start + min_length - 1) {
-                if (bed) {
-                    fprintf(stdout, "%s\t%" PRIi64 "\t%" PRIi64 "\tfrom-softmask\n", name, start, end + 1);
-                } else {
-                    for (int64_t j = start; j <= end; ++j) {
-                        assert(islower(uc_seq[j]));
-                        uc_seq[j] = 'N';
-                    }
+    if (length > min_contig_length) {
+        for (int64_t i = 0; i < length; ++i) {
+            bool lower = islower(uc_seq[i]) || (bed && uc_seq[i] == 'N');
+            if (lower) {
+                if (start == -1) {
+                    start = i;
                 }
             }
-            if (end != -1) {
-                start = -1;
+            if (start != -1) {
+                int64_t end = -1;
+                if (!lower) {
+                    end = i - 1;
+                } else if (i == length - 1) {
+                    end = i;
+                }
+                if (end > start + min_length - 1) {
+                    if (bed) {
+                        fprintf(stdout, "%s\t%" PRIi64 "\t%" PRIi64 "\tfrom-softmask\n", name, start, end + 1);
+                    } else {
+                        for (int64_t j = start; j <= end; ++j) {
+                            assert(islower(uc_seq[j]));
+                            uc_seq[j] = 'N';
+                        }
+                    }
+                }
+                if (end != -1) {
+                    start = -1;
+                }
             }
         }
     }
@@ -71,15 +75,17 @@ static void hardmask(void* min_length_p, const char* name, const char* seq, int6
 int main(int argc, char *argv[]) {
 
     int64_t min_length = 0;
+    int64_t min_contig_length = 0;
     
     while (1) {
         static struct option long_options[] = { { "minLength", required_argument, 0, 'm' },
+                                                { "minContigLength", required_argument, 0, 'c' },
                                                 { "bed", no_argument, 0, 'b' },
                                                 { 0, 0, 0, 0 } };
 
         int option_index = 0;
 
-        int key = getopt_long(argc, argv, "m:b", long_options, &option_index);
+        int key = getopt_long(argc, argv, "m:c:b", long_options, &option_index);
         int i = 0;
 
         if (key == -1) {
@@ -91,6 +97,10 @@ int main(int argc, char *argv[]) {
             i = sscanf(optarg, "%" PRIi64 "", &min_length);
             assert(i == 1);
             break;
+        case 'c':
+            i = sscanf(optarg, "%" PRIi64 "", &min_contig_length);
+            assert(i == 1);
+            break;            
         case 'b':
             bed = true;
             break;
@@ -105,6 +115,8 @@ int main(int argc, char *argv[]) {
         return 0;
     }
 
+    int64_t min_length_pair[2] = {min_length, min_contig_length};
+    
     for (int64_t j = optind; j < argc; j++) {
         FILE *fileHandle;
         if (strcmp(argv[j], "-") == 0) {
@@ -115,7 +127,7 @@ int main(int argc, char *argv[]) {
                 st_errnoAbort("Could not open input file %s", argv[j]);
             }
         }
-        fastaReadToFunction(fileHandle, &min_length, hardmask);
+        fastaReadToFunction(fileHandle, &min_length_pair[0], hardmask);
     }
 
     return 0;

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -308,9 +308,12 @@
 		 cpu="6"
 		 />
 	<!-- cactus-graphmap-split options -->
-	<!-- minQueryCoverage: At least this fraction of input contig must align to reference contig for it to be assigned. -->
-	<!-- minQuerySmallCoverage: Like minQueryCoverage, but applied only to contigs with length < minQuerySmallThreshold. -->
-	<!-- minQuerySmallThreshold: Threshold used to toggle between minQueryCoverage and minuQuerySmallCoverage. -->
+	<!-- minQueryCoverages: (space-separated) At least this fraction of input contig must align to reference contig for it to be assigned. -->
+	<!-- minQueryCoverageThresholds: (space-separated, exactly 1 fewer than minQueryCoverages). With above, form coverage bins.-->
+	<!--          Example:  coverages = "0.99 0.95 0.90" / thresholds = "10000 100000" would give the following bins: -->
+	<!--                    0-99999 : min_coverage = 0.99 -->
+	<!--                    10000-99999 : min_coverage = 0. 95 -->
+	<!--                    100000-infinity : min_coverage = 0.90 -->		  
 	<!-- minQueryUniqueness: The ratio of the number of query bases aligned to the chosen ref contig vs the next best ref contig must exceed this threshold to not be considered ambigious. -->
 	<!-- maxGap: Include indel gaps <= maxGap when counting minigraph coverage -->
 	<!-- ambiguousName: Contigs deemed ambiguous using the above filters get added to a "contig" with this name, and are preserved in output. -->
@@ -318,13 +321,12 @@
 	<!-- remapSplitOptions: extra rgfa-split options to apply when splitting after remapping (use -u 3000000 to enable autoclipping between contigs, add -s to allow within contig)-->
 	<!-- useMinimapPAF: use minimap2 PAF for ambiguous contigs (rather than keeping their original mappings in the input PAF, requried if autoclipping enabled above) -->
 	<graphmap_split
-		 minQueryCoverage="0.65"
-		 minQuerySmallCoverage="0.75"
-		 minQuerySmallThreshold="3000000"
+		 minQueryCoverages="0.99 0.95 0.90 0.85 0.80 0.75"
+		 minQueryCoverageThresholds="50000 100000 1000000 5000000 10000000"
 		 minQueryUniqueness="3"
-		 maxGap="50000"
+		 maxGap="20"
 		 ambiguousName="_AMBIGUOUS_"
-		 remap="1"
+		 remap="0"
 		 remapSplitOptions=""
 		 useMinimapPAF="0"
 		 />

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -293,6 +293,7 @@
 	<!--                           Filter is disabled when set to 0.  Any non-zero value will prevent query overlaps -->
 	<!-- maskFilter: any softmasked sequence intervals > than this many bp will be hardmasked before being read by the minigraph mapper [negative value = disable]-->
 	<!-- removeMinigraphFromPAF: replace all minigraph contigs with transitive alignments in cactus-align-->
+	<!-- refOverrideThreshold: only override masking filters for reference contigs less than this length (used to override unplaced contigs but not chroms)-->
 	<!-- cpu: use up to this many cpus for each minigraph command. -->
 	<graphmap
 		 assemblyName="_MINIGRAPH_"
@@ -307,6 +308,7 @@
 		 minGAFQueryOverlapFilter="10000"
 		 maskFilter="-1"
 		 removeMinigraphFromPAF="0"
+		 refOverrideThreshold="5000000"
 		 cpu="6"
 		 />
 	<!-- cactus-graphmap-split options -->

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -306,7 +306,7 @@
 		 minGAFNodeLength="0"
 		 minGAFQueryOverlapFilter="10000"
 		 maskFilter="-1"
-		 removeMinigraphFromPAF="1"
+		 removeMinigraphFromPAF="0"
 		 cpu="6"
 		 />
 	<!-- cactus-graphmap-split options -->

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -323,10 +323,10 @@
 	<!-- remapSplitOptions: extra rgfa-split options to apply when splitting after remapping (use -u 3000000 to enable autoclipping between contigs, add -s to allow within contig)-->
 	<!-- useMinimapPAF: use minimap2 PAF for ambiguous contigs (rather than keeping their original mappings in the input PAF, requried if autoclipping enabled above) -->
 	<graphmap_split
-		 minQueryCoverages="0.99 0.95 0.90 0.85 0.80 0.75"
-		 minQueryCoverageThresholds="50000 100000 1000000 5000000 10000000"
+		 minQueryCoverages="0.90 0.80 0.75 0.70"
+       minQueryCoverageThresholds="10000 100000 1000000"
 		 minQueryUniqueness="3"
-		 maxGap="20"
+		 maxGap="5000"
 		 ambiguousName="_AMBIGUOUS_"
 		 remap="0"
 		 remapSplitOptions=""

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -292,6 +292,7 @@
 	<!--                           if 1 query region in a block of at least this size overlaps query regions in blocks smaller than this, filter out the smaller ones -->
 	<!--                           Filter is disabled when set to 0.  Any non-zero value will prevent query overlaps -->
 	<!-- maskFilter: any softmasked sequence intervals > than this many bp will be hardmasked before being read by the minigraph mapper [negative value = disable]-->
+	<!-- removeMinigraphFromPAF: replace all minigraph contigs with transitive alignments in cactus-align-->
 	<!-- cpu: use up to this many cpus for each minigraph command. -->
 	<graphmap
 		 assemblyName="_MINIGRAPH_"
@@ -305,6 +306,7 @@
 		 minGAFNodeLength="0"
 		 minGAFQueryOverlapFilter="10000"
 		 maskFilter="-1"
+		 removeMinigraphFromPAF="1"
 		 cpu="6"
 		 />
 	<!-- cactus-graphmap-split options -->

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -293,7 +293,6 @@
 	<!--                           Filter is disabled when set to 0.  Any non-zero value will prevent query overlaps -->
 	<!-- maskFilter: any softmasked sequence intervals > than this many bp will be hardmasked before being read by the minigraph mapper [negative value = disable]-->
 	<!-- removeMinigraphFromPAF: replace all minigraph contigs with transitive alignments in cactus-align-->
-	<!-- refOverrideThreshold: only override masking filters for reference contigs less than this length (used to override unplaced contigs but not chroms)-->
 	<!-- cpu: use up to this many cpus for each minigraph command. -->
 	<graphmap
 		 assemblyName="_MINIGRAPH_"
@@ -308,7 +307,6 @@
 		 minGAFQueryOverlapFilter="10000"
 		 maskFilter="-1"
 		 removeMinigraphFromPAF="0"
-		 refOverrideThreshold="5000000"
 		 cpu="6"
 		 />
 	<!-- cactus-graphmap-split options -->

--- a/src/cactus/refmap/cactus_graphmap.py
+++ b/src/cactus/refmap/cactus_graphmap.py
@@ -308,7 +308,7 @@ def minigraph_map_one(job, config, event_name, fa_path, fa_file_id, gfa_file_id,
            "-o", os.path.basename(gaf_path)] + opts_list
 
     mask_filter = getOptionalAttrib(xml_node, "maskFilter", int, default=-1)
-    if mask_filter >= 0:
+    if mask_filter >= 0 and not is_ref:
         cmd[2] = '-'
         cmd = [['cactus_softmask2hardmask', os.path.basename(fa_path), '-m', str(mask_filter)], cmd]
     

--- a/src/cactus/refmap/cactus_graphmap.py
+++ b/src/cactus/refmap/cactus_graphmap.py
@@ -308,9 +308,13 @@ def minigraph_map_one(job, config, event_name, fa_path, fa_file_id, gfa_file_id,
            "-o", os.path.basename(gaf_path)] + opts_list
 
     mask_filter = getOptionalAttrib(xml_node, "maskFilter", int, default=-1)
-    if mask_filter >= 0 and not is_ref:
+    if mask_filter >= 0:
         cmd[2] = '-'
         cmd = [['cactus_softmask2hardmask', os.path.basename(fa_path), '-m', str(mask_filter)], cmd]
+        if is_ref:
+            ref_override_thresh = getOptionalAttrib(xml_node, "refOverrideThreshold", int, default=None)
+            if ref_override_thresh:
+                cmd[0] += ['-c', str(ref_override_thresh)]
     
     cactus_call(work_dir=work_dir, parameters=cmd)
 

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -273,7 +273,8 @@ def clip_vg(job, options, config, vg_path, vg_id):
             fix_cmd += ['--dont_collapse', options.reference + '*']
         cactus_call(parameters=fix_cmd)
         # GFAFfix doesn't seem to unchop that well, so we do that in vg after
-        cactus_call(parameters=[['vg', 'convert', '-g', '-p', gfa_out_path], ['vg', 'mod', '-u', '-']], outfile=normalized_path)
+        # The double convert is to work around: https://github.com/vgteam/vg/issues/3373
+        cactus_call(parameters=[['vg', 'convert', '-g', '-a', gfa_out_path], ['vg', 'mod', '-u', '-'], ['vg', 'convert', '-p', '-']], outfile=normalized_path)
         clipped_path = normalized_path
 
     # also forwardize just in case

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -273,7 +273,7 @@ def clip_vg(job, options, config, vg_path, vg_id):
             fix_cmd += ['--dont_collapse', options.reference + '*']
         cactus_call(parameters=fix_cmd)
         # GFAFfix doesn't seem to unchop that well, so we do that in vg after
-        cactus_call(parameters=[['vg', 'convert', '-g', '-p', gfa_out_path], ['vg', 'mod', '-u', '-O', '-']], outfile=normalized_path)
+        cactus_call(parameters=[['vg', 'convert', '-g', '-p', gfa_out_path], ['vg', 'mod', '-u', '-']], outfile=normalized_path)
         clipped_path = normalized_path
 
     # also forwardize just in case

--- a/src/cactus/refmap/cactus_graphmap_split.py
+++ b/src/cactus/refmap/cactus_graphmap_split.py
@@ -293,14 +293,16 @@ def split_gfa(job, config, gfa_id, paf_ids, ref_contigs, other_contig, reference
         cmd += ['-r', 'id={}|'.format(reference_event)]
     if mask_bed_id:
         cmd += ['-B', bed_path]
-    min_mapq = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap"), "minMAPQ")
-    if min_mapq:
-        cmd += ['-A', min_mapq]
     # optional stuff added to second pass:
     if not gfa_id:
         remap_opts = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_split"), "remapSplitOptions", default=None)
         if remap_opts:
-            cmd += remap_opts.split(' ')        
+            cmd += remap_opts.split(' ')
+            # only do mapq filter on minimap2 input.  it will already have been run in mzgaf2paf otherwise
+            # (and we may have applied a reference exception)
+            min_mapq = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap"), "minMAPQ")
+            if min_mapq:
+                cmd += ['-A', min_mapq]
     for contig in ref_contigs:
         cmd += ['-c', contig]
 

--- a/src/cactus/refmap/cactus_graphmap_split.py
+++ b/src/cactus/refmap/cactus_graphmap_split.py
@@ -293,16 +293,14 @@ def split_gfa(job, config, gfa_id, paf_ids, ref_contigs, other_contig, reference
         cmd += ['-r', 'id={}|'.format(reference_event)]
     if mask_bed_id:
         cmd += ['-B', bed_path]
+    min_mapq = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap"), "minMAPQ")
+    if min_mapq:
+        cmd += ['-A', min_mapq]
     # optional stuff added to second pass:
     if not gfa_id:
         remap_opts = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_split"), "remapSplitOptions", default=None)
         if remap_opts:
-            cmd += remap_opts.split(' ')
-            # only do mapq filter on minimap2 input.  it will already have been run in mzgaf2paf otherwise
-            # (and we may have applied a reference exception)
-            min_mapq = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap"), "minMAPQ")
-            if min_mapq:
-                cmd += ['-A', min_mapq]
+            cmd += remap_opts.split(' ')        
     for contig in ref_contigs:
         cmd += ['-c', contig]
 

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -273,10 +273,9 @@ def make_align_job(options, toil):
         raise RuntimeError("--pafMaskFilter can only be run with --pafInput")
 
     paf_to_stable = False
-    if options.pafInput:
+    configNode = ET.parse(options.configFile).getroot()
+    if options.pafInput and getOptionalAttrib(findRequiredNode(configNode, "graphmap"), "removeMinigraphFromPAF", typeFn=bool, default=False):
         # remove minigraph event from input seqfile
-        # TODO: this could be an option if someone wanted to keep it around for some reason,
-        # otherwise, best to never add it in the first place
         seqFile = SeqFile(options.seqFile)
         configNode = ET.parse(options.configFile).getroot()
         graph_event = getOptionalAttrib(findRequiredNode(configNode, "graphmap"), "assemblyName", default="_MINIGRAPH_")
@@ -399,8 +398,9 @@ def make_align_job(options, toil):
         cafNode.attrib["runMapQFiltering"] = "0"
         # more iterations here helps quite a bit to reduce underalignment
         cafNode.attrib["maxRecoverableChainsIterations"] = "50"
-        # pulling apart a recoverable chain bigger than the poa window is counterproductive
-        cafNode.attrib["maxRecoverableChainLength"] = "10000"
+        if getOptionalAttrib(findRequiredNode(configNode, "graphmap"), "removeMinigraphFromPAF", typeFn=bool, default=False):
+            # pulling apart a recoverable chain bigger than the poa window is counterproductive
+            cafNode.attrib["maxRecoverableChainLength"] = "10000"
         # turn down minimum block degree to get a fat ancestor
         barNode.attrib["minimumBlockDegree"] = "1"
         # turn on POA

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -398,9 +398,6 @@ def make_align_job(options, toil):
         cafNode.attrib["runMapQFiltering"] = "0"
         # more iterations here helps quite a bit to reduce underalignment
         cafNode.attrib["maxRecoverableChainsIterations"] = "50"
-        if getOptionalAttrib(findRequiredNode(configNode, "graphmap"), "removeMinigraphFromPAF", typeFn=bool, default=False):
-            # pulling apart a recoverable chain bigger than the poa window is counterproductive
-            cafNode.attrib["maxRecoverableChainLength"] = "10000"
         # turn down minimum block degree to get a fat ancestor
         barNode.attrib["minimumBlockDegree"] = "1"
         # turn on POA


### PR DESCRIPTION
* tune chromosome splitting parameters for the umpteenth time.  now geared towards sequences that have been clipped (rather than masked) in the prprocessor
* the recently added stable coordinate conversion / minigraph event dropping logic made optional (via config) and deactivated by default.   it seems to hurt more than it helps, especially for vcf comparison metrics.  
* small patches to graphmap-join