### PR TITLE
Fix endless loop after cactus_consolidated that happens in some --realTimeLogging / Docker combinations

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,6 +4,8 @@
 - Update to Toil 3.5.6
 - Update examples to use Python 3.8 specifically (was previously just python3, but this is often python3.6, support for which was dropped in Toil 3.5.6)
 - cactus-prepare WDL output can now batch up `hal_append_subtree` jobs
+- Fix bug where "reference" phase within cactus_consolidated could take ages on some input
+- Fix bug where --realTimeLogging flag would cause infinite loop after cactus_consolidated within some Docker invocations.
 
 # Release 2.0.4   2021-11-12
 


### PR DESCRIPTION
Since `cactus_consolidated` can take a long time, it's really helpful to get its stderr messages in real time.  Doing this in Toil took a [little hacking](https://github.com/ComparativeGenomicsToolkit/cactus/blob/465b4024a4581e82b31c97a781b5a50e68a92785/src/cactus/shared/common.py#L790-L798) where a child process is forked off to send realtimelogging messages as the main process runs.

But in Docker, this could sometimes cause Toil to [loop forever](https://github.com/ComparativeGenomicsToolkit/cactus/issues/610#issuecomment-1006125899).  And according to @adamnovak's [explanation](https://github.com/ComparativeGenomicsToolkit/cactus/issues/610#issuecomment-1015759593), this is because the init daemon inside docker doesn't, by default, clean out "zombie processes".

And apparently, exiting isn't enough (with os._exit(), anyway) for a process to not be zombie.  It needs to be [waited() for](https://medium.com/@BeNitinAgarwal/an-init-system-inside-the-docker-container-3821ee233f4b) as well.  This PR does that and it seems to fix the issue. 

