### PR TITLE
Update to newer lastz

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "submodules/abPOA"]
 	path = submodules/abPOA
 	url = https://github.com/ComparativeGenomicsToolkit/abPOA.git
+[submodule "submodules/lastz"]
+	path = submodules/lastz
+	url = https://github.com/ComparativeGenomicsToolkit/lastz.git

--- a/Makefile
+++ b/Makefile
@@ -186,6 +186,7 @@ suball.matchingAndOrdering: suball.sonLib
 
 suball.cPecan: suball.sonLib
 	cd submodules/cPecan && ${MAKE}
+	rm -f ${BINDIR}/cPecanLastz*
 
 suball.cactus2hal: suball.sonLib suball.hal all_libs.api
 	cd submodules/cactus2hal && ${MAKE}
@@ -202,6 +203,11 @@ suball.abPOA:
 	cd submodules/abPOA && ${MAKE}
 	ln -f submodules/abPOA/lib/*.a ${LIBDIR}
 	ln -f submodules/abPOA/include/*.h ${INCLDIR}
+
+suball.lastz:
+	cd submodules/lastz && ${MAKE}
+	mkdir -p bin
+	ln -f submodules/lastz/src/* bin
 
 subclean.%:
 	cd submodules/$* && ${MAKE} clean

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ modules = api setup blastLib caf bar blast hal reference pipeline preprocessor
 
 # submodules are in multiple pass to handle dependencies cactus2hal being dependent on
 # both cactus and sonLib
-submodules1 = sonLib cPecan hal matchingAndOrdering pinchesAndCacti abPOA
+submodules1 = sonLib cPecan hal matchingAndOrdering pinchesAndCacti abPOA lastz
 submodules2 = cactus2hal
 submodules = ${submodules1} ${submodules2}
 

--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ There are many different ways to install and run Cactus:
 
 #### Docker Image
 
-Cactus docker images are hosted on [quay](https://quay.io/repository/comparative-genomics-toolkit/cactus).  The image for the latest release is listed on the [Releases Page](https://github.com/ComparativeGenomicsToolkit/cactus/releases).  Here is an command line to run the included evolver mammals example with release 2.0.4
+Cactus docker images are hosted on [quay](https://quay.io/repository/comparative-genomics-toolkit/cactus).  The image for the latest release is listed on the [Releases Page](https://github.com/ComparativeGenomicsToolkit/cactus/releases).  Here is an command line to run the included evolver mammals example with release 2.0.5
 ```
 wget https://raw.githubusercontent.com/ComparativeGenomicsToolkit/cactus/master/examples/evolverMammals.txt
-docker run -v $(pwd):/data --rm -it quay.io/comparative-genomics-toolkit/cactus:v2.0.4 cactus /data/jobStore /data/evolverMammals.txt /data/evolverMammals.hal --root mr --binariesMode local
+docker run -v $(pwd):/data --rm -it quay.io/comparative-genomics-toolkit/cactus:v2.0.5 cactus /data/jobStore /data/evolverMammals.txt /data/evolverMammals.hal --root mr --binariesMode local
 
 ```
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,4 +1,6 @@
-# Release 2.0.5
+# Release 2.0.5  2022-01-25
+
+This release fixes fixes a major (though rare) bug where the reference phase could take forever on some inputs.  It includes a newer version of lastz which seems to fix some crashes as well.
 
 - Debug symbols no longer stripped from `cactus_consolidated` binary in Release.
 - Update to Toil 3.5.6
@@ -6,6 +8,7 @@
 - cactus-prepare WDL output can now batch up `hal_append_subtree` jobs
 - Fix bug where "reference" phase within cactus_consolidated could take ages on some input
 - Fix bug where --realTimeLogging flag would cause infinite loop after cactus_consolidated within some Docker invocations.
+- Upgrade to more recent version of lastz
 
 # Release 2.0.4   2021-11-12
 

--- a/src/cactus/blast/cactus_coverageTest.py
+++ b/src/cactus/blast/cactus_coverageTest.py
@@ -132,7 +132,7 @@ class TestCase(unittest.TestCase):
         seqs = [i for i in seqs if 'chimp' not in i]
         seqs = random.sample(seqs, 2)
         cigarPath = getTempFile()
-        cactus_call(parameters=["cPecanLastz", "--format=cigar", "%s[multiple]" % seqs[0],
+        cactus_call(parameters=["lastz", "--format=cigar", "%s[multiple]" % seqs[0],
                     "%s[multiple]" % seqs[1]], outfile=cigarPath)
         bed = cactus_call(parameters=["cactus_coverage", seqs[1], cigarPath], check_output=True)
         prevChrom = None

--- a/src/cactus/preprocessor/lastzRepeatMasking/cactus_lastzRepeatMask.py
+++ b/src/cactus/preprocessor/lastzRepeatMasking/cactus_lastzRepeatMask.py
@@ -84,7 +84,7 @@ class LastzRepeatMaskJob(RoundedJob):
         # period parameter is a fudge to ensure sufficient alignments
         # are found
         cactus_call(outfile=alignment,
-                    parameters=["cPecanLastz"] + lastZSequenceHandling +
+                    parameters=["lastz"] + lastZSequenceHandling +
                                 self.repeatMaskOptions.lastzOpts.split() +
                                 # Note that --querydepth has no effect when --ungapped is passed (which is by default)
                                 ["--querydepth=keep,nowarn:%i" % (self.repeatMaskOptions.period+3),

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -317,7 +317,7 @@ def runLastz(seq1, seq2, alignmentsFile, lastzArguments, work_dir=None, gpuLastz
     if gpuLastz == True:
         lastzCommand = "run_segalign"
     else:
-        lastzCommand = "cPecanLastz"
+        lastzCommand = "lastz"
         seq1 += "[multiple][nameparse=darkspace]"
         seq2 += "[nameparse=darkspace]"
     cactus_call(work_dir=work_dir, outfile=alignmentsFile,

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -383,7 +383,7 @@ def getDockerImage():
 
 def getDockerRelease(gpu=False):
     """Get the most recent docker release."""
-    r = "quay.io/comparative-genomics-toolkit/cactus:v2.0.4"
+    r = "quay.io/comparative-genomics-toolkit/cactus:v2.0.5"
     if gpu:
         r += "-gpu"
     return r


### PR DESCRIPTION
Switch from [cPecanLastz](https://github.com/ComparativeGenomicsToolkit/cPecan/tree/master/externalTools/lastz-distrib-1.03.54) to newer version of [lastz](https://github.com/ComparativeGenomicsToolkit/lastz/commit/6114fb94ff14069c53605dc49e53d2f883e9f997).  This seems to solve the [error reported here](https://github.com/ComparativeGenomicsToolkit/cactus/issues/641#issuecomment-1020599920).  Which is why I'm fast-tracking this change into master now, even though it is already in the "paf-chains" branch. 

Also, prepare for a release. 

