### PR TITLE
Faster Cap updates

### DIFF
--- a/api/impl/cactusFlowerPrivate.h
+++ b/api/impl/cactusFlowerPrivate.h
@@ -19,6 +19,7 @@ struct _flower {
     Name parentFlowerName;
     CactusDisk *cactusDisk;
     bool builtBlocks;
+    bool lazyCaps;
 };
 
 ////////////////////////////////////////////////

--- a/api/inc/cactusFlower.h
+++ b/api/inc/cactusFlower.h
@@ -342,6 +342,12 @@ bool flower_builtBlocks(Flower *flower);
 void flower_setBuiltBlocks(Flower *flower, bool b);
 
 /*
+ * Switches to lazy caps mode where updating caps doesn't preserve sorting
+ * (setting to false will trigger a sort);
+ */
+void flower_setLazyCaps(Flower *flower, bool b);
+
+/*
  * Returns non-zero iff the flower has no nested flowers.
  */
 bool flower_isLeaf(Flower *flower);


### PR DESCRIPTION
This is me trying to solve #640.

Idea 1: just don't bother keeping the caps sorted during `recoverBrokenAdjacencies()`.  This is accomplished with the "lazyCaps" flag added to flower.  When it's false, everything proceeds as usual, when it's true the post-update sorting logic is disabled.  This only works if caps are only written and not read from the flower list (assertion added to check this)