### PR TITLE
Fix command line abpoa runner to use latest cli interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ ${versionPy}:
 bin/mafComparator:
 	rm -rf submodules/mafTools
 	cd submodules && git clone https://github.com/dentearl/mafTools.git && cd mafTools && git checkout 82077ac39c9966ac8fb8efe9796fbcfb7da55477
-	cd submodules/mafTools && sed -i -e 's/-Werror//g' inc/common.mk lib/Makefile && sed -i -e 's/mafExtractor//g' Makefile && make
+	cd submodules/mafTools && sed -i -e 's/-Werror/-fsigned-char/g' inc/common.mk lib/Makefile && sed -i -e 's/mafExtractor//g' Makefile && make
 	cp submodules/mafTools/bin/mafComparator bin/
 	cd ${CWD}/test && wget -q https://raw.githubusercontent.com/UCSantaCruzComputationalGenomicsLab/cactusTestData/master/evolver/mammals/loci1/all.maf -O mammals-truth.maf
 	cd ${CWD}/test && wget -q https://raw.githubusercontent.com/UCSantaCruzComputationalGenomicsLab/cactusTestData/master/evolver/primates/loci1/all.maf -O primates-truth.maf

--- a/bar/impl/poaBarAligner.c
+++ b/bar/impl/poaBarAligner.c
@@ -207,8 +207,8 @@ char* dump_abpoa_input(Msa* msa, abpoa_para_t* abpt, uint8_t **bseqs, char* abpo
             abpt->wb,
             abpt->wf,
             abpoa_matrix_path);
-    if (abpt->disable_seeding) {
-        strcat(abpoa_command, " -N");
+    if (!abpt->disable_seeding) {
+        strcat(abpoa_command, " -S");
     } else {
         char kw_opts[128];
         sprintf(kw_opts, " -k %d -w %d -n %d", abpt->k, abpt->w, abpt->min_w);


### PR DESCRIPTION
looks like `abpoa` recently turned seeding off by default (good idea).  this fixes the debug option in cactus to use the new options when running from the command line. 