### PR TITLE
Don't strip debug symbols from cactus_consolidated in release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,8 @@ RUN cd /home/cactus && ./build-tools/downloadPangenomeTools
 # remove test executables
 RUN cd /home/cactus && rm -f ${binPackageDir}/bin/*test ${binPackageDir}/bin/*tests ${binPackageDir}/bin/*Test ${binPackageDir}/bin/*Tests
 
-# make the binaries smaller by removing debug symbols 
-RUN cd /home/cactus && strip -d bin/* 2> /dev/null || true
+# make the binaries smaller by removing debug symbols (but leave them in cactus_consolidated)
+RUN cd /home/cactus && strip -d bin/!(cactus_consolidated) 2> /dev/null || true
 
 # build cactus python3
 RUN ln -fs /usr/bin/python3 /usr/bin/python

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,7 @@
+# Release 2.0.5
+
+- Debug symbols no longer stripped from `cactus_consolidated` binary in Release.
+
 # Release 2.0.4   2021-11-12
 
 This release fixes a bug introduced in 2.0.0 where ancestral sequences could not be specified in the input, which prevented the recommended producedure for updating existing alignments from working. 

--- a/build-tools/makeBinRelease
+++ b/build-tools/makeBinRelease
@@ -105,8 +105,8 @@ cp -r .git ${binPackageDir}
 rm -rf ${binPackageDir}/.git/modules
 # remove test executables
 rm -f ${binPackageDir}/bin/*test ${binPackageDir}/bin/*tests ${binPackageDir}/bin/*Test ${binPackageDir}/bin/*Tests
-# make binaries smaller
-strip -d ${binPackageDir}/bin/* 2> /dev/null || true
+# make binaries smaller, but leave debug info in cactus_consolidated
+strip -d ${binPackageDir}/bin/!(cactus_consolidated) 2> /dev/null || true
 if [ -z ${CACTUS_LEGACY_ARCH+x} ]	
 then
 	 outArchive=${buildDir}/cactus-bin-${REL_TAG}.tar.gz


### PR DESCRIPTION
It's come up a couple times recently (#585, #610) where it could be helpful for users to be able to run `cactus_consolidated` in gdb.  But to keep size down, debug symbols are stripped from the released binaries, so this is tough to do in practice.  

This PR changes the release process to leave debug symbols in `cactus_consolidated`.  It only costs about `2Mb`, and ought to make debugging easier down the road.  