### PR TITLE
Add Docker Tag override

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN cd /home/cactus && rm -f ${binPackageDir}/bin/*test ${binPackageDir}/bin/*te
 RUN /bin/bash -O extglob -c "cd /home/cactus && strip -d bin/!(cactus_consolidated) 2> /dev/null || true"
 
 # build cactus python3
-RUN mkdir -p /wheels && cd /wheels && python3.8 -m pip install -U pip wheel && python3.8 -m pip wheel -r /home/cactus/toil-requirement.txt && python3.8 -m pip wheel /home/cactus
+RUN mkdir -p /wheels && cd /wheels && python3.8 -m pip install -U pip==21.3.1 wheel && python3.8 -m pip wheel -r /home/cactus/toil-requirement.txt && python3.8 -m pip wheel /home/cactus
 
 # Create a thinner final Docker image in which only the binaries and necessary data exist.
 FROM quay.io/comparative-genomics-toolkit/ubuntu:18.04
@@ -64,7 +64,7 @@ RUN rsync -avm --include='*.py' -f 'hide,! */' /tmp/cactus/submodules/hal /usr/l
 ENV PYTHONPATH /usr/local/lib:${PYTHONPATH}
 
 # install the python3 binaries then clean up
-RUN python3.8 -m pip install -U pip wheel setuptools && \
+RUN python3.8 -m pip install -U pip==21.3.1 wheel setuptools && \
     python3.8 -m pip install -f /wheels -r /tmp/cactus/toil-requirement.txt && \
     python3.8 -m pip install -f /wheels /tmp/cactus && \
     rm -rf /wheels /root/.cache/pip/* /tmp/cactus && \

--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ Cactus can be setup and used in a virtual environment as in the [previous sectio
 
 Singularity binaries can be used in place of docker binaries with the `--binariesMode singularity` flag.  Note, you must use Singularity 2.3 - 2.6 or Singularity 3.1.0+. Singularity 3 versions below 3.1.0 are incompatible with cactus (see [issue #55](https://github.com/ComparativeGenomicsToolkit/cactus/issues/55) and [issue #60](https://github.com/ComparativeGenomicsToolkit/cactus/issues/60)).
 
+By default, cactus will use the image, `quay.io/comparative-genomics-toolkit/cactus:<CACTUS_COMMIT>` when running binaries. This is usually okay, but can be overridden with the `CACTUS_DOCKER_ORG` and `CACTUS_DOCKER_TAG` environment variables.  For example, to use GPU release 2.0.5, run `export CACTUS_DOCKER_TAG=v2.0.5-gpu` before running cactus.  
+
 The `--binariesMode local` flag can be used to force `cactus` to run local binaries -- this is the default behavior if they are found.
 
 ## Running

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -372,8 +372,10 @@ def getDockerOrg():
 def getDockerTag():
     """Get what docker tag we should use for the cactus image
     (either forced to be latest or the current cactus commit)."""
-    if 'CACTUS_USE_LATEST' in os.environ:
-        return "latest"
+    if 'CACTUS_DOCKER_TAG' in os.environ:
+        return os.environ['CACTUS_DOCKER_TAG']
+    elif 'CACTUS_USE_LATEST' in os.environ:
+        return "latest"    
     else:
         return cactus_commit
 


### PR DESCRIPTION
There is currently no way to specify which Docker binaries to use.  This PR adds an override option via `CACTUS_DOCKER_TAG` which could, for example, allow someone to use the GPU docker image (#651 is a possible use case).  I think it would be cleaner to eventually just detect that a GPU is wanted and automatically use the latest gpu release.

This also brings in a patch from #652 that lets the docker build work again in light of a trouble-making [new pip version](https://github.com/DataBiosphere/toil/issues/4028)