### PR TITLE
Fix CI, which broke due to networkx update

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
 
     install_requires = [
         'decorator',
-        'networkx>=2,<3',
+        'networkx>=2,<2.81',
         'pytest',
         'cigar',
         'biopython'], 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
 
     install_requires = [
         'decorator',
-        'networkx>=2,<2.81',
+        'networkx>=2,<2.8.1',
         'pytest',
         'cigar',
         'biopython'], 


### PR DESCRIPTION
Networkx version 2.81 (may 18th) breaks the outgroup test.  This rolls back the required version in setup.py to be < 2.8.1.  (todo: get Cactus working with latest networkx)

```
File "/builds/comparativegenomicstoolkit/cactus/src/cactus/progressive/outgroupTest.py", line 244, in testDynamicOutgroupsOnRandomTrees
    og.compute(maxNumOutgroups=3)
  File "/builds/comparativegenomicstoolkit/cactus/src/cactus/progressive/outgroup.py", line 314, in compute
    self.__dpInit(node)
  File "/builds/comparativegenomicstoolkit/cactus/src/cactus/progressive/outgroup.py", line 346, in __dpInit
    self.dpTree = copy.deepcopy(self.mcTree)
  File "/usr/lib/python3.8/copy.py", line 172, in deepcopy
    y = _reconstruct(x, memo, *rv)
  File "/usr/lib/python3.8/copy.py", line 270, in _reconstruct
    state = deepcopy(state, memo)
  File "/usr/lib/python3.8/copy.py", line 146, in deepcopy
    y = copier(x, memo)
  File "/usr/lib/python3.8/copy.py", line 230, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/lib/python3.8/copy.py", line 172, in deepcopy
    y = _reconstruct(x, memo, *rv)
  File "/usr/lib/python3.8/copy.py", line 270, in _reconstruct
    state = deepcopy(state, memo)
  File "/usr/lib/python3.8/copy.py", line 146, in deepcopy
    y = copier(x, memo)
  File "/usr/lib/python3.8/copy.py", line 230, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/lib/python3.8/copy.py", line 172, in deepcopy
    y = _reconstruct(x, memo, *rv)
  File "/usr/lib/python3.8/copy.py", line 272, in _reconstruct
    y.__setstate__(state)
  File "/builds/comparativegenomicstoolkit/cactus/venv/lib/python3.8/site-packages/networkx/classes/reportviews.py", line 1290, in __setstate__
    self._adjdict = G._pred if hasattr(G, "pred") else G._adj
AttributeError: 'DiGraph' object has no attribute '_adj'
```