### PR TITLE
Update libxml2 version used in static binaries build

### DIFF
--- a/BIN-INSTALL.md
+++ b/BIN-INSTALL.md
@@ -12,7 +12,7 @@ cd "cactus-bin-${REL_TAG}"
 
 ## Setup
 
-To build a python virtualenv and activate, do the following steps:
+To build a python virtualenv and activate, do the following steps (Ubuntu 18.04 users should use `-p python3.8` below):
 ```
 virtualenv -p python3 cactus_env
 echo "export PATH=$(pwd)/bin:\$PATH" >> cactus_env/bin/activate

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ To avoid problems with conflicting versions of dependencies on your system, we s
 python3 -m pip install virtualenv
 ```
 
-To set up a virtual environment in the directory `cactus_env`, run:
+To set up a virtual environment in the directory `cactus_env`, run (Ubuntu 18.04 users should use `-p python3.8` below):
 ```
 python3 -m virtualenv -p python3 cactus_env
 ```

--- a/build-tools/makeBinRelease
+++ b/build-tools/makeBinRelease
@@ -63,9 +63,9 @@ make install
 export PATH=${DEP_PREFIX}/bin:$PATH
 # libxml2
 cd ${DEP_PREFIX}
-wget -q http://xmlsoft.org/sources/libxml2-2.7.2.tar.gz
-tar -zxf libxml2-2.7.2.tar.gz
-cd libxml2-2.7.2
+wget -q http://xmlsoft.org/sources/libxml2-2.9.12.tar.gz
+tar -zxf libxml2-2.9.12.tar.gz
+cd libxml2-2.9.12
 ./configure --enable-static --disable-shared --prefix=${DEP_PREFIX}
 make -j $(nproc)
 make install


### PR DESCRIPTION
Switch from (very old) 2.7.2 to (very new) 2.9.12.

Resolves #742 and probably #688 and #585

I'm hoping the newer library is fixing some sort of quirk in the static build, and it's not just a case of either version working on some systems and not working on others.  But I only have [one datapoint](https://github.com/ComparativeGenomicsToolkit/cactus/issues/742#issuecomment-1172036016) to go on so far, so who knows -- will err on the side of the more up-to-date library.  
