### PR TITLE
gcc-10 and above flipped a default from -fcommon to -fno-common.

### DIFF
--- a/bar/tests/flowersShared.h
+++ b/bar/tests/flowersShared.h
@@ -12,7 +12,7 @@
 #include "pairwiseAligner.h"
 
 //Statemachine
-StateMachine *stateMachine;
+static StateMachine *stateMachine;
 
 //Basic flower.
 static CactusDisk *cactusDisk;


### PR DESCRIPTION
`gcc-10` and above [flipped](https://gcc.gnu.org/gcc-10/porting_to.html) a default from `-fcommon` to `-fno-common`, and as a result, gcc will reject multiple definitions of global variables. 

```
linuxbrew@295dcf1deec5:~/cactus$ gcc --version
gcc (Ubuntu 10.3.0-1ubuntu1~20.04) 10.3.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```
ERROR using GCC 10:
```
make[4]: Entering directory '/home/linuxbrew/cactus/bar'
cc -Iinc -Iimpl -I../hal/inc -I../api/inc -I../setup/inc -I../bar/inc -I../caf/inc -I../hal/inc -I../reference/inc -I../pipeline/inc -I../submodules/sonLib/C/inc -I../blastLib -I../submodules/sonLib/externalTools/cutest -I../submodules/pinchesAndCacti/inc -I../submodules/matchingAndOrdering/inc -I../submodules/cPecan/inc -I../lib -I../include -fPIC -std=c99 -O3 -g -Wall --pedantic -funroll-loops -DNDEBUG  -UNDEBUG -I/home/linuxbrew/.linuxbrew/opt/libxml2/include/libxml2 -fopenmp  -Wno-error -o ../bin/cactus_barTests tests/adjacencySequencesTest.c tests/allTests.c tests/endAlignerTest.c tests/flowerAlignerTest.c tests/rescueTest.c tests/poaBarTest.c ../lib/cactusBarLib.a ../lib/stCaf.a ../lib/stReference.a ../lib/cactusBarLib.a ../lib/cactusBlastAlignment.a ../lib/cactusLib.a /home/linuxbrew/cactus/submodules/sonLib/lib/sonLib.a /home/linuxbrew/cactus/submodules/sonLib/lib/cuTest.a -L/home/linuxbrew/.linuxbrew/opt/bzip2/lib -L/home/linuxbrew/.linuxbrew/opt/libxml2/lib -L../lib -Wl,-rpath,../lib -labpoa -lz -lbz2 -lpthread -lm -lstdc++ -lm -lxml2  ../lib/stCaf.a /home/linuxbrew/cactus/submodules/sonLib/lib/stPinchesAndCacti.a ../lib/cactusLib.a /home/linuxbrew/cactus/submodules/sonLib/lib/3EdgeConnected.a /home/linuxbrew/cactus/submodules/sonLib/lib/cPecanLib.a /home/linuxbrew/cactus/submodules/sonLib/lib/sonLib.a  -lm
/home/linuxbrew/.linuxbrew/bin/ld: /tmp/cc5Mn8XY.o:/home/linuxbrew/cactus/bar/tests/flowersShared.h:15: multiple definition of `stateMachine'; /tmp/ccnwoq0X.o:/home/linuxbrew/cactus/bar/tests/flowersShared.h:15: first defined here
/home/linuxbrew/.linuxbrew/bin/ld: /tmp/ccpHH84X.o:/home/linuxbrew/cactus/bar/tests/flowersShared.h:15: multiple definition of `stateMachine'; /tmp/ccnwoq0X.o:/home/linuxbrew/cactus/bar/tests/flowersShared.h:15: first defined here
/home/linuxbrew/.linuxbrew/bin/ld: /tmp/cc2kRTD1.o:/home/linuxbrew/cactus/bar/tests/flowersShared.h:15: multiple definition of `stateMachine'; /tmp/ccnwoq0X.o:/home/linuxbrew/cactus/bar/tests/flowersShared.h:15: first defined here
collect2: error: ld returned 1 exit status
make[4]: *** [Makefile:22: ../bin/cactus_barTests] Error 1
make[4]: Leaving directory '/home/linuxbrew/cactus/bar'
make[3]: *** [Makefile:16: all_progs] Error 2
make[3]: Leaving directory '/home/linuxbrew/cactus/bar'
make[2]: *** [Makefile:63: all_progs.bar] Error 2
make[2]: Leaving directory '/home/linuxbrew/cactus'
make[1]: *** [Makefile:58: all_progs] Error 2
make[1]: Leaving directory '/home/linuxbrew/cactus'
make: *** [Makefile:34: all] Error 2
```

There are two solutions to overcome this problem for cactus

1. Make the pointer `StateMachine *stateMachine` static (as this PR proposes)
2. Add  `CFLAGS+= -fcommon' in the `Makefile` to suppress this error.  

The `-fcommon `workaround is discouraged because this seems a quick fix anyway.