### PR TITLE
Copy phast binaries to bin/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ all:
 static:
 	CFLAGS="$${CFLAGS} -static" \
 	CXXFLAGS="$${CXXFLAGS} -static" \
+	LIBS="-static" \
 	KC_OPTIONS="--enable-lzo --enable-static --disable-shared" \
 	KT_OPTIONS="--without-lua --enable-static --disable-shared" \
 	${MAKE} all

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Cactus uses many different algorithms and individual code contributions, princip
 
 - Yung H. Tsin and Nima Norouzi for contributing their 3-edge connected components program code, which is crucial in constructing the cactus graph structure, see: Tsin,Y.H., "A simple 3-edge-connected component algorithm," Theory of Computing Systems, vol.40, No.2, 2007, pp.125-142.
 - Bob Harris for providing endless support for his [LastZ](https://github.com/lastz/lastz) pairwise, blast-like genome alignment tool.
-- Melissa Jane Hubiz and Adam Siepel for halPhyloP and [Phast](http://compgen.cshl.edu/phast/), binaries from the latter are now shipped, for convenience, with Cactus.
+- Melissa Jane Hubiz and Adam Siepel for halPhyloP and [Phast](http://compgen.cshl.edu/phast/).
 - Sneha Goenka and Yatish Turakhia for [SegAlign](https://github.com/gsneha26/SegAlign), the GPU-accelerated version of LastZ.
 - Yan Gao et al. for [abPOA](https://github.com/yangao07/abPOA)
 - Heng Li for [minigraph](https://github.com/lh3/minigraph), [minimap2](https://github.com/lh3/minimap2), [gfatools](https://github.com/lh3/gfatools) and [dna-brnn](https://github.com/lh3/dna-rnn)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Cactus uses many different algorithms and individual code contributions, princip
 
 - Yung H. Tsin and Nima Norouzi for contributing their 3-edge connected components program code, which is crucial in constructing the cactus graph structure, see: Tsin,Y.H., "A simple 3-edge-connected component algorithm," Theory of Computing Systems, vol.40, No.2, 2007, pp.125-142.
 - Bob Harris for providing endless support for his [LastZ](https://github.com/lastz/lastz) pairwise, blast-like genome alignment tool.
+- Melissa Jane Hubiz and Adam Siepel for halPhyloP and [Phast](http://compgen.cshl.edu/phast/), binaries from the latter are now shipped, for convenience, with Cactus.
 - Sneha Goenka and Yatish Turakhia for [SegAlign](https://github.com/gsneha26/SegAlign), the GPU-accelerated version of LastZ.
 - Yan Gao et al. for [abPOA](https://github.com/yangao07/abPOA)
 - Heng Li for [minigraph](https://github.com/lh3/minigraph), [minimap2](https://github.com/lh3/minimap2), [gfatools](https://github.com/lh3/gfatools) and [dna-brnn](https://github.com/lh3/dna-rnn)

--- a/build-tools/downloadPhast
+++ b/build-tools/downloadPhast
@@ -34,8 +34,13 @@ rm -rf phast
 git clone https://github.com/CshlSiepelLab/phast.git
 cd phast
 git checkout ${gitrel}
+# hack in flags support
+sed -i src/make-include.mk -e 's/CFLAGS =/CFLAGS +=/' -e 's/LIBS =/LIBS +=/' 
 # note: phast's makefile doesn't support -j (somehow this only came up when upgrading to ubunut 22.04)
 cd src && make
+
+# copy over the binaries
+cp ../bin/* ${CWD}/bin
 
 cd ${CWD}
 

--- a/build-tools/downloadPhast
+++ b/build-tools/downloadPhast
@@ -44,7 +44,15 @@ sed -i src/make-include.mk -e 's/CFLAGS =/CFLAGS +=/' -e 's/LIBS =/LIBS +=/'
 cd src && make
 
 # copy over the binaries
-cp ../bin/* ${binDir}
+for PHASTBIN in ../bin/*
+do
+	 if [[ $STATIC_CHECK -ne 1 || $(ldd ${PHASTBIN} | grep so | wc -l) -eq 0 ]]
+	 then
+		  cp ${PHASTBIN} ${binDir}
+	 else
+		  exit 1;
+	 fi
+done
 
 cd ${CWD}
 

--- a/build-tools/downloadPhast
+++ b/build-tools/downloadPhast
@@ -8,6 +8,8 @@ STATIC_CHECK=$1
 set -beEu -o pipefail
 gitrel=85f7ed179dd097a86ba4added22d571785cc3e1d
 
+binDir=$(pwd)/bin
+
 # works on MacOS and Linux
 numcpu=$(getconf _NPROCESSORS_ONLN)
 
@@ -16,6 +18,8 @@ submodulesDir=$(pwd)/submodules
 CWD=$(pwd)
 
 set -x
+
+mkdir -p ${binDir}
 
 # build clapack
 cd ${submodulesDir}
@@ -40,7 +44,7 @@ sed -i src/make-include.mk -e 's/CFLAGS =/CFLAGS +=/' -e 's/LIBS =/LIBS +=/'
 cd src && make
 
 # copy over the binaries
-cp ../bin/* ${CWD}/bin
+cp ../bin/* ${binDir}
 
 cd ${CWD}
 

--- a/build-tools/makeBinRelease
+++ b/build-tools/makeBinRelease
@@ -47,6 +47,7 @@ sed -i submodules/lastz/src/Makefile -e 's/-lm/-lm -static/g'
 export CFLAGS="-static"
 export CXXFLAGS="-static"
 export LDFLAGS="-static"
+export LIBS="-static"
 
 # build a couple dependencies from source because versions from awk don't support static linking
 pushd .
@@ -73,8 +74,9 @@ export CACTUS_STATIC_LINK_FLAGS="-L${DEP_PREFIX}/lib -lz -lpthread -lm -llzma"
 export CACTUS_LIBXML2_INCLUDE_PATH=${DEP_PREFIX}/include/libxml2
 popd
 
-# install Phast and enable halPhyloP compilation
-build-tools/downloadPhast
+# install Phast and enable halPhyloP compilation and copy the phast binaries
+build-tools/downloadPhast 1
+cp submodules/phast/LICENSE.txt ./PHAST.LICENSE.txt
 export ENABLE_PHYLOP=1
 
 # install UCSC browser libraries to compile UDC


### PR DESCRIPTION
We're already building and linking phast during the release builds in order to make `halPhyloP`.  This PR adds the various bins from the phast package (`phyloP, phyloFit, etc`) too for convenience of having access to them within the cactus docker (or with the bin install). 

