### PR TITLE
enable --realTimeLogging (whether user asks for it or not)

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ gsutil ls -l -r gs://<BUCKET/PREFIX> | cactus-terra-helper scrape-logs
 `cactus-prepare-toil` shares the interface of `cactus-prepare` except instead of printing the command lines or WDL script, it runs them directly from Toil.  An example use case of this is within UCSC's kubernetes cluster.  Like many computing environments, the number of jobs that can be scheduled is limited, so running `cactus` directly using Toil's `kubernetes` batch system will swamp the cluster.  But if the computation can be broken up into a handful of steps, and a job is only created for each step (as in the Cromwell/WDL method), then it can run through.  So `cactus-prepare-toil` will run as a high-level Toil workflow on the specified batch system, and it will launch jobs for each command (`cactus-preprocess, cactus-blast, cactus-align`), and each one of these jobs will get scheduled on a node and run its command with the `singleMachine` batch system.  Here is an example invocation for kubernetes:
 
 ```
-cactus-prepare-toil aws:us-west-2:<JOBSTORE-NAME> examples/evolverMammals.txt --binariesMode singularity --batchSystem kubernetes --realTimeLogging --outHal s3://<BUCKET-NAME>/out.hal --defaultDisk 20G --defaultMemory 12G --defaultCores 4
+cactus-prepare-toil aws:us-west-2:<JOBSTORE-NAME> examples/evolverMammals.txt --binariesMode singularity --batchSystem kubernetes --outHal s3://<BUCKET-NAME>/out.hal --defaultDisk 20G --defaultMemory 12G --defaultCores 4
 ```
 
 #### Updating existing alingments

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -58,6 +58,11 @@ def cactus_override_toil_options(options):
         # instead of Toil's default (1).
         options.retryCount = 5
 
+    if not options.realTimeLogging:
+        # Too much valuable debugging information to pass up
+        logger.info('Enabling realtime logging in Toil')
+        options.realTimeLogging = True
+
 def makeURL(path_or_url):
     if urlparse(path_or_url).scheme == '':
         return "file://" + os.path.abspath(path_or_url)


### PR DESCRIPTION
This prints out commands as they are executed: very valuable for debugging, and figuring out what's running when.  imho better on by default than off. 