### PR TITLE
turn off megablock filter when support set to 0

### DIFF
--- a/caf/impl/caf.c
+++ b/caf/impl/caf.c
@@ -385,7 +385,7 @@ void caf(Flower *flower, CactusParams *params, char *alignmentsFile, char *secon
                 stPinchThreadSetBlockIt blockIt = stPinchThreadSet_getBlockIt(threadSet);
                 stPinchBlock *block;
                 int64_t num_megablocks_destroyed = 0;
-                int64_t num_homologies_diestroyed = 0;
+                int64_t num_homologies_destroyed = 0;
                 while ((block = stPinchThreadSetBlockIt_getNext(&blockIt)) != NULL) {
                     if (minimumBlockDegreeToCheckSupport > 0 && stPinchBlock_getDegree(block) > minimumBlockDegreeToCheckSupport) {
                         uint64_t supportingHomologies = stPinchBlock_getNumSupportingHomologies(block);
@@ -398,13 +398,13 @@ void caf(Flower *flower, CactusParams *params, char *alignmentsFile, char *secon
                                     supportingHomologies, possibleSupportingHomologies, support);
                             stPinchBlock_destruct(block);
                             ++num_megablocks_destroyed;
-                            num_homologies_diestroyed += supportingHomologies;
+                            num_homologies_destroyed += supportingHomologies;
                         }
                     }
                 }
                 if (num_megablocks_destroyed > 0) {
                   st_logInfo("Destroyed %" PRIi64 " megablocks with a total of %" PRIi64 " supporting homologies\n",
-                             num_megablocks_destroyed, num_homologies_diestroyed);
+                             num_megablocks_destroyed, num_homologies_destroyed);
                 }
             }
 

--- a/caf/impl/caf.c
+++ b/caf/impl/caf.c
@@ -387,7 +387,7 @@ void caf(Flower *flower, CactusParams *params, char *alignmentsFile, char *secon
                 int64_t num_megablocks_destroyed = 0;
                 int64_t num_homologies_diestroyed = 0;
                 while ((block = stPinchThreadSetBlockIt_getNext(&blockIt)) != NULL) {
-                    if (stPinchBlock_getDegree(block) > minimumBlockDegreeToCheckSupport) {
+                    if (minimumBlockDegreeToCheckSupport > 0 && stPinchBlock_getDegree(block) > minimumBlockDegreeToCheckSupport) {
                         uint64_t supportingHomologies = stPinchBlock_getNumSupportingHomologies(block);
                         uint64_t possibleSupportingHomologies = numPossibleSupportingHomologies(block, flower);
                         double support = ((double) supportingHomologies) / possibleSupportingHomologies;

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -120,7 +120,7 @@
 	<!-- maxRecoverableChainsIterations TODO-->
 	<!-- maxRecoverableChainLength TODO-->
 	<!-- minimumBlockDegreeToCheckSupport Apply support filter to blocks of more than this degree (0 = disable) -->
-	<!-- minimumBlockHomologySupport TPDO-->
+	<!-- minimumBlockHomologySupport TODO-->
 	<caf annealingRounds="64"
 		 deannealingRounds="2 4 8"
 		 trim="3"

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -119,8 +119,8 @@
 	<!-- removeRecoverableChains TODO-->
 	<!-- maxRecoverableChainsIterations TODO-->
 	<!-- maxRecoverableChainLength TODO-->
-	<!-- minimumBlockDegreeToCheckSupport TODO-->
-	<!-- minimumBlockHomologySupport TODO-->
+	<!-- minimumBlockDegreeToCheckSupport Apply support filter to blocks of more than this degree (0 = disable) -->
+	<!-- minimumBlockHomologySupport TPDO-->
 	<caf annealingRounds="64"
 		 deannealingRounds="2 4 8"
 		 trim="3"


### PR DESCRIPTION
Apparently when @benedictpaten changed the value of `minimumBlockDegreeToCheckSupport` from 10 to 0 in https://github.com/ComparativeGenomicsToolkit/cactus/commit/9cbbb9045a93166bc3d8b02b6d9209f19196f7bf it was with the intention of disabling the filter. 

But what it did in effect was apply the filter to all blocks, instead of those with degree > 10.  

This PR leaves the setting at 0, but changes the interpretation of 0 as a special toggle-off value.  

@benedictpaten should we run some tests for this? 