### PR TITLE
Update minigraph and use its new base aligner

### DIFF
--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -59,7 +59,7 @@ fi
 cd ${pangenomeBuildDir}
 git clone https://github.com/lh3/minigraph.git
 pushd minigraph
-git checkout 47829dff05e7a98fde575f644d71d7c4c430ebbe
+git checkout ca582d9f099b7b4095bbc58f8caced14d82a9031
 # hack in flags support
 sed -i Makefile -e 's/CFLAGS=/CFLAGS+=/'
 make -j ${numcpu}
@@ -163,7 +163,7 @@ fi
 cd ${pangenomeBuildDir}
 git clone https://github.com/ComparativeGenomicsToolkit/cactus-gfa-tools.git
 cd cactus-gfa-tools
-git checkout 058bfb8859d007992cec54a2ecfd68af45524fd2
+git checkout d6112cf6411a410a84c6138e364375aa769983cb
 make -j ${numcpu}
 if [[ $STATIC_CHECK -ne 1 || $(ldd paf2lastz | grep so | wc -l) -eq 0 ]]
 then

--- a/examples/evolverPrimates.txt
+++ b/examples/evolverPrimates.txt
@@ -3,3 +3,4 @@ simHuman	https://raw.githubusercontent.com/ComparativeGenomicsToolkit/cactusTest
 simChimp	https://raw.githubusercontent.com/ComparativeGenomicsToolkit/cactusTestData/master/evolver/primates/loci1/simChimp.chr6
 simGorilla	https://raw.githubusercontent.com/ComparativeGenomicsToolkit/cactusTestData/master/evolver/primates/loci1/simGorilla.chr6
 simOrang	https://raw.githubusercontent.com/ComparativeGenomicsToolkit/cactusTestData/master/evolver/primates/loci1/simOrang.chr6
+_MINIGRAPH_	file:///home/hickey/dev/cactus/fam

--- a/examples/evolverPrimates.txt
+++ b/examples/evolverPrimates.txt
@@ -3,4 +3,3 @@ simHuman	https://raw.githubusercontent.com/ComparativeGenomicsToolkit/cactusTest
 simChimp	https://raw.githubusercontent.com/ComparativeGenomicsToolkit/cactusTestData/master/evolver/primates/loci1/simChimp.chr6
 simGorilla	https://raw.githubusercontent.com/ComparativeGenomicsToolkit/cactusTestData/master/evolver/primates/loci1/simGorilla.chr6
 simOrang	https://raw.githubusercontent.com/ComparativeGenomicsToolkit/cactusTestData/master/evolver/primates/loci1/simOrang.chr6
-_MINIGRAPH_	file:///home/hickey/dev/cactus/fam

--- a/paf/impl/paf.c
+++ b/paf/impl/paf.c
@@ -24,10 +24,22 @@ static Cigar *parse_cigar_record(char **c) {
         i++;
     }
     char t = (*c)[i]; // The type of the cigar operation
-    if(t != 'M' && t != 'I' && t != 'D') {
+    switch(t) {
+    case 'M': // match
+    case '=': // exact match
+    case 'X': // snp match
+        cigar->op = match;
+        break;
+    case 'I':
+        cigar->op = query_insert;
+        break;
+    case 'D':
+        cigar->op = query_delete;
+        break;
+    default:
         st_errAbort("Got an unexpected character paf cigar string: %c\n", t);
+        break;
     }
-    cigar->op = t == 'M' ? match : (t == 'I' ? query_insert : query_delete);
     (*c)[i] = ' ';
     cigar->length = atoll(*c);
     *c = &((*c)[i+1]);

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -247,35 +247,24 @@
 	<!-- assemblyName: special name of "virtual" minigraph assembly, which is just the list of sequences from the graph. -->
 	<!-- minigraphMapOptions: flags to pass to minigraph for mapping -->
 	<!-- minigraphConstructOptions: flags to pass to minigraph for construction -->
-	<!-- universalMZFilter: only use minimizers who appear in this proportion (1.0 == 100%) of sequences that map over them. -->
-	<!-- nodeBasedUniversal: universal filter calculated in terms of nodes istead of mapped regions. -->
-	<!-- minMZBlockLength: only use minimizers that form contiguous blocks at least this long -->
 	<!-- minMAPQ: ignore minigraph alignments with mapping quality less than this -->
 	<!-- minGAFBlockLength: ignore minigraph alignments with block length less than this -->
-	<!-- minGAFNodeLength: ignore minigraph nodes with length less than this -->
-	<!-- minGAFQueryOverlapFilter: if 2 or more query regions in blocks of at least this size, filter them out. -->
-	<!--                           if 1 query region in a block of at least this size overlaps query regions in blocks smaller than this, filter out the smaller ones -->
-	<!--                           Filter is disabled when set to 0.  Any non-zero value will prevent query overlaps -->
 	<!-- maskFilter: any softmasked sequence intervals > than this many bp will be hardmasked before being read by the minigraph mapper [negative value = disable]-->
 	<!-- delFilter: any deletions implied by split-read mappings greater than this are removed from the paf (by removing all lines of the smallest block bordering deletion)-->
 	<!-- delFilterThreshold: only remove deletion if it costs < delFilterThreshold * deletion-size matches. must be in range (0, 1] -->
+	<!-- minIdentity: ignore PAF lines with identity (col 10 / col 11) is less than this -->	
 	<!-- removeMinigraphFromPAF: replace all minigraph contigs with transitive alignments in cactus-align-->
 	<!-- cpu: use up to this many cpus for each minigraph command. -->
 	<graphmap
 		 assemblyName="_MINIGRAPH_"
-		 minigraphMapOptions="-S --write-mz -xasm"
-		 minigraphConstructOptions="-xggs"
-		 universalMZFilter="0"
-		 nodeBasedUniversal="0"
-		 strictUniversal="0"
-		 minMZBlockLength="0"
+		 minigraphMapOptions="-c -xasm"
+		 minigraphConstructOptions="-c -xggs"
 		 minMAPQ="5"
 		 minGAFBlockLength="50000"
-		 minGAFNodeLength="0"
-		 minGAFQueryOverlapFilter="10000"
 		 maskFilter="-1"
 		 delFilter="-1"
 		 delFilterThreshold="0.01"
+		 minIdentity="0.01"		 
 		 removeMinigraphFromPAF="0"
 		 cpu="6"
 		 />
@@ -287,18 +276,15 @@
 	<!--                    10000-99999 : min_coverage = 0. 95 -->
 	<!--                    100000-infinity : min_coverage = 0.90 -->		  
 	<!-- minQueryUniqueness: The ratio of the number of query bases aligned to the chosen ref contig vs the next best ref contig must exceed this threshold to not be considered ambigious. -->
-	<!-- maxGap: Include indel gaps <= maxGap when counting minigraph coverage -->
 	<!-- ambiguousName: Contigs deemed ambiguous using the above filters get added to a "contig" with this name, and are preserved in output. -->
 	<!-- remapSplitOptions: extra rgfa-split options to apply when splitting after remapping (use -u 3000000 to enable autoclipping between contigs, add -s to allow within contig)-->
-	<!-- minIdentity: ignore PAF lines with identity (col 10 / col 11) is less than this -->
+
   	<graphmap_split
 		 minQueryCoverages="0.75 0.5 0.25"
        minQueryCoverageThresholds="100000 1000000"
 		 minQueryUniqueness="3"
-		 maxGap="5000"
 		 ambiguousName="_AMBIGUOUS_"
 		 remapSplitOptions=""
-		 minIdentity="0.01"
 		 />
 	<!-- hal2vg options -->
 	<!-- includeMinigraph: include minigraph node sequences as paths in output (note that cactus-graphmap-join will still remove them by default) -->

--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -280,7 +280,7 @@ class TestCase(unittest.TestCase):
         paf_path = os.path.join(self.tempDir, 'yeast.paf')
         fa_path = os.path.join(self.tempDir, 'yeast.gfa.fa')        
         subprocess.check_call(['cactus-graphmap', self._job_store(binariesMode), seq_file_path, mg_path, paf_path,
-                               '--outputFasta', fa_path, '--base', '--delFilter', '2000000'] + cactus_opts)
+                               '--outputFasta', fa_path, '--delFilter', '2000000'] + cactus_opts)
             
         # split into chromosomes
         chroms = ['chrI', 'chrII', 'chrIII', 'chrIV', 'chrV', 'chrVI', 'chrVII', 'chrVIII', 'chrIX', 'chrX', 'chrXI', 'chrXIV', 'chrXV']


### PR DESCRIPTION
Minigraph can write cigar strings since version [0.17](https://github.com/lh3/minigraph/releases/tag/v0.17).  This simplifies our pangenome pipeline considerably since it's no longer necessary to phony in cigars from the raw chains of minigrpah minimizers.  It also means that the work in #652, where cactus was run pairwise to in a first pass to compute base alignments, isn't needed either. 

This is a PR on top of #652 that undoes the cactus base alignment step, along with a lot of the fiddly minimizer-specific filters, and moves to running `minigraph` with `-c`.  

There is now no longer any reason for this PR to be based on the paf chains branch (this only happened originally since its big refactor made implementing the *cactus* base aligner step so much easier).  So I think a manual rebase onto master, though painful, will be worth it....