### PR TITLE
Use consistent poa bar for all but trivial alignments

### DIFF
--- a/bar/impl/poaBarAligner.c
+++ b/bar/impl/poaBarAligner.c
@@ -1020,14 +1020,20 @@ int64_t getMaxSequenceLength(End *end) {
 stList *make_flower_alignment_poa(Flower *flower, int64_t max_seq_length, int64_t window_size, int64_t mask_filter,
                                   abpoa_para_t * poa_parameters) {
     End *dominantEnd = getDominantEnd(flower);
-    if(dominantEnd != NULL && getMaxSequenceLength(dominantEnd) < max_seq_length) {
+    int64_t seq_no = dominantEnd != NULL ? end_getInstanceNumber(dominantEnd) : -1;
+    /*
+     * Todo: the "seq_no == 1" is a very heavy handed way of dealing with this bug:
+     * https://github.com/ComparativeGenomicsToolkit/cactus/issues/654
+     * I think what's needed is a way to check that there's no duplicate sequence that can 
+     * align inconsistently....
+     */
+    if(dominantEnd != NULL && seq_no == 1 && getMaxSequenceLength(dominantEnd) < max_seq_length) {
         /*
          * If there is a single end that is connected to all adjacencies that are less than max_seq_length in length,
          * just use that alignment
          */
 
         // Make inputs
-        int64_t seq_no = end_getInstanceNumber(dominantEnd);
         char **end_strings = st_malloc(sizeof(char *) * seq_no);
         int *end_string_lengths = st_malloc(sizeof(int) * seq_no);
         int64_t overlaps[seq_no];


### PR DESCRIPTION
There's a bypass of `make_consistent_partial_order_alignments()` where if all the sequences start at the same end, it aligns them once from that end and that's it.  This seems reasonable enough, but #654 shows a case where this isn't working.  It seems it's aligning the same sequence to its reverse complement and another sequence.  Something somehow turns out off-by-one, and it folds a bunch of self loops up. 

But this doesn't happen when the consistency code is enabled for this case.  So this PR just turns on `make_consistent_partial_order_alignments()` for all non-trivial alignments.  On my test-case, this fixes the self-loop without affecting speed.  

This seems like a band-aid fix though.  Is the inconsistency itself due to an underlying off-by-1 bug?  Or is there away to be more permissive about skipping the consistency check (ie there's a dominant end but with no self alignments?)    But this PR should be a reasonable patch in the meantime. 