### PR TITLE
Add back segalign support

### DIFF
--- a/paf/paf_tile.c
+++ b/paf/paf_tile.c
@@ -48,7 +48,7 @@ void increase_alignment_level_counts(uint16_t *counts, Paf *paf) {
             if(c->op == match) {
                 for(int64_t j=0; j<c->length; j++) {
                     assert(i + j < paf->query_end && i + j >= 0 && i + j < paf->query_length);
-                    if(counts[i + j] < INT16_MAX) { // prevent overflow
+                    if(counts[i + j] < INT16_MAX - 1) { // prevent overflow
                         counts[i + j]++;
                     }
                 }

--- a/src/cactus/blast/cactus_blast.py
+++ b/src/cactus/blast/cactus_blast.py
@@ -92,7 +92,7 @@ def runCactusBlastOnly(options):
             config_wrapper = ConfigWrapper(config_node)
             config_wrapper.substituteAllPredefinedConstantsWithLiterals()
             # apply gpu override
-            config_wrapper.initGPU(options.gpu)
+            config_wrapper.initGPU(options)
             mc_tree, input_seq_map, og_candidates = parse_seqfile(options.seqFile, config_wrapper)
             og_map = compute_outgroups(mc_tree, config_wrapper, set(og_candidates))
             event_set = get_event_set(mc_tree, config_wrapper, og_map, options.root)

--- a/src/cactus/preprocessor/cactus_preprocessor.py
+++ b/src/cactus/preprocessor/cactus_preprocessor.py
@@ -445,6 +445,8 @@ def main():
             raise RuntimeError('--inPaths must be used in conjunction with --outPaths and not with --inSeqFile nor --outSeqFile')
         if len(options.inPaths) != len(options.outPaths):
             raise RuntimeError('--inPaths and --outPaths must have the same number of arguments')
+        if not options.inputNames or len(options.inputNames) != len(options.inPaths):
+            raise RuntimeError('--inputNames must be used in conjunction with --inputPaths to specify (exactly) one event name for each input')
     else:
         raise RuntimeError('--inSeqFile/--outSeqFile/--inputNames or --inPaths/--outPaths required to specify input')
     if options.maskAlpha and options.clipAlpha:

--- a/src/cactus/progressive/cactus_progressive.py
+++ b/src/cactus/progressive/cactus_progressive.py
@@ -335,7 +335,7 @@ def main():
             config_wrapper = ConfigWrapper(config_node)
             config_wrapper.substituteAllPredefinedConstantsWithLiterals()
             # apply gpu override
-            config_wrapper.initGPU(options.gpu)            
+            config_wrapper.initGPU(options)
             mc_tree, input_seq_map, og_candidates = parse_seqfile(options.seqFile, config_wrapper)
             og_map = compute_outgroups(mc_tree, config_wrapper, set(og_candidates), options.root)
             event_set = get_event_set(mc_tree, config_wrapper, og_map, options.root)

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -216,8 +216,7 @@ def make_align_job(options, toil):
     config_node = ET.parse(options.configFile).getroot()
     config_wrapper = ConfigWrapper(config_node)
     config_wrapper.substituteAllPredefinedConstantsWithLiterals()
-    # apply gpu override
-    config_wrapper.initGPU(options.gpu)
+    config_wrapper.initGPU(options)
     mc_tree, input_seq_map, og_candidates = parse_seqfile(options.seqFile, config_wrapper,
                                                           default_branch_length = 0.025 if options.pangenome else None)
     og_map = compute_outgroups(mc_tree, config_wrapper, set(og_candidates))


### PR DESCRIPTION
Some of the overrides remain a bit hacky.  (think we'll need a new comand line option equivalent to --consCores for running on aws/autoscale, for example).

Also, there may be a speed regression in some cases because alignment jobs are smaller than they were on master where everything was just cat'd together.  Don't think it should be too serious though. 