### PR TITLE
Abort with error if stripping unique id leaves empty header

### DIFF
--- a/pipeline/impl/convertAlignmentCoordinates.c
+++ b/pipeline/impl/convertAlignmentCoordinates.c
@@ -20,6 +20,9 @@ void stripUniqueIdsFromLeafSequences(Flower *flower) {
         if(stList_length(tokens) > 1 && !strncmp(stList_get(tokens, 0), "id=", 3)) {
             free(stList_removeFirst(tokens));
             char *newHeader = fastaEncodeHeader(tokens);
+            if (strlen(newHeader) == 0) {
+                st_errAbort("Input fasta sequence has no header after unique ID prefix: >%s", header);
+            }
             sequence_setHeader(sequence, newHeader);
         }
         stList_destruct(tokens);


### PR DESCRIPTION
A fasta header that's just an id prefix with nothing after, ex
```
>id=chimp|
ACACACAC
```
leads to a really cryptic error in `halAppendCactusSubtree` (#582).

This is a case that arises from an error that I don't think we want to handle.  This PR adds a check at the beginning of `cactus_consolidated` to fail with a message if it's encountered.

@benedictpaten I'm PRing this against your branch instead of master to avoid a merge conflict down the road, as the function in question is modified in your branch.  

