### PR TITLE
Add biggest genomes first in minigraph construction

### DIFF
--- a/doc/pangenome.md
+++ b/doc/pangenome.md
@@ -53,7 +53,7 @@ Note: The pangenome pipeline supports gzipped fasta files if they end with `.gz`
 
 ### Evolver Primates: Constructing the Minigraph GFA
 
-The next step is to create the initial [minigraph](https://github.com/lh3/minigraph) graph. `minigraph` iteratively adds sequences to the graph, beginning with a reference genome that will serve throughout the pipeline as its uncollapsed backbone.  This reference genome needs to selected now and used consistently (via the `--reference` option in all following commands).  Other genomes are added to the `minigraph` in the order they appear in the seqfile.
+The next step is to create the initial [minigraph](https://github.com/lh3/minigraph) graph. `minigraph` iteratively adds sequences to the graph, beginning with a reference genome that will serve throughout the pipeline as its uncollapsed backbone.  This reference genome needs to selected now and used consistently (via the `--reference` option in all following commands).  Other genomes are added to the `minigraph` in the order of decreasing size (this can be toggled off to use the order in the seqfile with the `minigraphSortBySize` parameter in the configuration).
 
 ```
 cactus-minigraph ./jobstore primates-pg/evolverPrimates.pg.txt primates-pg/primates.gfa.gz --realTimeLogging --reference simChimp

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -279,6 +279,7 @@
 	<!-- assemblyName: special name of "virtual" minigraph assembly, which is just the list of sequences from the graph. -->
 	<!-- minigraphMapOptions: flags to pass to minigraph for mapping -->
 	<!-- minigraphConstructOptions: flags to pass to minigraph for construction -->
+	<!-- minigraphSortBySize: Add genomes by order of their size (except for reference which is first) when constructing minigraph. -->
 	<!-- minMAPQ: ignore minigraph alignments with mapping quality less than this -->
 	<!-- minGAFBlockLength: ignore minigraph alignments with block length less than this -->
 	<!-- minGAFQueryOverlapFilter: if 2 or more query regions in blocks of at least this size, filter them out. -->
@@ -298,6 +299,7 @@
 		 assemblyName="_MINIGRAPH_"
 		 minigraphMapOptions="-c -xasm"
 		 minigraphConstructOptions="-c -xggs"
+		 minigraphSortBySize="1"
 		 minMAPQ="5"
 		 minGAFBlockLength="250000"
 		 minGAFQueryOverlapFilter="0"


### PR DESCRIPTION
This simple heuristic seems to help Partial Order Alignment in general.  And seems better than using the arbitrary order that most seqfiles will be in. 

The user can override this by toggling `minigraphSortBySize` in the xml confiration.  