### PR TITLE
Add vg clip option

### DIFF
--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -245,7 +245,9 @@ fi
 
 # vg
 cd ${pangenomeBuildDir}
-wget -q https://github.com/vgteam/vg/releases/download/v1.34.0/vg
+#tempoarary hack until 1.35.0 is actually released
+wget -q http://public.gi.ucsc.edu/~hickey/vg
+#wget -q https://github.com/vgteam/vg/releases/download/v1.35.0/vg
 chmod +x vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd vg | grep so | wc -l) -eq 0 ]]
 then


### PR DESCRIPTION
`vg clip` can be used to simplify a graph to make it easier to index.  It gets run optionally just before indexing so that if you make a graph , then run the same data again with clipping turned on, you'll get an id-compatible subset the second time around (for the GFA)