### PR TITLE
Fix cactus-blast and cactus-align so they can be used for updating genomes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,12 +2,6 @@ image: quay.io/comparative-genomics-toolkit/cactus-ci-base:latest
 
 before_script:
   - whoami
-  # Configure Docker to use a mirror for Docker Hub and restart the daemon
-  # Set the registry as insecure because it is probably cluster-internal over plain HTTP.
-  - |
-    if [[ ! -z "${DOCKER_HUB_MIRROR}" ]] ; then
-        echo "{\"registry-mirrors\": [\"${DOCKER_HUB_MIRROR}\"], \"insecure-registries\": [\"${DOCKER_HUB_MIRROR##*://}\"]}" | sudo tee /etc/docker/daemon.json
-    fi
   - startdocker || true
   - docker info
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ RUN python3.8 -m pip install -U wheel setuptools && \
     python3.8 -m pip install -f /wheels -r /tmp/cactus/toil-requirement.txt && \
     python3.8 -m pip install -f /wheels /tmp/cactus && \
     rm -rf /wheels /root/.cache/pip/* /tmp/cactus && \
-    apt-get remove -y git python3-pip rsync && \
+    apt-get remove -y git rsync && \
     apt-get auto-remove -y
 
 # check the linking on all our binaries (those kent tools above aren't static)

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN cd /home/cactus && rm -f ${binPackageDir}/bin/*test ${binPackageDir}/bin/*te
 RUN /bin/bash -O extglob -c "cd /home/cactus && strip -d bin/!(cactus_consolidated) 2> /dev/null || true"
 
 # build cactus python3
-RUN mkdir -p /wheels && cd /wheels && python3.8 -m pip install cython && python3.8 -m pip wheel -r /home/cactus/toil-requirement.txt && python3.8 -m pip wheel /home/cactus
+RUN mkdir -p /wheels && cd /wheels && python3.8 -m pip install -U cython pip wheel && python3.8 -m pip wheel -r /home/cactus/toil-requirement.txt && python3.8 -m pip wheel /home/cactus
 
 # Create a thinner final Docker image in which only the binaries and necessary data exist.
 FROM quay.io/comparative-genomics-toolkit/ubuntu:18.04
@@ -64,12 +64,15 @@ RUN rsync -avm --include='*.py' -f 'hide,! */' /tmp/cactus/submodules/hal /usr/l
 ENV PYTHONPATH /usr/local/lib:${PYTHONPATH}
 
 # install the python3 binaries then clean up
-RUN python3.8 -m pip install -U wheel setuptools && \
+RUN python3.8 -m pip install -U pip wheel setuptools && \
     python3.8 -m pip install -f /wheels -r /tmp/cactus/toil-requirement.txt && \
     python3.8 -m pip install -f /wheels /tmp/cactus && \
     rm -rf /wheels /root/.cache/pip/* /tmp/cactus && \
-    apt-get remove -y git rsync && \
+    apt-get remove -y git python3-pip rsync && \
     apt-get auto-remove -y
+
+# sanity check to make sure cactus at least runs
+RUN cactus --help
 
 # check the linking on all our binaries (those kent tools above aren't static)
 RUN for i in /usr/local/bin/* ; do if [ -f ${i} ] && [ $(ldd ${i} | grep "not found" | wc -l) -ge 1 ]; then exit 1; fi; done

--- a/Makefile
+++ b/Makefile
@@ -217,10 +217,12 @@ docker: Dockerfile
 
 # Requires ~/.dockercfg
 push: docker
-	docker push ${name}
+	docker push ${name}:${tag}
+	docker push ${name}:latest
 
 push_only:
-	docker push ${name}
+	docker push ${name}:${tag}
+	docker push ${name}:latest
 
 binRelease:
 	./build-tools/makeBinRelease

--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -43,6 +43,15 @@ class TestCase(unittest.TestCase):
         sys.stderr.write('Running {}'.format(' '.format(cmd)))
         subprocess.check_call(' '.join(cmd), shell=True)
 
+    def _run_evolver_in_docker(self, seqFile = './examples/evolverMammals.txt'):
+
+        out_hal = self._out_hal('in_docker')
+        cmd = ['docker', 'run', '--rm', '-v', '{}:{}'.format(os.path.dirname(out_hal), '/data'),
+               '-v', '{}:{}'.format(os.getcwd(), '/workdir'), 'evolvertestdocker/cactus:latest',
+               'cactus /data/js /workdir/{} /data/{}'.format(seqFile, os.path.basename(out_hal))]
+        sys.stderr.write('Running {}'.format(' '.format(cmd)))
+        subprocess.check_call(' '.join(cmd), shell=True)
+               
     def _write_primates_seqfile(self, seq_file_path):
         """ create the primates seqfile at given path"""
         with open(seq_file_path, 'w') as seq_file:
@@ -443,6 +452,18 @@ class TestCase(unittest.TestCase):
         #self._check_coverage(self._out_hal("docker"), delta_pct=0.20)
         self._check_maf_accuracy(self._out_hal("docker"), delta=0.04)
 
+    def testEvolverInDocker(self):
+        """ Check that the output of halStats on a hal file produced by running cactus in docker
+        is reasonable.  Note: the local image being tested should be set up via CACTUS_DOCKER_ORG (with tag==latest)
+        """
+        # run cactus
+        self._run_evolver_in_docker()
+
+        # check the output
+        #self._check_stats(self._out_hal("docker"), delta_pct=0.25)
+        #self._check_coverage(self._out_hal("docker"), delta_pct=0.20)
+        self._check_maf_accuracy(self._out_hal("in_docker"), delta=0.04)
+        
     def testEvolverPrepareNoOutgroupDocker(self):
 
         # run cactus step by step via the plan made by cactus-prepare, hacking to apply --nonCactusInput option to cactus-align


### PR DESCRIPTION
[updating](https://github.com/ComparativeGenomicsToolkit/cactus/blob/master/doc/updating-alignments.md) hal files often requires sequences be aligned to a pre-existing ancestor.  In `cactus` this is triggered simply by including the ancestral sequence in the input.  

But when running `cactus-prepare / cactus-blast / cactus-align` ancestral sequence entries get created as part of the workflow and they are ignored until they are needed.  So there is no way let them be used as an input.

This PR adds an `--includeRoot` override to do so in `cactus-blast` and `cactus-align`.  So running, ex, `cactus-blast ./jobstor seqs..txt Anc2.cigar --root Anc2 --includeRoot` will include Anc2 in the alignment (and throw an error if Anc2 is not in seqs.txt.

Todo; really need to get the update examples under CI (ideally with scripting support in cactus-prepare). 

Resolves #638