### PR TITLE
Fix quote fail in recent update to install instructions

### DIFF
--- a/BIN-INSTALL.md
+++ b/BIN-INSTALL.md
@@ -15,8 +15,8 @@ cd "cactus-bin-${REL_TAG}"
 To build a python virtualenv and activate, do the following steps:
 ```
 virtualenv -p python3.8 cactus_env
-echo 'export PATH=$(pwd)/bin:$PATH' >> cactus_env/bin/activate
-echo 'export PYTHONPATH=$(pwd)/lib:$PYTHONPATH' >> cactus_env/bin/activate
+echo "export PATH=$(pwd)/bin:\$PATH" >> cactus_env/bin/activate
+echo "export PYTHONPATH=$(pwd)/lib:\$PYTHONPATH" >> cactus_env/bin/activate
 source cactus_env/bin/activate
 python3 -m pip install -U setuptools pip==21.3.1
 python3 -m pip install -U -r ./toil-requirement.txt

--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ export PYTHONPATH=$(pwd)/submodules:$PYTHONPATH
 
 It's useful to add the paths to the virtualenv so as not to set them each time you need to run cactus from a new shell.  This can be done with
 ```
-echo 'export PATH=$(pwd)/bin:$PATH' >> cactus_env/bin/activate
-echo 'export PYTHONPATH=$(pwd)/lib:$PYTHONPATH' >> cactus_env/bin/activate
+echo "export PATH=$(pwd)/bin:\$PATH" >> cactus_env/bin/activate
+echo "export PYTHONPATH=$(pwd)/lib:\$PYTHONPATH" >> cactus_env/bin/activate
 ```
 
 #### Python Install With Docker Binaries


### PR DESCRIPTION
I recently changed the install instructions to add PATH to the virtualenv.  But as @rsharris [points out](https://github.com/ComparativeGenomicsToolkit/cactus/issues/700#issuecomment-1088760751) (thanks!!) this doesn't actually work because of a typo.   Should be fixed now.

resolves #700