### PR TITLE
Update python installation instructions

### DIFF
--- a/BIN-INSTALL.md
+++ b/BIN-INSTALL.md
@@ -14,13 +14,13 @@ cd "cactus-bin-${REL_TAG}"
 
 To build a python virtualenv and activate, do the following steps:
 ```
-virtualenv -p python3.6 venv
-source venv/bin/activate
-pip install -U setuptools pip
-pip install -U -r ./toil-requirement.txt
-pip install -U .
-export PATH=$(pwd)/bin:$PATH
-export PYTHONPATH=$(pwd)/lib:$PYTHONPATH
+virtualenv -p python3.8 cactus_env
+echo 'export PATH=$(pwd)/bin:$PATH' >> cactus_env/bin/activate
+echo 'export PYTHONPATH=$(pwd)/lib:$PYTHONPATH' >> cactus_env/bin/activate
+source cactus_env/bin/activate
+python3 -m pip install -U setuptools pip==21.3.1
+python3 -m pip install -U -r ./toil-requirement.txt
+python3 -m pip install -U .
 ```
 
 Some tools required for `hal2assemblyHub.py` are not included and must be downloaded separately.

--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ To install Cactus in Python, clone it and **its submodules with --recursive** fr
 ```
 git clone https://github.com/ComparativeGenomicsToolkit/cactus.git --recursive
 cd cactus
-python3.8 -m pip install --upgrade setuptools
-python3.8 -m pip install --upgrade -r toil-requirement.txt
-python3.8 -m pip install --upgrade .
+python3 -m pip install -U setuptools pip==21.3.1
+python3 -m pip install -U -r ./toil-requirement.txt
+python3 -m pip install -U .
 ```
 
 ##### Build the Cactus Binaries
@@ -115,6 +115,12 @@ build-tools/downloadPangenomeTools
 To use HAL python scripts such as `hal2mafMP.py`, add the submodules directory to the PYTHONPATH with
 ```
 export PYTHONPATH=$(pwd)/submodules:$PYTHONPATH
+```
+
+It's useful to add the paths to the virtualenv so as not to set them each time you need to run cactus from a new shell.  This can be done with
+```
+echo 'export PATH=$(pwd)/bin:$PATH' >> cactus_env/bin/activate
+echo 'export PYTHONPATH=$(pwd)/lib:$PYTHONPATH' >> cactus_env/bin/activate
 ```
 
 #### Python Install With Docker Binaries


### PR DESCRIPTION
@ekinda reasonably [points out](https://github.com/ComparativeGenomicsToolkit/cactus/issues/447#issuecomment-1029153970) that the installation instructions can be confusing:  They describe adding `cactus/bin` to `PATH`, but don't mention that you have to do this each time you want to run cactus in a new shell.  Forgetting to do so will cause cactus to try to pull in a docker image for the binaries, and if that's not set up well, will lead to a confusing error message. 

This PR attempts to fix that by changing the instructions to update the virtualenv instead.  This way the PATH gets updated whenever the virtualenv is sourced, which I think is more intuitive.  

It also syncs up the instructions in README.md and BIN-INSTALL.md (which shuold be kept consistent), and specifies use of pip 21 in order to work around the pip 22 / toil incompatibility (this will be fixed in the next Toil release)

Resolves #447 