### PR TITLE
Add deletion filter option to cactus-graphmap

### DIFF
--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -254,6 +254,19 @@ else
 	 exit 1
 fi
 
+# filter-paf-deletions
+cd ${pangenomeBuildDir}
+#todo: make release
+#wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.16/filter-paf-deletions
+wget http://public.gi.ucsc.edu/~hickey/filter-paf-deletions
+chmod +x filter-paf-deletions
+if [[ $STATIC_CHECK -ne 1 || $(ldd filter-paf-deletions | grep so | wc -l) -eq 0 ]]
+then
+	 mv filter-paf-deletions ${binDir}
+else
+	 exit 1
+fi
+
 # vg
 cd ${pangenomeBuildDir}
 wget -q https://github.com/vgteam/vg/releases/download/v1.36.0/vg

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -269,7 +269,9 @@ fi
 
 # vg
 cd ${pangenomeBuildDir}
-wget -q https://github.com/vgteam/vg/releases/download/v1.36.0/vg
+#wget -q https://github.com/vgteam/vg/releases/download/v1.37.0/vg
+#temp workaround until vg 1.37 is released (contains vg clip -D patch)
+wget http://public.gi.ucsc.edu/~hickey/vg
 chmod +x vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd vg | grep so | wc -l) -eq 0 ]]
 then

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -292,6 +292,7 @@
 	<!--                           if 1 query region in a block of at least this size overlaps query regions in blocks smaller than this, filter out the smaller ones -->
 	<!--                           Filter is disabled when set to 0.  Any non-zero value will prevent query overlaps -->
 	<!-- maskFilter: any softmasked sequence intervals > than this many bp will be hardmasked before being read by the minigraph mapper [negative value = disable]-->
+	<!-- delFilter: any deletions implied by split-read mappings greater than this are removed from the paf (by removing all lines of the smallest block bordering deletion)-->
 	<!-- removeMinigraphFromPAF: replace all minigraph contigs with transitive alignments in cactus-align-->
 	<!-- cpu: use up to this many cpus for each minigraph command. -->
 	<graphmap
@@ -306,6 +307,7 @@
 		 minGAFNodeLength="0"
 		 minGAFQueryOverlapFilter="10000"
 		 maskFilter="-1"
+		 delFilter="-1"
 		 removeMinigraphFromPAF="0"
 		 cpu="6"
 		 />

--- a/src/cactus/refmap/cactus_graphmap.py
+++ b/src/cactus/refmap/cactus_graphmap.py
@@ -270,7 +270,7 @@ def make_minigraph_vg(job, gfa_file_id, gfa_file_path):
                 outfile=vg_path)
 
     return job.fileStore.writeGlobalFile(vg_path), job.fileStore.writeGlobalFile(trans_path)
-    
+
     
 def minigraph_map_all(job, config, gfa_id, fa_id_map, graph_event, keep_gaf, mg_vg_id, mg_trans_id):
     """ top-level job to run the minigraph mapping in parallel, returns paf """


### PR DESCRIPTION
minigraph can produce split mappings that induce huge deletions in the graph.  This doesn't happen often, but I don't seem to be able to reliably prevent it using the existing block filters.  

This PR adds an optional pass right after the creating of the paf mapping from the assembly to minigraph:  it looks at consecutive query intervals, computes roughly where their corresponding target intervals fall on the nearest reference path (in the mingraph), and if the result is a novel deletion above a certain threshold, the paf is filtered.  The filtering just removes the side of the deletion with the fewest aligned blocks (process is repeated until nothing removed on one iteration).

Testing this finds a bunch of such mappings involving chr1 telomeres (which caused a big bubble in the first released graph).  

Given a bit more time, I think I'd like to work on something more general that compares paf paths to existing minigraph paths and cuts contigs rather than filtering -- I think that'd be simpler and more robust than the current approach.