### PR TITLE
Make sure base docker images exactly consistent across build

### DIFF
--- a/Dockerfile.segalign
+++ b/Dockerfile.segalign
@@ -1,3 +1,4 @@
+# Reminder: if updating this image, also update it in build-tools/makeGpuDockerRelease
 FROM nvidia/cuda:11.4.3-devel-ubuntu20.04 as builder
 
 # Prevent dpkg from trying to ask any questions, ever

--- a/build-tools/makeGpuDockerRelease
+++ b/build-tools/makeGpuDockerRelease
@@ -24,8 +24,9 @@ git checkout "${REL_TAG}"
 git submodule update --init --recursive
 
 CFLAGS="" CXXFLAGS="" docker build . -f Dockerfile.segalign -t segalign:local
-# switch the runtime image to segalign, and revert build back to ubuntu 20 (to match segalign's system)
-sed '0,/FROM/! s/FROM.*/FROM segalign:local/' Dockerfile  | sed -e 's/ubuntu:22.04/ubuntu:20.04/g'> Dockerfile.gpu
+# switch the runtime image to segalign, and the build image to the build image from Dockerfile.segalign
+# important, if the build image in Dockerfile.segaling changes, the line below needs to be updated too
+sed '0,/FROM/! s/FROM.*/FROM segalign:local/' Dockerfile  | sed -e '0,/FROM/s/FROM.*/FROM nvidia\/cuda:11.4.3-devel-ubuntu20.04 as builder/g' > Dockerfile.gpu
 # enable gpu by default
 sed -i src/cactus/cactus_progressive_config.xml -e 's/gpuLastz="false"/gpuLastz="true"/g' -e 's/realign="1"/realign="0"/'
 docker build . -f Dockerfile.gpu -t ${dockname}:$(getLatestReleaseTag)-gpu

--- a/src/cactus/refmap/cactus_graphmap.py
+++ b/src/cactus/refmap/cactus_graphmap.py
@@ -141,6 +141,11 @@ def graph_map(options):
                 leaves = [mc_tree.getName(leaf) for leaf in mc_tree.getLeaves()]
                 if options.reference not in leaves:
                     raise RuntimeError("Genome specified with --reference, {}, not found in tree leaves".format(options.reference))
+                for sample in input_seq_map.keys():
+                    if sample != options.reference and sample.startswith(options.reference):
+                        raise RuntimeError("Input sample {} is prefixed by given reference {}. ".format(sample, options.reference) +                        
+                                           "This is not supported by this version of Cactus, " +
+                                           "so one of these samples needs to be renamed to continue")
             
             if options.refFromGFA:
                 if not options.reference:

--- a/src/cactus/refmap/cactus_graphmap_split.py
+++ b/src/cactus/refmap/cactus_graphmap_split.py
@@ -137,7 +137,14 @@ def cactus_graphmap_split(options):
                 raise RuntimeError("Minigraph name {} not found in seqfile".format(graph_event))
             if options.reference and options.reference not in leaves:
                 raise RuntimeError("Name given with --reference {} not found in seqfile".format(options.reference))
-                
+
+            if options.reference:
+                for sample in seqFile.pathMap.keys():
+                    if sample != options.reference and sample.startswith(options.reference):
+                        raise RuntimeError("Input sample {} is prefixed by given reference {}. ".format(sample, options.reference) +
+                                           "This is not supported by this version of Cactus, " +
+                                           "so one of these samples needs to be renamed to continue")
+                        
             for genome, seq in seqFile.pathMap.items():
                 if genome in leaves:
                     if os.path.isdir(seq):

--- a/src/cactus/refmap/cactus_minigraph.py
+++ b/src/cactus/refmap/cactus_minigraph.py
@@ -84,6 +84,11 @@ def main():
             
             if options.reference not in input_seq_map:
                 raise RuntimeError("Specified reference not in seqfile")
+            for sample in input_seq_map.keys():
+                if sample != options.reference and sample.startswith(options.reference):
+                    raise RuntimeError("Input sample {} is prefixed by given reference {}. ".format(sample, options.reference) +                        
+                                       "This is not supported by this version of Cactus, " +
+                                       "so one of these samples needs to be renamed to continue")
 
             # apply cpu override                
             if options.mapCores is not None:


### PR DESCRIPTION
Some other small things
* Fix up `cactus-terra-helper scrape-logs` to not take empty logs
* Add name-checker in pangenome tools to make sure that the reference sample name is not a prefix of another sample name (until `cactus-graphmap-join` doesn't rely on prefixes for path selection)
