### PR TITLE
Fix to poa-bar self-alignment bug.

### DIFF
--- a/bar/impl/flowerAligner.c
+++ b/bar/impl/flowerAligner.c
@@ -482,13 +482,15 @@ End *getDominantEnd(Flower *flower) {
     if (end_getInstanceNumber(dominantEnd) * 2 < flower_getCapNumber(flower)) {
         return NULL;
     }
-    // If the end is not incident with all the adjacencies, return NULL
+    // If the end is not incident with all the adjacencies,
+    // or if both ends of an adjacency are incident with the end, creating a self loop return NULL
     Cap *cap;
     Flower_CapIterator *capIt = flower_getCapIterator(flower);
     while ((cap = flower_getNextCap(capIt)) != NULL) {
         assert(cap_getAdjacency(cap) != NULL);
-        if (end_getPositiveOrientation(cap_getEnd(cap)) != dominantEnd && end_getPositiveOrientation(
-                cap_getEnd(cap_getAdjacency(cap))) != dominantEnd) {
+        End *end1 = end_getPositiveOrientation(cap_getEnd(cap));
+        End *end2 = end_getPositiveOrientation(cap_getEnd(cap_getAdjacency(cap)));
+        if ((end1 != dominantEnd && end2 != dominantEnd) || (end1 == end2)) {
             flower_destructCapIterator(capIt);
             return NULL;
         }

--- a/bar/impl/poaBarAligner.c
+++ b/bar/impl/poaBarAligner.c
@@ -1021,18 +1021,12 @@ stList *make_flower_alignment_poa(Flower *flower, int64_t max_seq_length, int64_
                                   abpoa_para_t * poa_parameters) {
     End *dominantEnd = getDominantEnd(flower);
     int64_t seq_no = dominantEnd != NULL ? end_getInstanceNumber(dominantEnd) : -1;
-    /*
-     * Todo: the "seq_no == 1" is a very heavy handed way of dealing with this bug:
-     * https://github.com/ComparativeGenomicsToolkit/cactus/issues/654
-     * I think what's needed is a way to check that there's no duplicate sequence that can 
-     * align inconsistently....
-     */
-    if(dominantEnd != NULL && seq_no == 1 && getMaxSequenceLength(dominantEnd) < max_seq_length) {
+    if(dominantEnd != NULL && getMaxSequenceLength(dominantEnd) < max_seq_length) {
         /*
          * If there is a single end that is connected to all adjacencies that are less than max_seq_length in length,
+         * and the adjacencies include no self-aligned (self-loop) sequences
          * just use that alignment
          */
-
         // Make inputs
         char **end_strings = st_malloc(sizeof(char *) * seq_no);
         int *end_string_lengths = st_malloc(sizeof(int) * seq_no);


### PR DESCRIPTION
This is a better solution courtesy of @benedictpaten  for the self-loop issue in #654 than was previously added via #655: instead the of the consistency bypass being disabled for all but trivial alignments, it is properly fixed to be disabled for only self-alignments.  