### PR TITLE
Script in option to add back references to xg

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Cactus uses many different algorithms and individual code contributions, princip
 - Yan Gao et al. for [abPOA](https://github.com/yangao07/abPOA)
 - Heng Li for [minigraph](https://github.com/lh3/minigraph), [minimap2](https://github.com/lh3/minimap2), [gfatools](https://github.com/lh3/gfatools) and [dna-brnn](https://github.com/lh3/dna-rnn)
 - Dany Doerr for [GFAffix](https://github.com/marschall-lab/GFAffix), used to optionally clean pangenome graphs.
+- The vg team for [vg](https://github.com/vgteam/vg), used to process pangenome graphs.
 
 ## Setup
 

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -64,6 +64,7 @@ def main():
     parser.add_argument("--outName", required=True, type=str, help = "Basename of all output files")
     parser.add_argument("--reference", required=True, type=str, help = "Reference event name")
     parser.add_argument("--vcfReference", type=str, help = "Produce additional VCF for given reference event")
+    parser.add_argument("--xgReference", type=str, help = "Produce additonal XG that also includes given reference event (as copied from the GBWT)")
     parser.add_argument("--rename", nargs='+', default = [], help = "Path renaming, each of form src>dest (see clip-vg -r)")
     parser.add_argument("--clipLength", type=int, default=None, help = "clip out unaligned sequences longer than this")
     parser.add_argument("--wlineSep", type=str, help = "wline separator for vg convert")
@@ -242,6 +243,13 @@ def graphmap_join_workflow(job, options, config, vg_ids, hal_ids, unclip_seq_id_
                                                              cores=options.indexCores,
                                                              disk = sum(f.size for f in vg_ids) * 2)
         out_dicts.append(ref_deconstruct_job.rv())
+
+    # make an xg but including a different reference (as extracted from GBWT)
+    if options.xgReference:
+        xg_reference_job = gfa_merge_job.addFollowOnJobFn(make_xg_reference, options.outName, options.xgReference,
+                                                          out_dicts[0],
+                                                          disk = sum(f.size for f in vg_ids) * 5)
+        out_dicts.append(xg_reference_job.rv())
 
     # optional giraffe
     if options.giraffe:
@@ -473,6 +481,36 @@ def make_vcf(job, out_name, vcf_ref, index_dict, tag=''):
 
     return { '{}vcf.gz'.format(tag) : job.fileStore.writeGlobalFile(vcf_path),
              '{}vcf.gz.tbi'.format(tag) : job.fileStore.writeGlobalFile(vcf_path + '.tbi') }
+
+def make_xg_reference(job, out_name, xg_reference, index_dict):
+    work_dir = job.fileStore.getLocalTempDir()
+    xg_path = os.path.join(work_dir, os.path.basename(out_name) + '.xg')
+    gbwt_path = os.path.join(work_dir, os.path.basename(out_name) + '.gbwt')
+    job.fileStore.readGlobalFile(index_dict['xg'], xg_path)
+    job.fileStore.readGlobalFile(index_dict['gbwt'], gbwt_path)
+
+    # make a gaf of paths extracted from gbwt
+    gaf_path = os.path.join(work_dir, 'ref_paths.gaf')
+    # extract reference paths from GBWT using _thread_NAME_ prefix
+    paths_cmd = ['vg', 'paths', '-x', xg_path, '-g', gbwt_path, '-Q', '_thread_{}_'.format(xg_reference), '-A']
+    # translate the gbwt _thread_ names into vg subpaths (really should be a vg option to do this)
+    sed_cmd = ['sed', '-e', 's/_thread_//g', '-e', 's/\([a-z,A-Z,0-9]*\)_\([a-z,A-Z,0-9,\.]*\)_\([0-1]*\)_\([0-9]*\)/\\1.\\2[\\4]/g']
+    cactus_call(parameters=[paths_cmd, sed_cmd], outfile=gaf_path)
+
+    # make a mutable graph from the xg
+    vg_path = os.path.join(work_dir, os.path.basename(out_name) + '.vg')
+    cactus_call(parameters=['vg', 'convert', xg_path], outfile=vg_path)
+
+    # augment the paths into it
+    augmented_vg_path = os.path.join(work_dir, os.path.basename(out_name) + '.aug.vg')
+    cactus_call(parameters=['vg', 'augment', '-B', '-F', vg_path, gaf_path], outfile=augmented_vg_path)
+
+    # finally, make the xg
+    xg_ref_path = os.path.join(work_dir, os.path.basename(out_name) + '.{}.xg'.format(xg_reference))
+    cactus_call(parameters=['vg', 'convert', '-x', augmented_vg_path], outfile=xg_ref_path)
+
+    # return the dict
+    return { '{}.xg'.format(xg_reference) : job.fileStore.writeGlobalFile(xg_ref_path) }
     
 def make_giraffe_indexes(job, options, index_dict):
     """ make giraffe-specific indexes: distance and minimaer """


### PR DESCRIPTION
The use case is CHM13-based graphs.  By default, the xg's come out with just CHM13 paths, with everything else in the GBWT.  But to run `vg surject` and now `vg call` with a GRCh38-based reference, we need to add back GRCh38 to the xg.  I've been doing this by hand which is error-prone.  This PR automates the process...