### PR TITLE
Add back automatic fasta header prefix logic

### DIFF
--- a/doc/pangenome.md
+++ b/doc/pangenome.md
@@ -129,10 +129,8 @@ Below is an example of creating a yeast pangenome chromosome by chromosome, refe
 
 ```
 # make the seqfile
-cactus-prepare ./examples/yeastPangenome.txt --outDir ./yeast-pg --seqFileOnly
-
-# run the preprocessor (absolutely necessary if fasta sequence names aren't unique, which they aren't here)
-cactus-preprocess ./jobstore ./examples/yeastPangenome.txt ./yeast-pg/yeastPangenome.txt --pangenome
+mkdir -p yeast-pg
+cp ./examples/yeastPangenome.txt yeast-pg/
 
 # make the minigraph
 cactus-minigraph ./jobstore  ./yeast-pg/yeastPangenome.txt ./yeast-pg/yeast.gfa --realTimeLogging --reference S288C

--- a/doc/pangenome.md
+++ b/doc/pangenome.md
@@ -324,7 +324,7 @@ hal2assemblyHub.py ./jobstore ./yeast-pg/yeast-pg.hal yeast-pg/hub --shortLabel 
 Move `yeast-pg/hub` to somewhere web-accessible, and pass the full URL of `yeast-pg/hub/hub.txt` to the Genome Browser in the "My Data -> Track Hubs" menu.   Select `S288C` as the reference and display the hub.  Right-click on the display and select "Configure yeast track set" to toggle on all the assemblies (and toggle off Anc0 and _MINIGRAPH_).
 
 ## HPRC Graph
-The [Human Pangenome Reference Consortium](https://humanpangenome.org/data-and-resources/) is producing an ever-growing number of high quality phased assemblies.  This section will demonstrate how to use the Cactus-Minigraph Pangenome Pipeline to construct a Pangenome from them.  Note the instructions here are slightly different than were used to create the v1.0 Cactus-Minigraph pangenome that's been released by the HPRC, as they are based on a more recent and improved version of the pipeline. 
+The [Human Pangenome Reference Consortium](https://humanpangenome.org/data-and-resources/) is producing an ever-growing number of high quality phased assemblies.  This section will demonstrate how to use the Minigraph-Cactus Pangenome Pipeline to construct a Pangenome from them.  Note the instructions here are slightly different than were used to create the v1.0 Minigraph-Cactus pangenome that's been released by the HPRC, as they are based on a more recent and improved version of the pipeline. 
 
 The steps below are run on AWS/S3, and assume everything is written to s3://MYBUCKET. All jobs are run on r5.8xlarge (32 cores / 256G RAM) nodes. In theory, the entire pipeline could therefore be run on a single machine (ideally with 64 cores).  It would take several days though. They can be run on other batch systems, at least in theory.  Most of the compute-heavy tasks spawn relatively few jobs, and may be amenable to SLURM environments.
 
@@ -339,6 +339,8 @@ export MINIGRAPH=https://zenodo.org/record/6499594/files/GRCh38-90c.r518.gfa.gz
 WDL / cactus-prepare support is in progress!
 
 ### HPRC Graph: Setup and Name Munging
+
+**Important** The Cactus-Minigraph Pipeline does not support alt contigs in the reference.  If you really want them in your graph, then you will need to pull them out into separate samples (ie one alt contig per region per sample).  Otherwise they will end up as separate reference contigs and not align together.  As such we advice using the GRCh38 fasta file referenced in the `hprc-${VERSION}-mc.seqfile` generated below for any graph using GRCh38 as a reference.  
 
 The fasta sequences for the Year-1 HPRC assemblies are [available here](https://github.com/human-pangenomics/HPP_Year1_Assemblies).  We begin by using them to create an input seqfile for Cactus:
 

--- a/preprocessor/Makefile
+++ b/preprocessor/Makefile
@@ -6,7 +6,7 @@ CFLAGS += ${hiredisIncl}
 all: all_libs all_progs
 all_libs: 
 all_progs: all_libs
-	${MAKE} ${BINDIR}/cactus_analyseAssembly ${BINDIR}/cactus_makeAlphaNumericHeaders.py ${BINDIR}/cactus_filterSmallFastaSequences.py ${BINDIR}/cactus_softmask2hardmask
+	${MAKE} ${BINDIR}/cactus_analyseAssembly ${BINDIR}/cactus_makeAlphaNumericHeaders.py ${BINDIR}/cactus_filterSmallFastaSequences.py ${BINDIR}/cactus_softmask2hardmask ${BINDIR}/cactus_sanitizeFastaHeaders
 	cd lastzRepeatMasking && ${MAKE} all
 
 ${BINDIR}/cactus_filterSmallFastaSequences.py : cactus_filterSmallFastaSequences.py
@@ -22,6 +22,9 @@ ${BINDIR}/cactus_analyseAssembly : cactus_analyseAssembly.c ${LIBDEPENDS} ${LIBD
 
 ${BINDIR}/cactus_softmask2hardmask : cactus_softmask2hardmask.c ${LIBDEPENDS} ${LIBDIR}/cactusLib.a
 	${CC} ${CPPFLAGS} ${CFLAGS} ${LDFLAGS} -o ${BINDIR}/cactus_softmask2hardmask cactus_softmask2hardmask.c ${LIBDIR}/cactusLib.a ${LDLIBS}
+
+${BINDIR}/cactus_sanitizeFastaHeaders : cactus_sanitizeFastaHeaders.c ${LIBDEPENDS} ${LIBDIR}/cactusLib.a
+	${CC} ${CPPFLAGS} ${CFLAGS} ${LDFLAGS} -o ${BINDIR}/cactus_sanitizeFastaHeaders cactus_sanitizeFastaHeaders.c ${LIBDIR}/cactusLib.a ${LDLIBS}
 
 clean : 
 	rm -f *.o

--- a/preprocessor/cactus_sanitizeFastaHeaders.c
+++ b/preprocessor/cactus_sanitizeFastaHeaders.c
@@ -38,7 +38,7 @@ void addUniqueFastaPrefix(void* destination, const char *fastaHeader, const char
         return;
     }
 
-    if (stSet_search(header_set, fastaHeader) != NULL) {
+    if (stSet_search(header_set, (void*)fastaHeader) != NULL) {
         fprintf(stderr, "Error: The fasta header \"%s\" appears more than once for event \"%s\". Please ensure fast headers are unique for each input\n", fastaHeader, eventName);
         exit(1);
     }

--- a/preprocessor/cactus_sanitizeFastaHeaders.c
+++ b/preprocessor/cactus_sanitizeFastaHeaders.c
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2009-2011 by Benedict Paten (benedictpaten@gmail.com)
+ *
+ * Released under the MIT license, see LICENSE.txt
+ */
+
+#include <assert.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <time.h>
+#include <getopt.h>
+#include <inttypes.h>
+#include <sys/types.h>
+#include <sys/param.h>
+#include <sys/stat.h>
+#include <dirent.h>
+#include <math.h>
+#include <ctype.h>
+
+#include "bioioC.h"
+#include "cactus.h"
+
+void usage() {
+    fprintf(stderr, "cactus_addUniquePrefixes [fastaFile] [EVENT]\n");
+}
+
+static stSet* header_set = NULL;
+
+void addUniqueFastaPrefix(void* destination, const char *fastaHeader, const char *string, int64_t length) {
+
+    char* eventName = (char*)destination;
+
+    // these cause weird crashes in halAppendCactusSubtree -- until that's fixed there's no point in trying to support them
+    if (length == 0) {
+        fprintf(stderr, "Warning: ignoring empty fast a sequence \"%s\" from event \"%s\"\n", fastaHeader, eventName);
+        return;
+    }
+
+    if (stSet_search(header_set, fastaHeader) != NULL) {
+        fprintf(stderr, "Error: The fasta header \"%s\" appears more than once for event \"%s\". Please ensure fast headers are unique for each input\n", fastaHeader, eventName);
+        exit(1);
+    }
+    stSet_insert(header_set, stString_copy(fastaHeader));
+
+    // we mimic a very basic check from the preprocessor while we're at it
+    size_t header_len = strlen(fastaHeader);
+    int64_t pipe_pos = -1;
+    for (size_t i = 0; i < header_len; ++i) {
+        if (fastaHeader[i] == '|') {
+            pipe_pos = (int64_t)i;
+        } else if (fastaHeader[i] == ' ' || fastaHeader[i] == '\t') {
+            fprintf(stderr, "Error: The fasta header \"%s\" from event \"%s\" contains spaces or tabs. These characters will cause issues in space-separated formats like MAF, and may not function properly when viewed in a browser. Please remove these characters from the input headers and try again.\n", fastaHeader, eventName);
+            exit(1);
+        }
+    }
+  
+    char* newHeader = NULL;
+    if (strncmp(fastaHeader, "id=", 3) != 0 || strstr(fastaHeader, "|") == NULL) {
+        // no prefix found, we add one
+        newHeader = (char*)malloc(strlen(fastaHeader) + strlen(eventName) + 8);
+        sprintf(newHeader, "id=%s|%s", eventName, fastaHeader);
+    }
+    const char* header = newHeader ? newHeader : fastaHeader;
+    fastaWrite((char*)string, (char*)header, stdout);
+}
+
+int main(int argc, char *argv[]) {
+    if(argc != 3) {
+        usage();
+        return 1;
+    }
+
+    header_set = stSet_construct3(stHash_stringKey, stHash_stringEqualKey, free);
+    
+    FILE *fileHandle;
+    if (strcmp(argv[1], "-") == 0) {
+        fileHandle = stdin;
+    } else {
+        fileHandle = fopen(argv[1], "r");
+        if (fileHandle == NULL) {
+            st_errAbort("Could not open input file %s", argv[1]);
+        }
+    }
+
+    fastaReadToFunction(fileHandle, (void*)argv[2], addUniqueFastaPrefix);
+    fclose(fileHandle);
+    stSet_destruct(header_set);
+
+    return 0;
+}

--- a/preprocessor/cactus_sanitizeFastaHeaders.c
+++ b/preprocessor/cactus_sanitizeFastaHeaders.c
@@ -57,7 +57,7 @@ void addUniqueFastaPrefix(void* destination, const char *fastaHeader, const char
     }
   
     char* newHeader = NULL;
-    if (strncmp(fastaHeader, "id=", 3) != 0 || strstr(fastaHeader, "|") == NULL) {
+    if (strncmp(fastaHeader, "id=", 3) != 0 || pipe_pos <= 0) { 
         // no prefix found, we add one
         newHeader = (char*)malloc(strlen(fastaHeader) + strlen(eventName) + 8);
         sprintf(newHeader, "id=%s|%s", eventName, fastaHeader);

--- a/src/cactus/blast/cactus_blast.py
+++ b/src/cactus/blast/cactus_blast.py
@@ -18,7 +18,7 @@ from cactus.shared.common import makeURL, catFiles
 from cactus.shared.common import enableDumpStack
 from cactus.shared.common import cactus_override_toil_options
 
-from cactus.paf.local_alignment import make_paf_alignments
+from cactus.paf.local_alignment import sanitize_then_make_paf_alignments
 
 from toil.job import Job
 from toil.common import Toil
@@ -122,7 +122,8 @@ def runCactusBlastOnly(options):
                     logger.info("Importing {}".format(seq))
                     input_seq_id_map[genome] = toil.importFile(seq)
 
-            paf_id = toil.start(Job.wrapJobFn(make_paf_alignments, NXNewick().writeString(spanning_tree), input_seq_id_map, options.root, config_node))
+            paf_id = toil.start(Job.wrapJobFn(sanitize_then_make_paf_alignments, NXNewick().writeString(spanning_tree),
+                                              input_seq_id_map, options.root, config_node))
 
         # export the alignments
         toil.exportFile(paf_id, makeURL(options.outputFile))

--- a/src/cactus/paf/local_alignment.py
+++ b/src/cactus/paf/local_alignment.py
@@ -135,7 +135,7 @@ def make_chunked_alignments(job, event_a, genome_a, event_b, genome_b, distance,
             chunked_alignment_files.append(job.addChildJobFn(mappingFn, '{}_{}'.format(event_a, i), chunk_a,
                                                              '{}_{}'.format(event_b, j), chunk_b, distance, params,
                                                              cores=lastz_cores, disk=4*(chunk_a.size+chunk_b.size),
-                                                             memory=4*(chunk_a.size+chunk_b.size).rv())
+                                                             memory=4*(chunk_a.size+chunk_b.size)).rv())
 
     return job.addFollowOnJobFn(combine_chunks, chunked_alignment_files).rv()  # Combine the chunked alignment files
 

--- a/src/cactus/paf/local_alignment.py
+++ b/src/cactus/paf/local_alignment.py
@@ -63,7 +63,7 @@ def run_lastz(job, name_A, genome_A, name_B, genome_B, distance, params):
         # run_segalign can crash and still exit 0, so it's worth taking a moment to check the log for errors
         segalign_messages = segalign_messages.lower()
         for line in segalign_messages.split("\n"):
-            if not line.startswith("signals delivered")
+            if not line.startswith("signals delivered"):
                 for keyword in ['terminate', 'error', 'fail', 'assert', 'signal', 'abort', 'segmentation', 'sigsegv', 'kill']:
                     if keyword in segalign_messages:
                         job.fileStore.logToMaster("Segalign Stderr: " + segalign_messages)  # Log the messages

--- a/src/cactus/paf/local_alignment.py
+++ b/src/cactus/paf/local_alignment.py
@@ -65,7 +65,7 @@ def run_lastz(job, name_A, genome_A, name_B, genome_B, distance, params):
         for line in segalign_messages.split("\n"):
             if not line.startswith("signals delivered"):
                 for keyword in ['terminate', 'error', 'fail', 'assert', 'signal', 'abort', 'segmentation', 'sigsegv', 'kill']:
-                    if keyword in segalign_messages:
+                    if keyword in line:
                         job.fileStore.logToMaster("Segalign Stderr: " + segalign_messages)  # Log the messages
                         raise RuntimeError('{} exited 0 but keyword "{}" found in stderr'.format(lastz_cmd, keyword))
 

--- a/src/cactus/paf/local_alignment.py
+++ b/src/cactus/paf/local_alignment.py
@@ -15,7 +15,7 @@ from sonLib.bioio import newickTreeParser
 import os
 from cactus.paf.paf import get_event_pairs, get_leaves, get_node, get_distances
 from cactus.shared.common import cactus_call, getOptionalAttrib
-
+from cactus.preprocessor.checkUniqueHeaders import sanitize_fasta_headers
 
 def run_lastz(job, name_A, genome_A, name_B, genome_B, distance, params):
     # Create a local temporary file to put the alignments in.
@@ -249,6 +249,10 @@ def chain_alignments(job, alignment_files, reference_event_name, params):
 
     return job.fileStore.writeGlobalFile(output_alignments_file)  # Copy back
 
+def sanitize_then_make_paf_alignments(job, event_tree_string, event_names_to_sequences, ancestor_event_string, params):
+    sanitize_job = job.addChildJobFn(sanitize_fasta_headers, event_names_to_sequences)
+    paf_job = sanitize_job.addFollowOnJobFn(make_paf_alignments, event_tree_string, sanitize_job.rv(), ancestor_event_string, params)
+    return paf_job.rv()
 
 def make_paf_alignments(job, event_tree_string, event_names_to_sequences, ancestor_event_string, params):
     # a job should never set its own follow-on, so we hang everything off the root_job here to encapsulate

--- a/src/cactus/paf/local_alignment.py
+++ b/src/cactus/paf/local_alignment.py
@@ -66,7 +66,7 @@ def run_lastz(job, name_A, genome_A, name_B, genome_B, distance, params):
             if not line.startswith("signals delivered"):
                 for keyword in ['terminate', 'error', 'fail', 'assert', 'signal', 'abort', 'segmentation', 'sigsegv', 'kill']:
                     if keyword in line:
-                        job.fileStore.logToMaster("Segalign Stderr: " + segalign_messages)  # Log the messages
+                        job.fileStore.logToMaster("Segalign offending line: " + line)  # Log the messages
                         raise RuntimeError('{} exited 0 but keyword "{}" found in stderr'.format(lastz_cmd, keyword))
 
     # Return the alignment file

--- a/src/cactus/paf/local_alignment.py
+++ b/src/cactus/paf/local_alignment.py
@@ -135,7 +135,7 @@ def make_chunked_alignments(job, event_a, genome_a, event_b, genome_b, distance,
             chunked_alignment_files.append(job.addChildJobFn(mappingFn, '{}_{}'.format(event_a, i), chunk_a,
                                                              '{}_{}'.format(event_b, j), chunk_b, distance, params,
                                                              cores=lastz_cores, disk=4*(chunk_a.size+chunk_b.size),
-                                                             memory=8*chunk_a.size+chunk_b.size).rv())
+                                                             memory=4*(chunk_a.size+chunk_b.size).rv())
 
     return job.addFollowOnJobFn(combine_chunks, chunked_alignment_files).rv()  # Combine the chunked alignment files
 

--- a/src/cactus/paf/local_alignment.py
+++ b/src/cactus/paf/local_alignment.py
@@ -62,10 +62,12 @@ def run_lastz(job, name_A, genome_A, name_B, genome_B, distance, params):
     if gpu:
         # run_segalign can crash and still exit 0, so it's worth taking a moment to check the log for errors
         segalign_messages = segalign_messages.lower()
-        for keyword in ['terminate', 'error', 'fail', 'assert', 'signal', 'abort', 'segmentation', 'sigsegv', 'kill']:
-            if keyword in segalign_messages:
-                job.fileStore.logToMaster("Segalign Stderr: " + segalign_messages)  # Log the messages
-                raise RuntimeError('{} exited 0 but keyword "{}" found in stderr'.format(lastz_cmd, keyword))
+        for line in segalign_messages.split("\n"):
+            if not line.startswith("signals delivered")
+                for keyword in ['terminate', 'error', 'fail', 'assert', 'signal', 'abort', 'segmentation', 'sigsegv', 'kill']:
+                    if keyword in segalign_messages:
+                        job.fileStore.logToMaster("Segalign Stderr: " + segalign_messages)  # Log the messages
+                        raise RuntimeError('{} exited 0 but keyword "{}" found in stderr'.format(lastz_cmd, keyword))
 
     # Return the alignment file
     return job.fileStore.writeGlobalFile(alignment_file)

--- a/src/cactus/paf/local_alignment.py
+++ b/src/cactus/paf/local_alignment.py
@@ -134,7 +134,8 @@ def make_chunked_alignments(job, event_a, genome_a, event_b, genome_b, distance,
             mappingFn = mappers[params.find("blast").attrib["mapper"]]
             chunked_alignment_files.append(job.addChildJobFn(mappingFn, '{}_{}'.format(event_a, i), chunk_a,
                                                              '{}_{}'.format(event_b, j), chunk_b, distance, params,
-                                                             cores=lastz_cores, disk=4*(chunk_a.size+chunk_b.size)).rv())
+                                                             cores=lastz_cores, disk=4*(chunk_a.size+chunk_b.size),
+                                                             memory=8*chunk_a.size+chunk_b.size).rv())
 
     return job.addFollowOnJobFn(combine_chunks, chunked_alignment_files).rv()  # Combine the chunked alignment files
 

--- a/src/cactus/paf/local_alignment.py
+++ b/src/cactus/paf/local_alignment.py
@@ -65,7 +65,7 @@ def run_lastz(job, name_A, genome_A, name_B, genome_B, distance, params):
         for line in segalign_messages.split("\n"):
             if not line.startswith("signals delivered"):
                 for keyword in ['terminate', 'error', 'fail', 'assert', 'signal', 'abort', 'segmentation', 'sigsegv', 'kill']:
-                    if keyword in line:
+                    if keyword in line and 'signals' not in line:
                         job.fileStore.logToMaster("Segalign offending line: " + line)  # Log the messages
                         raise RuntimeError('{} exited 0 but keyword "{}" found in stderr'.format(lastz_cmd, keyword))
 

--- a/src/cactus/preprocessor/lastzRepeatMasking/cactus_lastzRepeatMask.py
+++ b/src/cactus/preprocessor/lastzRepeatMasking/cactus_lastzRepeatMask.py
@@ -130,9 +130,9 @@ class LastzRepeatMaskJob(RoundedJob):
         for line in segalign_messages.split("\n"):
             if not line.startswith("signals delivered"):
                 for keyword in ['terminate', 'error', 'fail', 'assert', 'signal', 'abort', 'segmentation', 'sigsegv', 'kill']:
-                    if keyword in line:
-                        job.fileStore.logToMaster("Segalign offending line: " + line)
-                        raise RuntimeError('{} exited 0 but keyword "{}" found in stderr'.format(lastz_cmd, keyword))
+                    if keyword in line and 'signals' not in line:
+                        fileStore.logToMaster("Segalign offending line: " + line)
+                        raise RuntimeError('{} exited 0 but keyword "{}" found in stderr'.format(cmd, keyword))
 
         # scrape the segalign output into one big file, making an effort to read in numeric order
         merged_path = fileStore.getLocalTempFile()

--- a/src/cactus/preprocessor/lastzRepeatMasking/cactus_lastzRepeatMask.py
+++ b/src/cactus/preprocessor/lastzRepeatMasking/cactus_lastzRepeatMask.py
@@ -128,7 +128,7 @@ class LastzRepeatMaskJob(RoundedJob):
         # run_segalign can crash and still exit 0, so it's worth taking a moment to check the log for errors
         segalign_messages = segalign_messages.lower()
         for line in segalign_messages.split("\n"):
-            if not line.startswith("signals delivered")
+            if not line.startswith("signals delivered"):
                 for keyword in ['terminate', 'error', 'fail', 'assert', 'signal', 'abort', 'segmentation', 'sigsegv', 'kill']:
                     if keyword in segalign_messages:
                         job.fileStore.logToMaster("Segalign Stderr: " + segalign_messages)  # Log the messages

--- a/src/cactus/preprocessor/lastzRepeatMasking/cactus_lastzRepeatMask.py
+++ b/src/cactus/preprocessor/lastzRepeatMasking/cactus_lastzRepeatMask.py
@@ -127,10 +127,12 @@ class LastzRepeatMaskJob(RoundedJob):
         segalign_messages = cactus_call(parameters=cmd, work_dir=alignment_dir, returnStdErr=True)
         # run_segalign can crash and still exit 0, so it's worth taking a moment to check the log for errors
         segalign_messages = segalign_messages.lower()
-        for keyword in ['terminate', 'error', 'fail', 'assert', 'signal', 'abort', 'segmentation', 'sigsegv', 'kill']:
-            if keyword in segalign_messages:
-                job.fileStore.logToMaster("Segalign Stderr: " + segalign_messages)  # Log the messages
-                raise RuntimeError('{} exited 0 but keyword "{}" found in stderr'.format(cmd, keyword))
+        for line in segalign_messages.split("\n"):
+            if not line.startswith("signals delivered")
+                for keyword in ['terminate', 'error', 'fail', 'assert', 'signal', 'abort', 'segmentation', 'sigsegv', 'kill']:
+                    if keyword in segalign_messages:
+                        job.fileStore.logToMaster("Segalign Stderr: " + segalign_messages)  # Log the messages
+                        raise RuntimeError('{} exited 0 but keyword "{}" found in stderr'.format(lastz_cmd, keyword))
 
         # scrape the segalign output into one big file, making an effort to read in numeric order
         merged_path = fileStore.getLocalTempFile()

--- a/src/cactus/preprocessor/lastzRepeatMasking/cactus_lastzRepeatMask.py
+++ b/src/cactus/preprocessor/lastzRepeatMasking/cactus_lastzRepeatMask.py
@@ -131,7 +131,7 @@ class LastzRepeatMaskJob(RoundedJob):
             if not line.startswith("signals delivered"):
                 for keyword in ['terminate', 'error', 'fail', 'assert', 'signal', 'abort', 'segmentation', 'sigsegv', 'kill']:
                     if keyword in line:
-                        job.fileStore.logToMaster("Segalign Stderr: " + segalign_messages)  # Log the messages
+                        job.fileStore.logToMaster("Segalign offending line: " + line)
                         raise RuntimeError('{} exited 0 but keyword "{}" found in stderr'.format(lastz_cmd, keyword))
 
         # scrape the segalign output into one big file, making an effort to read in numeric order

--- a/src/cactus/preprocessor/lastzRepeatMasking/cactus_lastzRepeatMask.py
+++ b/src/cactus/preprocessor/lastzRepeatMasking/cactus_lastzRepeatMask.py
@@ -130,7 +130,7 @@ class LastzRepeatMaskJob(RoundedJob):
         for line in segalign_messages.split("\n"):
             if not line.startswith("signals delivered"):
                 for keyword in ['terminate', 'error', 'fail', 'assert', 'signal', 'abort', 'segmentation', 'sigsegv', 'kill']:
-                    if keyword in segalign_messages:
+                    if keyword in line:
                         job.fileStore.logToMaster("Segalign Stderr: " + segalign_messages)  # Log the messages
                         raise RuntimeError('{} exited 0 but keyword "{}" found in stderr'.format(lastz_cmd, keyword))
 

--- a/src/cactus/progressive/cactus_prepare.py
+++ b/src/cactus/progressive/cactus_prepare.py
@@ -237,7 +237,13 @@ def get_jobstore(options, task=None):
     return js
 
 def human2bytesN(s):
-    return human2bytes(s) if s else s
+    if s is not None:
+        sb = human2bytes(s)
+        if sb < 10000000:
+            raise RuntimeError("Suspiciously small disk or memory specification detected: {}.  Did you forget to add a \"G\" for gigabytes?".format(sb))
+        return sb
+    else:
+        return None
 
 def bytes2humanN(s):
     return bytes2human(s).replace(' ', '') if s else s

--- a/src/cactus/progressive/cactus_progressive.py
+++ b/src/cactus/progressive/cactus_progressive.py
@@ -39,6 +39,7 @@ from cactus.pipeline.cactus_workflow import cactus_cons_with_resources
 from cactus.progressive.progressive_decomposition import compute_outgroups, parse_seqfile, get_subtree, get_spanning_subtree, get_event_set
 from cactus.preprocessor.cactus_preprocessor import CactusPreprocessor
 from cactus.preprocessor.dnabrnnMasking import loadDnaBrnnModel
+from cactus.preprocessor.checkUniqueHeaders import sanitize_fasta_headers
 from cactus.paf.local_alignment import make_paf_alignments, trim_unaligned_sequences
 from cactus.shared.configWrapper import ConfigWrapper
 from cactus.progressive.multiCactusTree import MultiCactusTree
@@ -273,9 +274,8 @@ def progressive_workflow(job, options, config_node, mc_tree, og_map, input_seq_i
         pp_job = job.addChildJobFn(preprocess_all, options, config_node, input_seq_id_map)
         seq_id_map = pp_job.rv()
     else:
-        pp_job = Job()
-        job.addChild(pp_job)
-        seq_id_map = input_seq_id_map
+        pp_job = job.addChildJobFn(sanitize_fasta_headers, input_seq_id_map)
+        seq_id_map = pp_job.rv()
 
     # then do the progressive workflow
     root_event = options.root if options.root else mc_tree.getRootName()

--- a/src/cactus/refmap/cactus_graphmap.py
+++ b/src/cactus/refmap/cactus_graphmap.py
@@ -215,8 +215,6 @@ def minigraph_workflow(job, options, config, seq_id_map, gfa_id, graph_event):
         # gaf2paf needs unzipped gfa, so we take care of that upfront
         gfa_unzip_job = root_job.addChildJobFn(unzip_gz, options.minigraphGFA, gfa_id, disk=5*gfa_id.size)
         gfa_id = gfa_unzip_job.rv()
-        root_job = Job()
-        gfa_unzip_job.addFollowOn(root_job)
         gfa_id_size *= 10
         options.minigraphGFA = options.minigraphGFA[:-3]
     paf_job = Job.wrapJobFn(minigraph_map_all, config, gfa_id, seq_id_map, graph_event)

--- a/src/cactus/refmap/cactus_graphmap.py
+++ b/src/cactus/refmap/cactus_graphmap.py
@@ -204,6 +204,7 @@ def minigraph_workflow(job, options, config, seq_id_map, gfa_id, graph_event):
 
     # enforce unique prefixes and unzip fastas
     sanitize_job = root_job.addChildJobFn(sanitize_fasta_headers, seq_id_map)
+    seq_id_map = sanitize_job.rv()
     
     if options.outputFasta:
         # convert GFA to fasta

--- a/src/cactus/refmap/cactus_graphmap_split.py
+++ b/src/cactus/refmap/cactus_graphmap_split.py
@@ -24,6 +24,7 @@ from cactus.shared.common import getOptionalAttrib, findRequiredNode
 from cactus.shared.common import unzip_gz, write_s3
 from cactus.shared.common import get_faidx_subpath_rename_cmd
 from cactus.preprocessor.fileMasking import get_mask_bed_from_fasta
+from cactus.preprocessor.checkUniqueHeaders import sanitize_fasta_headers
 from cactus.refmap.cactus_graphmap import filter_paf
 from toil.job import Job
 from toil.common import Toil
@@ -128,7 +129,8 @@ def cactus_graphmap_split(options):
             paf_id = toil.importFile(makeURL(options.graphmapPAF))
 
             #import the sequences (that we need to align for the given event, ie leaves and outgroups)
-            seqIDMap = {}
+            input_seq_id_map = {}
+            input_name_map = {}
             leaves = set([seqFile.tree.getName(node) for node in seqFile.tree.getLeaves()])
             
             if graph_event not in leaves:
@@ -144,17 +146,18 @@ def cactus_graphmap_split(options):
                         seq = tmpSeq
                     seq = makeURL(seq)
                     logger.info("Importing {}".format(seq))
-                    seqIDMap[genome] = (seq, toil.importFile(seq))
+                    input_seq_id_map[genome] = toil.importFile(seq)
+                    input_name_map[genome] = os.path.basename(seq)
 
             # run the workflow
-            wf_output = toil.start(Job.wrapJobFn(graphmap_split_workflow, options, config, seqIDMap,
+            wf_output = toil.start(Job.wrapJobFn(graphmap_split_workflow, options, config, input_seq_id_map, input_name_map,
                                                  gfa_id, options.minigraphGFA,
                                                  paf_id, options.graphmapPAF, ref_contigs, options.otherContig))
 
         #export the split data
         export_split_data(toil, wf_output[0], wf_output[1], wf_output[2], wf_output[3], options.outDir, config)
 
-def graphmap_split_workflow(job, options, config, seqIDMap, gfa_id, gfa_path, paf_id, paf_path, ref_contigs, other_contig):
+def graphmap_split_workflow(job, options, config, seq_id_map, seq_name_map, gfa_id, gfa_path, paf_id, paf_path, ref_contigs, other_contig):
 
     root_job = Job()
     job.addChild(root_job)
@@ -164,8 +167,8 @@ def graphmap_split_workflow(job, options, config, seqIDMap, gfa_id, gfa_path, pa
     paf_size = paf_id.size
 
     # fix up the headers
-    sanitize_job = root_job.addChildJobFn(sanitize_fasta_headers, seqIDMap)
-    seqIDMap = sanitize_job.rv()
+    sanitize_job = root_job.addChildJobFn(sanitize_fasta_headers, seq_id_map)
+    seq_id_map = sanitize_job.rv()
     
     # use file extension to sniff out compressed input
     if gfa_path.endswith(".gz"):
@@ -182,7 +185,7 @@ def graphmap_split_workflow(job, options, config, seqIDMap, gfa_id, gfa_path, pa
 
     mask_bed_id = None
     if options.maskFilter:
-        mask_bed_id = sanitize_job.addFollowOnJobFn(get_mask_bed, seqIDMap, options.maskFilter).rv()
+        mask_bed_id = sanitize_job.addFollowOnJobFn(get_mask_bed, seq_id_map, options.maskFilter).rv()
         
     # use rgfa-split to split the gfa and paf up by contig
     split_gfa_job = root_job.addFollowOnJobFn(split_gfa, config, gfa_id, [paf_id], ref_contigs,
@@ -190,24 +193,24 @@ def graphmap_split_workflow(job, options, config, seqIDMap, gfa_id, gfa_path, pa
                                               disk=(gfa_size + paf_size) * 5)
 
     # use the output of the above splitting to do the fasta splitting
-    split_fas_job = split_gfa_job.addFollowOnJobFn(split_fas, seqIDMap, split_gfa_job.rv(0))
+    split_fas_job = split_gfa_job.addFollowOnJobFn(split_fas, seq_id_map, seq_name_map, split_gfa_job.rv(0))
 
     # gather everythign up into a table
-    gather_fas_job = split_fas_job.addFollowOnJobFn(gather_fas, seqIDMap, split_gfa_job.rv(0), split_fas_job.rv(0), split_fas_job.rv(1))
+    gather_fas_job = split_fas_job.addFollowOnJobFn(gather_fas, split_gfa_job.rv(0), split_fas_job.rv(0), split_fas_job.rv(1))
 
     # lump "other" contigs together into one file (to make fewer align jobs downstream)
     bin_other_job = gather_fas_job.addFollowOnJobFn(bin_other_contigs, config, ref_contigs, other_contig, gather_fas_job.rv(0),
                                                     disk=(gfa_size + paf_size) * 2)
 
     # return all the files, as well as the 2 split logs
-    return (seqIDMap, bin_other_job.rv(), split_gfa_job.rv(1), gather_fas_job.rv(1))
+    return (seq_name_map, bin_other_job.rv(), split_gfa_job.rv(1), gather_fas_job.rv(1))
 
 def get_mask_bed(job, seq_id_map, min_length):
     """ make a bed file from the fastas """
     beds = []
     for event in seq_id_map.keys():
         fa_id = seq_id_map[event]
-        fa_path = '{}.fa'.format(event) # ugh, our fa_id is now unzipped 
+        fa_path = '{}.fa'.format(event) 
         beds.append(job.addChildJobFn(get_mask_bed_from_fasta, event, fa_id, fa_path, min_length, disk=fa_id.size * 5).rv())
     return job.addFollowOnJobFn(cat_beds, beds).rv()
 
@@ -330,7 +333,7 @@ def split_gfa(job, config, gfa_id, paf_ids, ref_contigs, other_contig, reference
             
     return output_id_map, job.fileStore.writeGlobalFile(log_path)
 
-def split_fas(job, seq_id_map, split_id_map):
+def split_fas(job, seq_id_map, seq_name_map, split_id_map):
     """ Use samtools to split a bunch of fasta files into reference contigs, using the output of rgfa-split as a guide"""
 
     if (seq_id_map, split_id_map) == (None, None):
@@ -346,8 +349,8 @@ def split_fas(job, seq_id_map, split_id_map):
     fa_contig_sizes = {}
     
     # we do each fasta in parallel
-    for event in seq_id_map.keys():
-        fa_path, fa_id = seq_id_map[event]
+    for event, fa_id in seq_id_map.items():
+        fa_path = seq_name_map[event]
         if fa_id.size:
             split_job = root_job.addChildJobFn(split_fa_into_contigs, event, fa_id, fa_path, split_id_map,
                                                strip_prefix=False, 
@@ -357,19 +360,15 @@ def split_fas(job, seq_id_map, split_id_map):
 
     return fa_contigs, fa_contig_sizes
 
-def split_fa_into_contigs(job, event, fa_id, fa_path, split_id_map, strip_prefix=False):
+def split_fa_into_contigs(job, event, fa_id, fa_name, split_id_map, strip_prefix=False):
     """ Use samtools turn on fasta into one for each contig. this relies on the informatino in .fa_contigs
     files made by rgfa-split """
 
     # download the fasta
     work_dir = job.fileStore.getLocalTempDir()
-    fa_path = os.path.join(work_dir, os.path.basename(fa_path))
-    is_gz = fa_path.endswith(".gz")
-    job.fileStore.readGlobalFile(fa_id, fa_path, mutable=is_gz)
-    if is_gz:
-        # todo: more general cleanup.  before the file could actually be gzipped, but sanitze_fasta_headers
-        # which is run before insures this isn't true
-        fa_path = fa_path[:-3]
+    fa_path = os.path.join(work_dir, '{}.fa'.format(event))
+    is_gz = fa_name.endswith(".gz")
+    job.fileStore.readGlobalFile(fa_id, fa_path)
 
     unique_id = 'id={}|'.format(event)
                         
@@ -417,7 +416,7 @@ def split_fa_into_contigs(job, event, fa_id, fa_path, split_id_map, strip_prefix
         
     return contig_fa_dict, contig_size_dict
 
-def gather_fas(job, seq_id_map, output_id_map, contig_fa_map, contig_size_map):
+def gather_fas(job, output_id_map, contig_fa_map, contig_size_map):
     """ take the split_fas output which has everything sorted by event, and move into the ref-contig-based table
     from split_gfa.  return the updated table, which can then be exported into the chromosome projects """
 
@@ -521,7 +520,7 @@ def bin_other_contigs(job, config, ref_contigs, other_contig, output_id_map):
 
     return output_id_map
 
-def export_split_data(toil, input_seq_id_map, output_id_map, split_log_id, contig_size_table_id, output_dir, config):
+def export_split_data(toil, input_name_map, output_id_map, split_log_id, contig_size_table_id, output_dir, config):
     """ download all the split data locally """
 
     amb_name = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_split"), "ambiguousName", default="_AMBIGUOUS_")
@@ -561,7 +560,7 @@ def export_split_data(toil, input_seq_id_map, output_id_map, split_log_id, conti
             if not os.path.isdir(fa_base) and not fa_base.startswith('s3://'):
                 os.makedirs(fa_base)
             fa_path = makeURL(os.path.join(fa_base, '{}_{}.fa'.format(event, ref_contig)))
-            if input_seq_id_map[event][0].endswith('.gz'):
+            if input_name_map[event].endswith('.gz'):
                 fa_path += '.gz'
             seq_file_map[event] = fa_path
             toil.exportFile(ref_contig_fa_id, fa_path)

--- a/src/cactus/refmap/cactus_minigraph.py
+++ b/src/cactus/refmap/cactus_minigraph.py
@@ -127,9 +127,9 @@ def minigraph_construct_workflow(job, config_node, name_id_map, seq_order, gfa_p
     """ minigraph can handle bgzipped files but not gzipped; so unzip everything in case before running"""
     sanitize_job = job.addChildJobFn(sanitize_fasta_headers, name_id_map)
     mg_cores = getOptionalAttrib(findRequiredNode(config_node, "graphmap"), "cpu", typeFn=int, default=1)
-    minigraph_job = unzip_job.addFollowOnJobFn(minigraph_construct, config_node, sanitize_job.rv(), seq_order, gfa_path,
-                                               cores = mg_cores,
-                                               disk = 5 * sum([name_id[1].size for name_id in name_id_map.values()]))
+    minigraph_job = sanitize_job.addFollowOnJobFn(minigraph_construct, config_node, sanitize_job.rv(), seq_order, gfa_path,
+                                                  cores = mg_cores,
+                                                  disk = 5 * sum([name_id[1].size for name_id in name_id_map.values()]))
     return minigraph_job.rv()
 
 def minigraph_construct(job, config_node, name_id_map, seq_order, gfa_path):

--- a/src/cactus/refmap/cactus_minigraph.py
+++ b/src/cactus/refmap/cactus_minigraph.py
@@ -108,13 +108,8 @@ def main():
                     input_seq_id_map[genome] = toil.importFile(seq)
                     if genome != options.reference:
                         input_seq_order.append(genome)
-
-            # zip names and ids
-            name_id_map = {}
-            for event, fa_id in input_seq_id_map.items():
-                name_id_map[event] = (input_seq_map[event], fa_id)
             
-            gfa_id = toil.start(Job.wrapJobFn(minigraph_construct_workflow, config_node, name_id_map, input_seq_order, options.outputGFA))
+            gfa_id = toil.start(Job.wrapJobFn(minigraph_construct_workflow, config_node, input_seq_id_map, input_seq_order, options.outputGFA))
 
         #export the gfa
         toil.exportFile(gfa_id, makeURL(options.outputGFA))
@@ -123,16 +118,16 @@ def main():
     run_time = end_time - start_time
     logger.info("cactus-minigraph has finished after {} seconds".format(run_time))
         
-def minigraph_construct_workflow(job, config_node, name_id_map, seq_order, gfa_path):
+def minigraph_construct_workflow(job, config_node, seq_id_map, seq_order, gfa_path):
     """ minigraph can handle bgzipped files but not gzipped; so unzip everything in case before running"""
-    sanitize_job = job.addChildJobFn(sanitize_fasta_headers, name_id_map)
+    sanitize_job = job.addChildJobFn(sanitize_fasta_headers, seq_id_map)
     mg_cores = getOptionalAttrib(findRequiredNode(config_node, "graphmap"), "cpu", typeFn=int, default=1)
     minigraph_job = sanitize_job.addFollowOnJobFn(minigraph_construct, config_node, sanitize_job.rv(), seq_order, gfa_path,
                                                   cores = mg_cores,
-                                                  disk = 5 * sum([name_id[1].size for name_id in name_id_map.values()]))
+                                                  disk = 5 * sum([seq_id.size for seq_id in seq_id_map.values()]))
     return minigraph_job.rv()
 
-def minigraph_construct(job, config_node, name_id_map, seq_order, gfa_path):
+def minigraph_construct(job, config_node, seq_id_map, seq_order, gfa_path):
     """ Make minigraph """
     work_dir = job.fileStore.getLocalTempDir()
     gfa_path = os.path.join(work_dir, os.path.basename(gfa_path))
@@ -146,8 +141,8 @@ def minigraph_construct(job, config_node, name_id_map, seq_order, gfa_path):
     
     # download the sequences
     local_fa_paths = {}
-    for event in name_id_map.keys():
-        fa_id = name_id_map[event][1]
+    for event, fa_id in seq_id_map.items():
+        fa_id = seq_id_map[event]
         fa_path = os.path.join(work_dir, '{}.fa'.format(event))
         job.fileStore.readGlobalFile(fa_id, fa_path)
         local_fa_paths[event] = fa_path

--- a/src/cactus/refmap/cactus_minigraph.py
+++ b/src/cactus/refmap/cactus_minigraph.py
@@ -22,6 +22,7 @@ from cactus.shared.common import cactus_override_toil_options
 from cactus.shared.common import cactus_call
 from cactus.shared.common import getOptionalAttrib, findRequiredNode
 from cactus.refmap.cactus_graphmap_join import unzip_seqfile
+from cactus.preprocessor.checkUniqueHeaders import sanitize_fasta_headers
 from toil.job import Job
 from toil.common import Toil
 from toil.statsAndLogging import logger
@@ -124,9 +125,9 @@ def main():
         
 def minigraph_construct_workflow(job, config_node, name_id_map, seq_order, gfa_path):
     """ minigraph can handle bgzipped files but not gzipped; so unzip everything in case before running"""
-    unzip_job = job.addChildJobFn(unzip_seqfile, name_id_map)
+    sanitize_job = job.addChildJobFn(sanitize_fasta_headers, name_id_map)
     mg_cores = getOptionalAttrib(findRequiredNode(config_node, "graphmap"), "cpu", typeFn=int, default=1)
-    minigraph_job = unzip_job.addFollowOnJobFn(minigraph_construct, config_node, unzip_job.rv(), seq_order, gfa_path,
+    minigraph_job = unzip_job.addFollowOnJobFn(minigraph_construct, config_node, sanitize_job.rv(), seq_order, gfa_path,
                                                cores = mg_cores,
                                                disk = 5 * sum([name_id[1].size for name_id in name_id_map.values()]))
     return minigraph_job.rv()

--- a/src/cactus/refmap/cactus_refmap.py
+++ b/src/cactus/refmap/cactus_refmap.py
@@ -42,7 +42,7 @@ from cactus.shared.common import cactus_call
 from cactus.shared.configWrapper import ConfigWrapper
 from cactus.shared.common import cactusRootPath
 from cactus.progressive.progressive_decomposition import compute_outgroups, parse_seqfile, get_subtree, get_spanning_subtree, get_event_set
-
+from cactus.preprocessor.checkUniqueHeaders import sanitize_fasta_headers
 
 ## utilitary fxns:
 
@@ -138,7 +138,8 @@ def run_cactus_reference_align(job, assembly_files, reference, debug_export=Fals
     """
     Preprocesses assemblies, then runs mappings.
     """
-    mappings = job.addFollowOnJobFn(map_all_to_ref, assembly_files, reference, debug_export, dipcall_bed_filter, dipcall_vcf_filter).rv()
+    sanitize_job = job.addChildJobFn(sanitize_fasta_headers, assembly_files)
+    mappings = sanitize_job.addFollowOnJobFn(map_all_to_ref, sanitize_job.rv(), reference, debug_export, dipcall_bed_filter, dipcall_vcf_filter).rv()
     return mappings
 
 def map_all_to_ref(job, assembly_files, reference, debug_export=False, dipcall_bed_filter=False, dipcall_vcf_filter=False):

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -317,6 +317,7 @@ def make_align_job(options, toil):
                               referenceEvent=options.reference,
                               pafMaskFilter=options.pafMaskFilter,
                               paf2Stable=paf_to_stable,
+                              cons_cores=options.consCores,
                               do_filter_paf=options.pangenome)
     return align_job
 

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -773,7 +773,10 @@ def cactus_call(tool=None,
         if process.returncode > 0:
             raise RuntimeError("Command {} exited {}: {}".format(call, process.returncode, out))
         else:
-            raise RuntimeError("Command {} signaled {}: {}".format(call, signal.Signals(-process.returncode).name, out))
+            signal_name = signal.Signals(-process.returncode).name
+            if 'cactus_consolidated' in call and signal_name == 'SIGILL':
+                logger.critical('\n\n\n*******************************************************************************************************\nERROR: Your CPU seems too old to support AVX2 instructions in this Cactus release.\n       Please see the release notes for more details: https://github.com/ComparativeGenomicsToolkit/cactus/releases\n*******************************************************************************************************\n\n\n')
+            raise RuntimeError("Command {} signaled {}: {}".format(call, signal_name, out))
 
     if check_output:
         return (output, stderr) if returnStdErr else output

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -770,13 +770,25 @@ def cactus_call(tool=None,
     if process.returncode != 0:
         out = "stdout={}".format(output)
         out += ", stderr={}".format(stderr)
+
+        sigill_msg = ''
+        if abs(process.returncode) == 4:
+            # this (rightfully) trips up many users, try to make logging a little more clear
+            # https://github.com/ComparativeGenomicsToolkit/cactus/issues/574
+            sigill_msg  = '\n\n\n'
+            sigill_msg += '***********************************************************************************\n'
+            sigill_msg += '***********************************************************************************\n'
+            sigill_msg += 'ERROR: Your CPU is incompatible with the Cactus binaries.\n'
+            sigill_msg += '       This is often due to it being too old to support AVX2 instructions.\n'
+            sigill_msg += '       Please see the release notes for more details:\n'
+            sigill_msg += '       https://github.com/ComparativeGenomicsToolkit/cactus/releases\n'
+            sigill_msg += '***********************************************************************************\n'
+            sigill_msg += '***********************************************************************************\n\n\n'
+        
         if process.returncode > 0:
-            raise RuntimeError("Command {} exited {}: {}".format(call, process.returncode, out))
+            raise RuntimeError("{}Command {} exited {}: {}".format(sigill_msg, call, process.returncode, out))
         else:
-            signal_name = signal.Signals(-process.returncode).name
-            if 'cactus_consolidated' in call and signal_name == 'SIGILL':
-                logger.critical('\n\n\n*******************************************************************************************************\nERROR: Your CPU seems too old to support AVX2 instructions in this Cactus release.\n       Please see the release notes for more details: https://github.com/ComparativeGenomicsToolkit/cactus/releases\n*******************************************************************************************************\n\n\n')
-            raise RuntimeError("Command {} signaled {}: {}".format(call, signal_name, out))
+            raise RuntimeError("{}Command {} signaled {}: {}".format(sigill_msg, call, signal.Signals(-process.returncode).name, out))
 
     if check_output:
         return (output, stderr) if returnStdErr else output


### PR DESCRIPTION
Before, cactus would add `id=EVENT|` prefixes to fasta files in its setup phase.  This was annoying, but made sure downstream code worked (to an extent).  

paf_chains pushed this logic into the preprocessor which is simpler in some respects.  But can lead to terrible problems if the user didn't run `cactus-preprocess` (and has bitten me several times).

This PR adds back the check, but hopefully in a simpler and faster way.  After importing fasta files, a new tool `cactus_sanitizeFastaHeaders` gets run on them to immediately add prefixes if they are not already found.  As a bonus, it unzips gzipped files so those should be generally supported now too. 

