### PR TITLE
Use "sys.executable -m pip" instead of "pip" in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 from setuptools.command.install import install
-import os
+import os, sys
 import subprocess
 
 # FIXME this is duplicated in makefile, we need to sort this out
@@ -15,7 +15,7 @@ class PostInstallCommand(install):
     """Post-installation customization.  Ensure sonLib submodule in the tree is installed virtual env."""
 
     def run(self):
-        subprocess.run(["pip", "install", "submodules/sonLib"], check=True)
+        subprocess.run([sys.executable, "-m", "pip", "install", "submodules/sonLib"], check=True)
         install.run(self)
 
 setup(


### PR DESCRIPTION
Resolves #626.  Thanks @EricDeveaud for the suggestion. 