### PR TITLE
Try os.sched_getaffinity(0) before toils cpu_count

### DIFF
--- a/src/cactus/maf/cactus_hal2maf.py
+++ b/src/cactus/maf/cactus_hal2maf.py
@@ -28,7 +28,7 @@ from toil.common import Toil
 from toil.statsAndLogging import logger
 from toil.statsAndLogging import set_logging_from_options
 from toil.realtimeLogger import RealtimeLogger
-from toil.lib.threading import cpu_count
+from cactus.shared.common import cactus_cpu_count
 from toil.lib.humanize import bytes2human
 from sonLib.bioio import getTempDirectory
 
@@ -122,7 +122,7 @@ def main():
     # apply cpu override                
     if options.batchCores is None:
         if options.batchSystem.lower() in ['single_machine', 'singleMachine']:
-            options.batchCores = cpu_count()
+            options.batchCores = cactus_cpu_count()
             if options.maxCores:
                 options.batchCores = min(options.batchCores, int(options.maxCores))
             logger.info('Setting batchCores to {}'.format(options.batchCores))

--- a/src/cactus/preprocessor/dnabrnnMasking.py
+++ b/src/cactus/preprocessor/dnabrnnMasking.py
@@ -7,7 +7,7 @@ import re
 import sys
 import shutil
 
-from toil.lib.threading import cpu_count
+from cactus.shared.common import cactus_cpu_count
 
 from sonLib.bioio import catFiles
 
@@ -36,7 +36,7 @@ class DnabrnnMaskJob(RoundedJob):
     def __init__(self, fastaID, dnabrnnOpts, cpu, minLength=None, action=None, inputBedID=None, eventName=None):
         memory = 4*1024*1024*1024
         disk = 2*(fastaID.size)
-        cores = min(cpu_count(), cpu)
+        cores = min(cactus_cpu_count(), cpu)
         RoundedJob.__init__(self, memory=memory, disk=disk, cores=cores, preemptable=True)
         self.fastaID = fastaID
         self.minLength = minLength

--- a/src/cactus/preprocessor/fileMasking.py
+++ b/src/cactus/preprocessor/fileMasking.py
@@ -9,7 +9,7 @@ import re
 import sys
 import shutil
 import xml.etree.ElementTree as ET
-from toil.lib.threading import cpu_count
+from cactus.shared.common import cactus_cpu_count
 
 from Bio import SeqIO
 from Bio.SeqRecord import SeqRecord

--- a/src/cactus/preprocessor/lastzRepeatMasking/cactus_lastzRepeatMask.py
+++ b/src/cactus/preprocessor/lastzRepeatMasking/cactus_lastzRepeatMask.py
@@ -7,7 +7,7 @@ import re
 import sys
 import shutil
 
-from toil.lib.threading import cpu_count
+from cactus.shared.common import cactus_cpu_count
 
 from sonLib.bioio import catFiles
 
@@ -48,7 +48,7 @@ class LastzRepeatMaskJob(RoundedJob):
         disk = 2*(queryID.size + targetsSize)
         if repeatMaskOptions.gpuLastz:
             # gpu jobs get the whole node (same hack as used in blast phase)
-            cores = cpu_count()
+            cores = cactus_cpu_count()
         else:
             cores = None
         RoundedJob.__init__(self, memory=memory, disk=disk, cores=cores, preemptable=True)

--- a/src/cactus/progressive/cactus_prepare.py
+++ b/src/cactus/progressive/cactus_prepare.py
@@ -36,7 +36,7 @@ from toil.job import Job
 from toil.common import Toil
 from toil.statsAndLogging import logger
 from toil.statsAndLogging import set_logging_from_options
-from toil.lib.threading import cpu_count
+from cactus.shared.common import cactus_cpu_count
 from toil.realtimeLogger import RealtimeLogger
 from toil.lib.conversions import human2bytes, bytes2human
 

--- a/src/cactus/progressive/cactus_progressive.py
+++ b/src/cactus/progressive/cactus_progressive.py
@@ -18,7 +18,7 @@ from argparse import ArgumentParser
 from base64 import b64encode
 
 from toil.lib.bioio import getTempFile
-from toil.lib.threading import cpu_count
+from cactus.shared.common import cactus_cpu_count
 from toil.statsAndLogging import logger
 from toil.statsAndLogging import set_logging_from_options
 from toil.realtimeLogger import RealtimeLogger
@@ -342,7 +342,7 @@ def main():
             if options.maxCores is not None:
                 options.consCores = int(options.maxCores)
             else:
-                options.consCores = cpu_count()
+                options.consCores = cactus_cpu_count()
         elif options.maxCores is not None and options.consCores > int(options.maxCores):
             raise RuntimeError('--consCores must be <= --maxCores')
     else:

--- a/src/cactus/refmap/cactus_graphmap.py
+++ b/src/cactus/refmap/cactus_graphmap.py
@@ -32,7 +32,7 @@ from toil.common import Toil
 from toil.statsAndLogging import logger
 from toil.statsAndLogging import set_logging_from_options
 from toil.realtimeLogger import RealtimeLogger
-from toil.lib.threading import cpu_count
+from cactus.shared.common import cactus_cpu_count
 from cactus.progressive.progressive_decomposition import compute_outgroups, parse_seqfile, get_subtree, get_spanning_subtree, get_event_set
 from sonLib.nxnewick import NXNewick
 from sonLib.bioio import getTempDirectory
@@ -130,7 +130,7 @@ def graph_map(options):
                 findRequiredNode(config_node, "graphmap").attrib["cpu"] = str(options.mapCores)
             mg_cores = getOptionalAttrib(findRequiredNode(config_node, "graphmap"), "cpu", typeFn=int, default=1)
             if options.batchSystem.lower() in ['single_machine', 'singleMachine']:
-                mg_cores = min(mg_cores, cpu_count(), int(options.maxCores) if options.maxCores else sys.maxsize)
+                mg_cores = min(mg_cores, cactus_cpu_count(), int(options.maxCores) if options.maxCores else sys.maxsize)
                 findRequiredNode(config_node, "graphmap").attrib["cpu"] = str(mg_cores)
                 
             # get the minigraph "virutal" assembly name

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -46,7 +46,7 @@ from toil.common import Toil
 from toil.statsAndLogging import logger
 from toil.statsAndLogging import set_logging_from_options
 from toil.realtimeLogger import RealtimeLogger
-from toil.lib.threading import cpu_count
+from cactus.shared.common import cactus_cpu_count
 
 from sonLib.nxnewick import NXNewick
 from sonLib.bioio import getTempDirectory, getTempFile, catFiles

--- a/src/cactus/refmap/cactus_graphmap_split.py
+++ b/src/cactus/refmap/cactus_graphmap_split.py
@@ -32,7 +32,7 @@ from toil.common import Toil
 from toil.statsAndLogging import logger
 from toil.statsAndLogging import set_logging_from_options
 from toil.realtimeLogger import RealtimeLogger
-from toil.lib.threading import cpu_count
+from cactus.shared.common import cactus_cpu_count
 
 from sonLib.nxnewick import NXNewick
 from sonLib.bioio import getTempDirectory, getTempFile, catFiles

--- a/src/cactus/refmap/cactus_minigraph.py
+++ b/src/cactus/refmap/cactus_minigraph.py
@@ -31,7 +31,7 @@ from toil.common import Toil
 from toil.statsAndLogging import logger
 from toil.statsAndLogging import set_logging_from_options
 from toil.realtimeLogger import RealtimeLogger
-from toil.lib.threading import cpu_count
+from cactus.shared.common import cactus_cpu_count
 from cactus.progressive.multiCactusTree import MultiCactusTree
 from sonLib.bioio import getTempDirectory
 
@@ -100,7 +100,7 @@ def main():
                 findRequiredNode(config_node, "graphmap").attrib["cpu"] = str(options.mapCores)
             mg_cores = getOptionalAttrib(findRequiredNode(config_node, "graphmap"), "cpu", typeFn=int, default=1)
             if options.batchSystem.lower() in ['single_machine', 'singleMachine']:
-                mg_cores = min(mg_cores, cpu_count(), int(options.maxCores) if options.maxCores else sys.maxsize)
+                mg_cores = min(mg_cores, cactus_cpu_count(), int(options.maxCores) if options.maxCores else sys.maxsize)
                 findRequiredNode(config_node, "graphmap").attrib["cpu"] = str(mg_cores)
             
             #import the sequences

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -36,7 +36,7 @@ from toil.job import Job
 from toil.common import Toil
 from toil.statsAndLogging import logger
 from toil.statsAndLogging import set_logging_from_options
-from toil.lib.threading import cpu_count
+from cactus.shared.common import cactus_cpu_count
 
 from sonLib.nxnewick import NXNewick
 from sonLib.bioio import getTempDirectory, getTempFile
@@ -113,7 +113,7 @@ def main():
             if options.maxCores is not None:
                 options.consCores = int(options.maxCores)
             else:
-                options.consCores = cpu_count()
+                options.consCores = cactus_cpu_count()
         elif options.maxCores is not None and options.consCores > int(options.maxCores):
             raise RuntimeError('--consCores must be <= --maxCores')
     else:

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -41,15 +41,25 @@ from toil.common import Toil
 from toil.job import Job
 from toil.realtimeLogger import RealtimeLogger
 from toil.lib.humanize import bytes2human
-
+from toil.lib.threading import cpu_count
 from sonLib.bioio import popenCatch
 from sonLib.bioio import getTempDirectory
 
 from cactus.shared.version import cactus_commit
+    
 
 _log = logging.getLogger(__name__)
 
 subprocess._has_poll = False
+
+def cactus_cpu_count():
+    """ try the more cluster-friendly cpu counter before reverting to toil's
+    https://github.com/ComparativeGenomicsToolkit/cactus/issues/820
+    """
+    try:
+        return len(os.sched_getaffinity(0))
+    except:
+        return cpu_count()
 
 def cactus_override_toil_options(options):
     """  Mess with some toil options to create useful defaults. """

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -56,10 +56,14 @@ def cactus_cpu_count():
     """ try the more cluster-friendly cpu counter before reverting to toil's
     https://github.com/ComparativeGenomicsToolkit/cactus/issues/820
     """
+    num_cpus = cpu_count()
     try:
-        return len(os.sched_getaffinity(0))
+        sched_cpus = len(os.sched_getaffinity(0))
+        if sched_cpus and sched_cpus < num_cpus:
+            num_cpus = sched_cpus
     except:
-        return cpu_count()
+        pass
+    return num_cpus
 
 def cactus_override_toil_options(options):
     """  Mess with some toil options to create useful defaults. """

--- a/src/cactus/shared/configWrapper.py
+++ b/src/cactus/shared/configWrapper.py
@@ -15,7 +15,7 @@ from xml.dom import minidom
 import sys
 from cactus.shared.common import findRequiredNode
 from cactus.shared.common import getOptionalAttrib
-from toil.lib.threading import cpu_count
+from cactus.shared.common import cactus_cpu_count
 
 class ConfigWrapper:
     defaultOutgroupStrategy = 'none'
@@ -259,7 +259,7 @@ class ConfigWrapper:
                 if options.maxCores is not None:
                     lastz_cores = options.maxCores
                 else:
-                    lastz_cores = cpu_count()
+                    lastz_cores = cactus_cpu_count()
             else:
                 # todo: toil doesn't support gpu properly yet
                 lastz_cores = None


### PR DESCRIPTION
Cactus uses toil's `cpu_count()` for some jobs, generally on singleMachine batch systems, to default to scheduling them using all available cores (note: this can always be lowered with `--maxCores` and some other more targeted options).  But apparently, this [overestimates the number of available cores in some environments](https://github.com/ComparativeGenomicsToolkit/cactus/issues/820).  So following advice from #820 we use `os.sched_getaffinity(0)` instead (reverting back to cpu_count() if that doesn't work).  Thanks @ericdeveaud and @adamnovak .  Resolves #820.  May make sense to apply this to Toil too in order to get better maxCores defaults...

