### PR TITLE
Sanitize wdl preprocess call names

### DIFF
--- a/src/cactus/progressive/cactus_prepare.py
+++ b/src/cactus/progressive/cactus_prepare.py
@@ -614,6 +614,8 @@ def input_fa_name(name):
 def preprocess_call_name(names):
     """ map an event name list to a preprocess call name """
     tag = '_'.join(names)
+    # replace all non alphanumeric chars with underscore
+    tag = "".join([ c if c.isalnum() else "_" for c in tag ])
     if len(tag) > 80:
         # avoid giant names
         cs = '_' + hashlib.md5(tag.encode()).hexdigest()


### PR DESCRIPTION
Terra doesn't seem to like dashes, for example, in the call names. 