### PR TITLE
Fix --pangenome option regression from v2.2.0

### DIFF
--- a/caf/impl/caf.c
+++ b/caf/impl/caf.c
@@ -384,6 +384,8 @@ void caf(Flower *flower, CactusParams *params, char *alignmentsFile, char *secon
                 // the first melting step.
                 stPinchThreadSetBlockIt blockIt = stPinchThreadSet_getBlockIt(threadSet);
                 stPinchBlock *block;
+                int64_t num_megablocks_destroyed = 0;
+                int64_t num_homologies_diestroyed = 0;
                 while ((block = stPinchThreadSetBlockIt_getNext(&blockIt)) != NULL) {
                     if (stPinchBlock_getDegree(block) > minimumBlockDegreeToCheckSupport) {
                         uint64_t supportingHomologies = stPinchBlock_getNumSupportingHomologies(block);
@@ -395,8 +397,14 @@ void caf(Flower *flower, CactusParams *params, char *alignmentsFile, char *secon
                                             "of %" PRIi64 " (%lf%%).\n", stPinchBlock_getDegree(block),
                                     supportingHomologies, possibleSupportingHomologies, support);
                             stPinchBlock_destruct(block);
+                            ++num_megablocks_destroyed;
+                            num_homologies_diestroyed += supportingHomologies;
                         }
                     }
+                }
+                if (num_megablocks_destroyed > 0) {
+                  st_logInfo("Destroyed %" PRIi64 " megablocks with a total of %" PRIi64 " supporting homologies\n",
+                             num_megablocks_destroyed, num_homologies_diestroyed);
                 }
             }
 

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -256,7 +256,6 @@ def make_align_job(options, toil):
 
     # toggle stable
     paf_to_stable = False
-    config_node = ET.parse(options.configFile).getroot()
     if getOptionalAttrib(findRequiredNode(config_node, "graphmap"), "removeMinigraphFromPAF", typeFn=bool, default=False):
         # remove minigraph event from input
         graph_event = getOptionalAttrib(findRequiredNode(config_node, "graphmap"), "assemblyName", default="_MINIGRAPH_")


### PR DESCRIPTION
This was due to a simple 1-line merging bug that reset the same config variable twice, causing all overrides applied from the `--pangenome` option to be lost.  

The critical override was that disabling the megablock filter, something that only comes up on deeper datasets that those found in the CI tests. 

All credit for finding this terrible regression goes to @minglibio who [patiently](https://github.com/ComparativeGenomicsToolkit/cactus/issues/780#issuecomment-1241758004) and persistently [raised it with supporting data](https://github.com/ComparativeGenomicsToolkit/cactus/issues/780#issuecomment-1260958635)

Resolves #780   