### PR TITLE
fix --root option

### DIFF
--- a/src/cactus/progressive/cactus_progressive.py
+++ b/src/cactus/progressive/cactus_progressive.py
@@ -373,7 +373,7 @@ def main():
             config_wrapper.initGPU(options)
             mc_tree, input_seq_map, og_candidates = parse_seqfile(options.seqFile, config_wrapper)
             og_map = compute_outgroups(mc_tree, config_wrapper, set(og_candidates), options.root)
-            event_set = get_event_set(mc_tree, config_wrapper, og_map, options.root)
+            event_set = get_event_set(mc_tree, config_wrapper, og_map, options.root, subtree=False)
             # infer default root
             if not options.root:
                 options.root = mc_tree.getRootName()


### PR DESCRIPTION
@vpymerel raises a serious bug with the `--root` option when running `cactus` (in the wrong github) [here](https://github.com/glennhickey/progressiveCactus/issues/132)

Namely with this tree
```
(BGIGI:0.216097,(((TGE_A:0.00174569,TGE_H20:0.0018409):0.00325768,TPA:0.00711254):0.0110921,(((TCM:0.00370156,TSI:0.00335399):0.00562986,(TDI:0.00349392,TPS:0.0069705):0.00518438):0.0073258,(TCE:0.0131574,TMS:0.00461954):0.00878047):0.00799635)TIMEMA:0.186162);
```
it fails with this error when run with `--root TIMEMA`
```
File "/home/cactus/cactus_env/lib/python3.10/site-packages/cactus/progressive/cactus_progressive.py", line 147, in progressive_schedule
raise RuntimeError("Unable to schedule job dependencies. Please file a bug report on github")
RuntimeError: Unable to schedule job dependencies. Please file a bug report on github
[2022-10-30T02:45:26+0200] [MainThread] [E] [toil.worker] Exiting the worker because of a failed job on host dna068
```

This is apparently a regression in the big refactor that was part of v2.2.0.  No idea how it got through CI (which does test --root I think), but this PR should patch it.

The work-around with the current release is to run without --root, and late use `halExtract --root` to subset the alignment after the fact. 