### PR TITLE
[WIP] Redo cactus-graphmap-join's interface

### DIFF
--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -279,7 +279,7 @@ fi
 # vg
 cd ${pangenomeBuildDir}
 #wget -q https://github.com/vgteam/vg/releases/download/v1.44.0/vg
-wget -q http://public.gi.ucsc.edu/~hickey/vg.4892ea34a182870157b316d6259eda35ae3ff87f -o vg
+wget -q http://public.gi.ucsc.edu/~hickey/vg.90337438e303e9cfde3f08d41e38b4539fa492d8 -o vg
 chmod +x vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd vg | grep so | wc -l) -eq 0 ]]
 then

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -215,7 +215,7 @@ fi
 
 # hal2vg
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.0/hal2vg
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.1/hal2vg
 chmod +x hal2vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd hal2vg | grep so | wc -l) -eq 0 ]]
 then
@@ -225,7 +225,7 @@ else
 fi
 # clip-vg
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.0/clip-vg
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.1/clip-vg
 chmod +x clip-vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd clip-vg | grep so | wc -l) -eq 0 ]]
 then
@@ -235,7 +235,7 @@ else
 fi
 # halRemoveDupes
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.0/halRemoveDupes
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.1/halRemoveDupes
 chmod +x halRemoveDupes
 if [[ $STATIC_CHECK -ne 1 || $(ldd halRemoveDupes | grep so | wc -l) -eq 0 ]]
 then
@@ -245,7 +245,7 @@ else
 fi
 # halMergeChroms
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.0/halMergeChroms
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.1/halMergeChroms
 chmod +x halMergeChroms
 if [[ $STATIC_CHECK -ne 1 || $(ldd halMergeChroms | grep so | wc -l) -eq 0 ]]
 then
@@ -256,7 +256,7 @@ fi
 
 # halUnclip
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.0/halUnclip
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.1/halUnclip
 chmod +x halUnclip
 if [[ $STATIC_CHECK -ne 1 || $(ldd halUnclip | grep so | wc -l) -eq 0 ]]
 then
@@ -267,7 +267,7 @@ fi
 
 # filter-paf-deletions
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.0/filter-paf-deletions
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.1/filter-paf-deletions
 chmod +x filter-paf-deletions
 if [[ $STATIC_CHECK -ne 1 || $(ldd filter-paf-deletions | grep so | wc -l) -eq 0 ]]
 then
@@ -279,7 +279,7 @@ fi
 # vg
 cd ${pangenomeBuildDir}
 #wget -q https://github.com/vgteam/vg/releases/download/v1.44.0/vg
-wget -q http://public.gi.ucsc.edu/~hickey/vg.90337438e303e9cfde3f08d41e38b4539fa492d8 -o vg
+wget -q http://public.gi.ucsc.edu/~hickey/vg.d7e210950390d0c703830291f08de5b5a44711a6 -O vg
 chmod +x vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd vg | grep so | wc -l) -eq 0 ]]
 then

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -279,7 +279,7 @@ fi
 # vg
 cd ${pangenomeBuildDir}
 #wget -q https://github.com/vgteam/vg/releases/download/v1.44.0/vg
-wget -q http://public.gi.ucsc.edu/~hickey/vg.29da45091889d9c61149048453f01d83fa41190e -O vg
+wget -q http://public.gi.ucsc.edu/~hickey/vg.f8202cac90de1b9d5b78f8bd031a23fc4e44b0ef -O vg
 chmod +x vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd vg | grep so | wc -l) -eq 0 ]]
 then

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -215,7 +215,7 @@ fi
 
 # hal2vg
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.17/hal2vg
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.0/hal2vg
 chmod +x hal2vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd hal2vg | grep so | wc -l) -eq 0 ]]
 then
@@ -225,7 +225,7 @@ else
 fi
 # clip-vg
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.17/clip-vg
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.0/clip-vg
 chmod +x clip-vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd clip-vg | grep so | wc -l) -eq 0 ]]
 then
@@ -235,7 +235,7 @@ else
 fi
 # halRemoveDupes
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.17/halRemoveDupes
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.0/halRemoveDupes
 chmod +x halRemoveDupes
 if [[ $STATIC_CHECK -ne 1 || $(ldd halRemoveDupes | grep so | wc -l) -eq 0 ]]
 then
@@ -245,7 +245,7 @@ else
 fi
 # halMergeChroms
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.17/halMergeChroms
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.0/halMergeChroms
 chmod +x halMergeChroms
 if [[ $STATIC_CHECK -ne 1 || $(ldd halMergeChroms | grep so | wc -l) -eq 0 ]]
 then
@@ -256,7 +256,7 @@ fi
 
 # halUnclip
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.17/halUnclip
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.0/halUnclip
 chmod +x halUnclip
 if [[ $STATIC_CHECK -ne 1 || $(ldd halUnclip | grep so | wc -l) -eq 0 ]]
 then
@@ -267,7 +267,7 @@ fi
 
 # filter-paf-deletions
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.0.17/filter-paf-deletions
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.0/filter-paf-deletions
 chmod +x filter-paf-deletions
 if [[ $STATIC_CHECK -ne 1 || $(ldd filter-paf-deletions | grep so | wc -l) -eq 0 ]]
 then
@@ -278,7 +278,8 @@ fi
 
 # vg
 cd ${pangenomeBuildDir}
-wget -q https://github.com/vgteam/vg/releases/download/v1.40.0/vg
+#wget -q https://github.com/vgteam/vg/releases/download/v1.44.0/vg
+wget -q http://public.gi.ucsc.edu/~hickey/vg.cfd44ad5b27a0999b70dea303f13ea273a5f4f00 -o vg
 chmod +x vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd vg | grep so | wc -l) -eq 0 ]]
 then

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -279,7 +279,7 @@ fi
 # vg
 cd ${pangenomeBuildDir}
 #wget -q https://github.com/vgteam/vg/releases/download/v1.44.0/vg
-wget -q http://public.gi.ucsc.edu/~hickey/vg.e4595514ba210f1c5ca614071e4b80cedc32ef83 -O vg
+wget -q http://public.gi.ucsc.edu/~hickey/vg.55fd373ec93206e7b3d5e92371157b16d3e23421 -O vg
 chmod +x vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd vg | grep so | wc -l) -eq 0 ]]
 then

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -215,7 +215,7 @@ fi
 
 # hal2vg
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.1/hal2vg
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.2/hal2vg
 chmod +x hal2vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd hal2vg | grep so | wc -l) -eq 0 ]]
 then
@@ -225,7 +225,7 @@ else
 fi
 # clip-vg
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.1/clip-vg
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.2/clip-vg
 chmod +x clip-vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd clip-vg | grep so | wc -l) -eq 0 ]]
 then
@@ -235,7 +235,7 @@ else
 fi
 # halRemoveDupes
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.1/halRemoveDupes
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.2/halRemoveDupes
 chmod +x halRemoveDupes
 if [[ $STATIC_CHECK -ne 1 || $(ldd halRemoveDupes | grep so | wc -l) -eq 0 ]]
 then
@@ -245,7 +245,7 @@ else
 fi
 # halMergeChroms
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.1/halMergeChroms
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.2/halMergeChroms
 chmod +x halMergeChroms
 if [[ $STATIC_CHECK -ne 1 || $(ldd halMergeChroms | grep so | wc -l) -eq 0 ]]
 then
@@ -256,7 +256,7 @@ fi
 
 # halUnclip
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.1/halUnclip
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.2/halUnclip
 chmod +x halUnclip
 if [[ $STATIC_CHECK -ne 1 || $(ldd halUnclip | grep so | wc -l) -eq 0 ]]
 then
@@ -267,7 +267,7 @@ fi
 
 # filter-paf-deletions
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.1/filter-paf-deletions
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.2/filter-paf-deletions
 chmod +x filter-paf-deletions
 if [[ $STATIC_CHECK -ne 1 || $(ldd filter-paf-deletions | grep so | wc -l) -eq 0 ]]
 then
@@ -278,8 +278,9 @@ fi
 
 # vg
 cd ${pangenomeBuildDir}
-#wget -q https://github.com/vgteam/vg/releases/download/v1.44.0/vg
-wget -q http://public.gi.ucsc.edu/~hickey/vg.2d79df419644a05ba010d415096a74bd09b9a716 -O vg
+#wget -q https://github.com/vgteam/vg/releases/download/v1.45.0/vg
+# This is vg release v1.44.0 patched to add this PR https://github.com/vgteam/vg/pull/3795
+wget -q http://public.gi.ucsc.edu/~hickey/vg-patch/vg.04a8bda9fdbb6f6af66d7aa9ab457d57d1b98e72 -O vg
 chmod +x vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd vg | grep so | wc -l) -eq 0 ]]
 then

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -279,7 +279,7 @@ fi
 # vg
 cd ${pangenomeBuildDir}
 #wget -q https://github.com/vgteam/vg/releases/download/v1.44.0/vg
-wget -q http://public.gi.ucsc.edu/~hickey/vg.9d386cff6a05734688e06e189eadb5eff4271ef3 -O vg
+wget -q http://public.gi.ucsc.edu/~hickey/vg.29da45091889d9c61149048453f01d83fa41190e -O vg
 chmod +x vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd vg | grep so | wc -l) -eq 0 ]]
 then

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -279,7 +279,7 @@ fi
 # vg
 cd ${pangenomeBuildDir}
 #wget -q https://github.com/vgteam/vg/releases/download/v1.44.0/vg
-wget -q http://public.gi.ucsc.edu/~hickey/vg.f8202cac90de1b9d5b78f8bd031a23fc4e44b0ef -O vg
+wget -q http://public.gi.ucsc.edu/~hickey/vg.2d79df419644a05ba010d415096a74bd09b9a716 -O vg
 chmod +x vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd vg | grep so | wc -l) -eq 0 ]]
 then

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -300,6 +300,17 @@ else
 	 exit 1
 fi
 
+# vcfbub
+cd ${pangenomeBuildDir}
+wget -q https://github.com/pangenome/vcfbub/releases/download/v0.1.0/vcfbub
+chmod +x vcfbub
+if [[ $STATIC_CHECK -ne 1 || $(ldd vcfbub | grep so | wc -l) -eq 0 ]]
+then
+	 mv vcfbub ${binDir}
+else
+	 exit 1
+fi
+
 cd ${CWD}
 rm -rf ${pangenomeBuildDir}
 

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -279,7 +279,7 @@ fi
 # vg
 cd ${pangenomeBuildDir}
 #wget -q https://github.com/vgteam/vg/releases/download/v1.44.0/vg
-wget -q http://public.gi.ucsc.edu/~hickey/vg.55fd373ec93206e7b3d5e92371157b16d3e23421 -O vg
+wget -q http://public.gi.ucsc.edu/~hickey/vg.9d386cff6a05734688e06e189eadb5eff4271ef3 -O vg
 chmod +x vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd vg | grep so | wc -l) -eq 0 ]]
 then

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -279,7 +279,7 @@ fi
 # vg
 cd ${pangenomeBuildDir}
 #wget -q https://github.com/vgteam/vg/releases/download/v1.44.0/vg
-wget -q http://public.gi.ucsc.edu/~hickey/vg.cfd44ad5b27a0999b70dea303f13ea273a5f4f00 -o vg
+wget -q http://public.gi.ucsc.edu/~hickey/vg.4892ea34a182870157b316d6259eda35ae3ff87f -o vg
 chmod +x vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd vg | grep so | wc -l) -eq 0 ]]
 then

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -279,7 +279,7 @@ fi
 # vg
 cd ${pangenomeBuildDir}
 #wget -q https://github.com/vgteam/vg/releases/download/v1.44.0/vg
-wget -q http://public.gi.ucsc.edu/~hickey/vg.d7e210950390d0c703830291f08de5b5a44711a6 -O vg
+wget -q http://public.gi.ucsc.edu/~hickey/vg.6b17e3a5c14ecbe2f38ba7c6418b7079e2df814e -O vg
 chmod +x vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd vg | grep so | wc -l) -eq 0 ]]
 then

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -279,7 +279,7 @@ fi
 # vg
 cd ${pangenomeBuildDir}
 #wget -q https://github.com/vgteam/vg/releases/download/v1.44.0/vg
-wget -q http://public.gi.ucsc.edu/~hickey/vg.6b17e3a5c14ecbe2f38ba7c6418b7079e2df814e -O vg
+wget -q http://public.gi.ucsc.edu/~hickey/vg.e4595514ba210f1c5ca614071e4b80cedc32ef83 -O vg
 chmod +x vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd vg | grep so | wc -l) -eq 0 ]]
 then

--- a/doc/mc-pangenomes/README.md
+++ b/doc/mc-pangenomes/README.md
@@ -2,7 +2,7 @@
 
 These are some pangenomes created using [Minigraph-Cactus](../pangenome.md), along with all steps used to produce them.
 
-The commits used can be found in the logs in the Output links. Data is provided in HAL, vg, GFA and VCF formats. Please read about [VCF output](../pangenome.md#vcf-output) before using it.  
+The commits used can be found in the logs in the Output links. Data is provided in HAL, vg, GFA and VCF formats. Please read about [VCF output](../pangenome.md#output) before using it.  
 
 Please cite the [Minigraph-Cactus paper](https://doi.org/10.1101/2022.10.06.511217) when using these pangenomes. For the HPRC pangenomes, please also cite the [HPRC Paper](https://doi.org/10.1101/2022.07.09.499321 ).
 

--- a/doc/pangenome.md
+++ b/doc/pangenome.md
@@ -94,7 +94,7 @@ The input is a two-column `seqFile` mapping sample names to fasta paths (gzipped
 
 
 
-**A naming convention must be followed for sample names**: The "." character is used to specify haplotype, and should be avoided in sample names unless it is being used that way.  For haploid samples, just don't use a ".".  For diploid or poloyploid samples, use the form `SAMPLE.HAPLOTYPE`. where `HAPLOTYPE` is either `0` for a haploid sample, or `1` or `2` for a diploid sample etc:
+**A naming convention must be followed for sample names**: The "." character is used to specify haplotype, and should be avoided in sample names unless it is being used that way.  For haploid samples, just don't use a ".".  For diploid or poloyploid samples, use the form `SAMPLE.HAPLOTYPE` where `HAPLOTYPE` is either `0` for a haploid sample, or `1` or `2` for a diploid sample etc:
 
 ```
 # Diploid sample:
@@ -119,13 +119,13 @@ CHM13  ./chm13.fa
 
 ### Clipping, Filtering and Indexing
 
-`cactus-graphmap-join` merges chromosome graphs created by `cactus-align-batch`, and also normalizes, clips and filters the graph in addition to producing some useful indexes.  It can produce up two three graphs (now in a single invocation), and a variety of indexes on any combination of them. The three graphs are the
+`cactus-graphmap-join` merges chromosome graphs created by `cactus-align-batch`, and also normalizes, clips and filters the graph in addition to producing some useful indexes.  It can produce up to three graphs (now in a single invocation), and a variety of indexes or any combination of them. The three graphs are the
 
 * `full` graph: This graph is normalized, but no sequence is removed. It and its indexes will have `.full` in their filenames. 
 * `clip` graph: This is the default graph. Stretches of sequence `>10kb` that were not aligned to the underlying SV/minigraph are removed.
 * `filter` graph: This graph is made by removing nodes covered by fewer than 2 haplotypes from the `clip` graph.  It and its indexes will have `.d2` in their filenames.
 
-The different graphs have different uses. For instance, the current version of `vg giraffe` performs best on the filtered graph (this will hopefully be remedied in an update soon).  For the HPRC paper, we used `d9`. When you pass `--giraffe` to `cactus-graphmap-join`, it will make the giraffe indexes on the filtered graph by default.  But you can override this behaviour to produces the indexes for any of the graphs though by passing in any combination of [`full`, `clip` and `filter`] to the `--giraffe` options. For example:
+The different graphs have different uses. For instance, the current version of `vg giraffe` performs best on the filtered graph (this will hopefully be remedied in an update soon).  For the HPRC paper, we used `d9`. When you pass `--giraffe` to `cactus-graphmap-join`, it will make the giraffe indexes on the filtered graph by default.  But you can override this behaviour to produces the indexes for any of the graphs  by passing in any combination of [`full`, `clip` and `filter`] to the `--giraffe` options. For example:
 
 `--giraffe`: Make the giraffe indexes for the filtered graph (default choice).
 
@@ -146,7 +146,7 @@ If you want to use the HAL output, `cactus-graphmap-join` can also merge HAL chr
 ### Output
 
 * `hal`: Cactus's [native alignment format](./progressive.md#using-the-hal-output) can be used to convert to MAF, build assembly hubs, run liftover and comparative annotation.
-* `gfa`: A [standard text-based graph format](https://github.com/GFA-spec/GFA-spec/blob/master/GFA1.md). Minigraph-Cactus uses GFA 1.1 as it represents haplotypes as [Walks][https://github.com/GFA-spec/GFA-spec/blob/master/GFA1.md#w-walk-line-since-v11). You can use `vg convert -gfW` to convert from GFA 1.1 to 1.0 and `vg convert -gf` to convert from 1.0 to 1.1.
+* `gfa`: A [standard text-based graph format](https://github.com/GFA-spec/GFA-spec/blob/master/GFA1.md). Minigraph-Cactus uses GFA 1.1 as it represents haplotypes as [Walks](https://github.com/GFA-spec/GFA-spec/blob/master/GFA1.md#w-walk-line-since-v11). You can use `vg convert -gfW` to convert from GFA 1.1 to 1.0 and `vg convert -gf` to convert from 1.0 to 1.1.
 * `vcf`: A [standard text-based format](https://en.wikipedia.org/wiki/Variant_Call_Format) that represents a pangenome graph as sites of variation along a reference. VCFs exported from the graph are nested, and by default `vcfbub` is used to flatten them.
 * `vg`: [vg](https://github.com/vgteam/vg)'s native packed-graph format, can be read and written by vg but does not scale well with the number of paths.
 * `gbz`: A read-only [format that scales extremely efficiently with the number of paths](https://github.com/jltsiren/gbwtgraph/blob/master/SERIALIZATION.md). Readable by `vg` tools and required for `giraffe`.

--- a/doc/pangenome.md
+++ b/doc/pangenome.md
@@ -453,7 +453,9 @@ Important:
 * we use `--filter 9` and `--giraffe` to make giraffe indexes on the subgraph covered by at least 9/90 haplotypes (filter does not apply to the reference).
 * we use `--reference GRCh38 CHM13v2` to specify an additional reference. In this case `CHM13v2` will still be clipped (but not filtered), and it will be treated as a reference path in vg (and therefore easier to query).  You can add `--vcfReference GRCh38 CHM13v2` to make a VCF based on CHM13 too. 
 
+```
 cactus-graphmap-join ${MYJOBSTORE} --vg $(for j in $(for i in `seq 22`; do echo chr$i; done ; echo "chrX chrY chrM chrOther"); do echo ${MYBUCKET}/align-hprc-${VERSION}-mc-grch38/${j}.vg; done) --hal $(for j in $(for i in `seq 22`; do echo chr$i; done ; echo "chrX chrY chrM chrOther"); do echo ${MYBUCKET}/align-hprc-${VERSION}-mc-grch38/${j}.hal; done) --outDir ${MYBUCKET}/ --outName hprc-${VERSION}-mc-grch38 --reference GRCh38 --filter 9 --giraffe --vcf --gbz --gfa --vg-chroms --batchSystem mesos --provisioner aws --defaultPreemptable --nodeType r5.16xlarge --nodeStorage 1000 --maxNodes 1 --indexCores 63  --logFile hprc-${VERSION}-mc-grch38.join.log 
+```
 
 **All sequences clipped out by `cactus-graphmap-join` will be saved in a BED file in the ".stats.gz" file in its output directory.**
 

--- a/doc/pangenome.md
+++ b/doc/pangenome.md
@@ -109,7 +109,7 @@ CHM13  ./chm13.fa
 
 1) `cactus-minigraph <jobStore> <seqFile> <outputGFA> --reference`: Construct a minigraph in GFA format (may be gzipped) from a set of FASTA files (may also be gzipped).  This is a very thin wrapper over `minigraph -cxggs`.  The reference is added first and the remainder of samples are added in decreasing order of size.  Use the `--mapCores` option to specify the number of cores.
 
-2) `cactus-graphmap <jobStore> <seqFile> <inputGFA> <outputPAF> --reference`: Map each input assembly back to the graph using `minigraph`.  The number of cores for each mapping job can be set with `--mapCores`.  The `--delFilter` option can be used to remove large split mappings (the unfiltered output is returned as well, in addition to a log of what was filtered).  For human data, `--delFilter 10000000` helps remove some spurious bubbles.
+2) `cactus-graphmap <jobStore> <seqFile> <inputGFA> <outputPAF> --reference`: Map each input assembly back to the graph using `minigraph`.  The number of cores for each mapping job can be set with `--mapCores`.  
 
 3) **(Optional)** `cactus-graphmap-split <jobStore> <seqFile> <inputGFA> <inputPAF> --reference --outDir`: Split the input assemblies and PAF into chromosomes using the rGFA tags in the GFA. Doing so reduces the memory requirements in the following steps.  It assigns each contig to a single chromosome according to the alignment in the input PAF, so all inter-chromosomal events will be filtered out.  Contigs that can't be assigned to a chromosome are deemed "ambiguous" and not considered in later steps.
 
@@ -422,7 +422,7 @@ Note: since there is already a minigraph available for this data, we just use it
 
 Now that the sequences are ready, we run `cactus-graphmap` as before.  There is a new option:
 
-`--delFilter N` : Filter out mappings that would induce a deletion bubble of `>N` bases w.r.t. a path in the reference.  If this option is used, the unfiltered paf will also be output (with a `.unfiltered` suffix) as well as a log detailing what was filtered and why (`.filter.log` suffix).  This option is very important as minigraph will produce a small number of split-mappings that can cause chromosome-scale bubbles.
+`--delFilter N` : Filter out mappings that would induce a deletion bubble of `>N` bases w.r.t. a path in the reference.  If this option is used, the unfiltered paf will also be output (with a `.unfiltered` suffix) as well as a log detailing what was filtered and why (`.filter.log` suffix).  This option is very important as minigraph will produce a small number of split-mappings that can cause chromosome-scale bubbles.  By default, it is set to 1000000.
 
 ```
 cactus-graphmap ${MYJOBSTORE} hprc-${VERSION}-mc.pp.seqfile ${MINIGRAPH} ${MYBUCKET}/hprc-${VERSION}-mc-grch38.paf --outputGAFDir ${MYBUCKET}/gaf-hprc-${VERSION}-mc-grch38 --outputFasta ${MYBUCKET}/fasta/minigraph.grch38.sv.gfa.fa.gz --reference GRCh38 --mapCores 16 --delFilter 10000000  --batchSystem mesos --provisioner aws --defaultPreemptable --nodeType r5.8xlarge:1.5 --nodeStorage 650 --maxNodes 25 --betaInertia 0 --targetTime 1  --logFile hprc-${VERSION}-mc-grch38.paf.log

--- a/doc/pangenome.md
+++ b/doc/pangenome.md
@@ -77,7 +77,7 @@ ls -hs primates-pg/primates-pg.d2.*
 
 By default, `--giraffe` will produce frequency filtered indexes, with a default minimum coverage of 2 (hence the `.d2`). This means only nodes covered by two haplotypes will appear in the index. This helps `vg giraffe` performance considerably (though a version of Giraffe that no longer needs it is under development). The dataset here is too small for this to be useful.  To index the clipped but unfiltered graph, use `--giraffe clip` or use `--giraffe full` to index the full, unclipped graph. See more detailed explanations below. 
 
-```
+
 ## Introduction
 
 Minigraph-Cactus uses [minigraph](https://github.com/lh3/minigraph) to construct a pangenome graph of structural variation in a set of input assemblies. The assemblies are then mapped back to this graph using minigraph.  These mappings are used as input to [Cactus](../README.md) to construct a new graph that contains variants of all sizes, allowing the input assemblies to be encoded as embedded paths in the graph. The graph is output in  pangenome graph formats such as [vg](https://github.com/vgteam/vg) and [GFA](https://github.com/GFA-spec/GFA-spec), in addition to the usual [HAL](https://github.com/ComparativeGenomicsToolkit/hal).

--- a/doc/pangenome.md
+++ b/doc/pangenome.md
@@ -34,7 +34,7 @@ cactus-minigraph ./jobstore primates-pg/evolverPrimates.pg.txt primates-pg/prima
 
 Make the assembly-to-graph alignments with `minigraph`
 ```
-cactus-graphmap ./jobstore primates-pg/evolverPrimates.pg.txt primates-pg/primates.sv.gfa.gz primates-pg/primates.paf  --reference simChimp --outputFasta primates-pg/primates.gfa.fa.gz
+cactus-graphmap ./jobstore primates-pg/evolverPrimates.pg.txt primates-pg/primates.sv.gfa.gz primates-pg/primates.paf  --reference simChimp --outputFasta primates-pg/primates.sv.gfa.fa.gz
 ```
 
 Create the Cactus base alignment and "raw" pangenome graph
@@ -168,17 +168,17 @@ mkdir -p yeast-pg
 cp ./examples/yeastPangenome.txt yeast-pg/
 
 # make the minigraph
-cactus-minigraph ./jobstore  ./yeast-pg/yeastPangenome.txt ./yeast-pg/yeast.gfa  --reference S288C
+cactus-minigraph ./jobstore  ./yeast-pg/yeastPangenome.txt ./yeast-pg/yeast.sv.gfa  --reference S288C
 
 # map back to the minigraph
-cactus-graphmap ./jobstore ./yeast-pg/yeastPangenome.txt ./yeast-pg/yeast.gfa ./yeast-pg/yeast.paf --outputFasta ./yeast-pg/yeast.gfa.fa  --reference S288C
+cactus-graphmap ./jobstore ./yeast-pg/yeastPangenome.txt ./yeast-pg/yeast.sv.gfa ./yeast-pg/yeast.paf --outputFasta ./yeast-pg/yeast.sv.gfa.fa  --reference S288C
 ```
 
 ### Yeast: Splitting By Chromosome
 Now the PAF and GFA `minigraph` output can be used to partition the graph and mappings based on the reference genome's (S288C's) chromosomes:
 
 ```
-cactus-graphmap-split ./jobstore ./yeast-pg/yeastPangenome.txt ./yeast-pg/yeast.gfa ./yeast-pg/yeast.paf --outDir yeast-pg/chroms  --reference S288C
+cactus-graphmap-split ./jobstore ./yeast-pg/yeastPangenome.txt ./yeast-pg/yeast.sv.gfa ./yeast-pg/yeast.paf --outDir yeast-pg/chroms  --reference S288C
 ```
 
 This command makes a cactus subproblem for each reference chromosome.  By default, it uses all contigs in the reference.  A subset can be specified using the `--refContigs` option.
@@ -420,7 +420,7 @@ Now that the sequences are ready, we run `cactus-graphmap` as before.  There is 
 `--delFilter N` : Filter out mappings that would induce a deletion bubble of `>N` bases w.r.t. a path in the reference.  If this option is used, the unfiltered paf will also be output (with a `.unfiltered` suffix) as well as a log detailing what was filtered and why (`.filter.log` suffix).  This option is very important as minigraph will produce a small number of split-mappings that can cause chromosome-scale bubbles.
 
 ```
-cactus-graphmap ${MYJOBSTORE} hprc-${VERSION}-mc.pp.seqfile ${MINIGRAPH} ${MYBUCKET}/hprc-${VERSION}-mc-grch38.paf --outputGAFDir ${MYBUCKET}/gaf-hprc-${VERSION}-mc-grch38 --outputFasta ${MYBUCKET}/fasta/minigraph.grch38.gfa.fa.gz --reference GRCh38 --mapCores 16 --delFilter 10000000  --batchSystem mesos --provisioner aws --defaultPreemptable --nodeType r5.8xlarge:1.5 --nodeStorage 650 --maxNodes 25 --betaInertia 0 --targetTime 1  --logFile hprc-${VERSION}-mc-grch38.paf.log
+cactus-graphmap ${MYJOBSTORE} hprc-${VERSION}-mc.pp.seqfile ${MINIGRAPH} ${MYBUCKET}/hprc-${VERSION}-mc-grch38.paf --outputGAFDir ${MYBUCKET}/gaf-hprc-${VERSION}-mc-grch38 --outputFasta ${MYBUCKET}/fasta/minigraph.grch38.sv.gfa.fa.gz --reference GRCh38 --mapCores 16 --delFilter 10000000  --batchSystem mesos --provisioner aws --defaultPreemptable --nodeType r5.8xlarge:1.5 --nodeStorage 650 --maxNodes 25 --betaInertia 0 --targetTime 1  --logFile hprc-${VERSION}-mc-grch38.paf.log
 ```
 
 Note:  The `--betaInertia 0 --targetTime 1` options force Toil to create AWS instances as soon as they are needed.

--- a/doc/pangenome.md
+++ b/doc/pangenome.md
@@ -317,6 +317,7 @@ chrXIII, 930506, 16183, 0
 chrXIV, 777615, 17052, 0
 chrXV, 1091343, 23011, 0
 chrXVI, 954457, 19805, 0
+```
 
 ### Yeast: Making a UCSC Genome Browser Assembly Hub
 

--- a/doc/progressive.md
+++ b/doc/progressive.md
@@ -17,7 +17,7 @@ Please cite the [Progressive Cactus paper](https://doi.org/10.1038/s41586-020-28
 * [Updating Alignments](#updating-alignments)
 * [GPU Acceleration](#gpu-acceleration)
 * [Pre-Alignment Checklist](#pre-alignment-checklist)
-* [FAQ](#faq)
+* [Frequently Asked Questions](#frequently-asked-questions)
 
 ## Quick Start
 

--- a/examples/yeastPangenome.txt
+++ b/examples/yeastPangenome.txt
@@ -1,6 +1,6 @@
 S288C	https://github.com/ComparativeGenomicsToolkit/cactusTestData/raw/master/yeast/S288C.fa.gz
-SK1.0	https://github.com/ComparativeGenomicsToolkit/cactusTestData/raw/master/yeast/SK1.fa.gz
-DBVPG6044.0	https://github.com/ComparativeGenomicsToolkit/cactusTestData/raw/master/yeast/DBVPG6044.fa.gz            
-UWOPS034614.0	https://github.com/ComparativeGenomicsToolkit/cactusTestData/raw/master/yeast/UWOPS034614.fa.gz
-Y12.0	https://github.com/ComparativeGenomicsToolkit/cactusTestData/raw/master/yeast/Y12.fa.gz
-YPS128.0	https://github.com/ComparativeGenomicsToolkit/cactusTestData/raw/master/yeast/YPS128.fa.gz
+SK1	https://github.com/ComparativeGenomicsToolkit/cactusTestData/raw/master/yeast/SK1.fa.gz
+DBVPG6044	https://github.com/ComparativeGenomicsToolkit/cactusTestData/raw/master/yeast/DBVPG6044.fa.gz            
+UWOPS034614	https://github.com/ComparativeGenomicsToolkit/cactusTestData/raw/master/yeast/UWOPS034614.fa.gz
+Y12	https://github.com/ComparativeGenomicsToolkit/cactusTestData/raw/master/yeast/Y12.fa.gz
+YPS128	https://github.com/ComparativeGenomicsToolkit/cactusTestData/raw/master/yeast/YPS128.fa.gz

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -331,6 +331,17 @@
 		 ambiguousName="_AMBIGUOUS_"
 		 remapSplitOptions=""
 		 />
+	<!-- cactus-graphmap-join options -->
+	<!-- gfaffix: toggle gfaffix normalization on/off -->
+	<!-- clipNonMinigraph: clip out regions if the don't align to minigraph (if disabled, clip if they don't align to anything) -->
+	<!-- minimizerOptions: options for vg minimizer -->
+	<!-- minFilterFragment: discard fragments that result from the vg clip frequency filter if they are smaller than this -->
+	<graphmap_join
+		 gfaffix="1"
+		 clipNonMinigraph="1"		 
+		 minimizerOptions="-k 29 -w 11"
+		 minFilterFragment="1000"
+		 />
 	<!-- hal2vg options -->
 	<!-- includeMinigraph: include minigraph node sequences as paths in output (note that cactus-graphmap-join will still remove them by default) -->
 	<!-- includeAncestor: include ancestral reference sequences as paths in output -->

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -292,6 +292,7 @@
 	<!-- maskFilter: any softmasked sequence intervals > than this many bp will be hardmasked before being read by the minigraph mapper [negative value = disable]-->
 	<!-- delFilter: any deletions implied by split-read mappings greater than this are removed from the paf (by removing all lines of the smallest block bordering deletion)-->
 	<!-- delFilterThreshold: only remove deletion if it costs < delFilterThreshold * deletion-size matches. must be in range (0, 1] -->
+	<!-- delFilterQuerySizeThreshold: deletion removed if the supporting query contig has length < delFilterQuerySizeThreshold * deletion-size --> 
 	<!-- minIdentity: ignore PAF lines with identity (col 10 / col 11) is less than this -->	
 	<!-- removeMinigraphFromPAF: replace all minigraph contigs with transitive alignments in cactus-align-->
 	<!-- cpu: use up to this many cpus for each minigraph command. -->
@@ -308,8 +309,9 @@
 		 PAFOverlapFilterRatio="5"
 		 PAFOverlapFilterMinLengthRatio="0"
 		 maskFilter="-1"
-		 delFilter="-1"
+		 delFilter="10000000"
 		 delFilterThreshold="0.01"
+		 delFilterQuerySizeThreshold="2"
 		 minIdentity="0.5"		 
 		 removeMinigraphFromPAF="0"
 		 cpu="6"

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -578,7 +578,7 @@ def make_giraffe_indexes(job, options, config, index_dict, tag=''):
 
     # make the distance index
     dist_path = os.path.join(work_dir, tag + os.path.basename(options.outName) + '.dist')
-    cactus_call(parameters=['vg', 'index', '-t', str(job.cores), '-j', dist_path, '-s', gbz_path])
+    cactus_call(parameters=['vg', 'index', '-t', str(job.cores), '-j', dist_path, gbz_path])
 
     # make the minimizer index
     min_path = os.path.join(work_dir, os.path.basename(options.outName) + '.min')

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -56,31 +56,22 @@ def main():
     Job.Runner.addToilOptions(parser)
 
     parser.add_argument("--vg", required=True, nargs='+',  help = "Input vg files (PackedGraph or HashGraph format)")
+    parser.add_argument("--hal", nargs='+', default = [], help = "Input hal files (for merging)")    
     parser.add_argument("--outDir", required=True, type=str, help = "Output directory")
     parser.add_argument("--outName", required=True, type=str, help = "Basename of all output files")
-    parser.add_argument("--reference", required=True, type=str, help = "Reference event name")
-    parser.add_argument("--vcfReference", type=str, help = "Produce additional VCF for given reference event")
-    parser.add_argument("--otherReferences", nargs='+', help = "Promote these events to reference-sense paths in vg (in addition to --reference)")
-    parser.add_argument("--rename", nargs='+', default = [], help = "Path renaming, each of form src>dest (see clip-vg -r)")
-    parser.add_argument("--clipLength", type=int, default=None, help = "clip out unaligned sequences longer than this")
-    parser.add_argument("--clipNonMinigraph", action="store_true", help = "apply --clipLength filter to stretches not aligned to minigraph")
-    parser.add_argument("--clipBed", nargs='+', default = [], help = "BED file(s) (ie from cactus-preprocess) of regions to clip")
-    parser.add_argument("--indexCores", type=int, default=1, help = "cores for general indexing and VCF constructions")
-    parser.add_argument("--giraffeCores", type=int, default=None, help = "cores for giraffe-specific indexing (defaults to --indexCores)")
-    parser.add_argument("--decoyGraph", help= "decoy sequences vg graph to add (PackedGraph or HashGraph format)")
-    parser.add_argument("--hal", nargs='+', default = [], help = "Input hal files (for merging)")
-    parser.add_argument("--vcf", action="store_true", help= "make VCF")
-    parser.add_argument("--vcfbub", type=int, default=100000, help = "Use vcfbub to flatten nested sites (sites with reference alleles > this will be replaced by their children)). Setting to 0 will disable, only prudcing raw VCF [default=100000].")
-    parser.add_argument("--giraffe", action="store_true", help= "make Giraffe-specific indexes (distance and minimizer)")
-    parser.add_argument("--normalizeIterations", type=int, default=None,
-                        help="Run this many iterations of vg normamlization (shared prefix zipping)")
-    parser.add_argument("--gfaffix", action="store_true",
-                        help="Run GFAFfix normalization")
-    parser.add_argument("--vgClipOpts", nargs='+', help = "If specified, run vg clip with given options (surround in quotes; multiple allowed to chain multiple clip commands)")
-    parser.add_argument("--unclipSeqFile",type=str, help = "seqfile of unclipped sequences. If given, halUnclip will be run on the HAL output to restore original sequences (removing _sub suffixes)")
-    parser.add_argument("--preserveIDs", action="store_true",
-                        help = "Do not alter node ids, either through vg ids -j or vg ids -s.  Only use when sure IDs have already been joined!")
+    parser.add_argument("--reference", required=True, nargs='+', type=str, help = "Reference event name(s). The first will be the \"true\" reference and will be left unclipped and uncollapsed. It also should have been used with --reference in all upstream commands. Other names will be promoted to reference paths in vg")
     
+    parser.add_argument("--clip", type=int, default=10000, help = "Generate clipped graph by removing anything longer than this amount that is unaligned to the underlying minigraph. Set to 0 to disable (must also set --filter 0 as well). [default=10000]")
+    
+    parser.add_argument("--filter", type=int, default=2, help = "Generate a frequency filtered graph (from the clipped graph) by removing any sequence present in fewer than this many sequences. Set to 0 to disable. [default=2]")
+    
+    parser.add_argument("--vcf", nargs='*', default=None, help = "Generate a VCF from the given graph type(s). Valid types are 'full', 'clip' and 'filter'. If no type specified, 'clip' will be used. Multipe types can be provided separated by space")
+    parser.add_argument("--vcfReference", nargs='+', default=None, help = "If multiple references were provided with --reference, this option can be used to specify a subset for vcf creation with --vcf. By default, --vcf will create VCFs for the first reference only")
+    parser.add_argument("--vcfbub", type=int, default=100000, help = "Use vcfbub to flatten nested sites (sites with reference alleles > this will be replaced by their children)). Setting to 0 will disable, only prudcing full VCF [default=100000].")
+    
+    parser.add_argument("--giraffe", nargs='*', default=None, help = "Generate Giraffe (.dist, .min) indexes for the given graph type(s). Valid types are 'full', 'clip' and 'filter'. If not type specified, 'filter' will be used. Multiple types can be provided seperated by a space")
+    parser.add_argument("--indexCores", type=int, default=None, help = "cores for general indexing and VCF constructions (defaults to the same as --maxCores)")
+        
     #Progressive Cactus Options
     parser.add_argument("--configFile", dest="configFile",
                         help="Specify cactus configuration file",
@@ -106,14 +97,48 @@ def main():
 
     if options.hal and len(options.hal) != len(options.vg):
         raise RuntimeError("If --hal and --vg should specify the same number of files")
-    if not options.giraffeCores:
-        options.giraffeCores = options.indexCores
-    if options.unclipSeqFile and not options.hal:
-        raise  RuntimeError("--unclipSeqFile can only be used with --hal")
-    if options.preserveIDs and (options.normalizeIterations or options.gfaffix):
-        raise RuntimeError("--preserveIDs cannot be used with any kind of normalization (--gfaffix or --normalizeIterations)")
-    if options.otherReferences and options.reference in options.otherReferences:
-        raise RuntimeError("the same cannot be specified both with --reference and --otherReferences")
+
+    # apply cpu override
+    if options.batchSystem.lower() in ['single_machine', 'singleMachine']:
+        if not options.indexCores:
+            options.indexCores = sys.maxsize
+        options.indexCores = min(options.indexCores, cactus_cpu_count(), int(options.maxCores) if options.maxCores else sys.maxsize)
+    else:
+        if not options.indexCores:
+            raise RuntimeError("--indexCores required run *not* running on single machine batch system")
+    
+    # sanity check the workflow options and apply defaults
+    if options.filter and not options.clip:
+        raise RuntimeError('--filter cannot be used without also disabling --clip.')
+
+    if options.vcf == []:
+        options.vcf = ['clip'] if options.clip else ['full']
+    options.vcf = list(set(options.vcf)) if options.vcf else []    
+    for vcf in options.vcf:
+        if vcf not in ['clip', 'filter', 'full']:
+            raise RuntimeError('Unrecognized value for --vcf: {}. Must be one of {clip, filter, full}'.format(vcf))
+        if vcf == 'clip' and not options.clip:
+            raise RuntimError('--vcf cannot be set to clip since clipping is disabled')
+        if vcf == 'filter' and not options.filter:
+            raise RuntimeError('--vcf cannot be set to filter since filtering is disabled')
+            
+    if not options.vcfReference:
+        options.vcfReference = [options.reference[0]]
+    else:
+        for vcfref in options.vcfReference:
+            if vcfref not in options.reference:
+                raise RuntimeError('--vcfReference {} was not specified as a --reference'.format(vcfref))
+
+    if options.giraffe == []:
+        options.giraffe = ['filter'] if options.filter else ['clip'] if options.clip else ['full']
+    options.giraffe = list(set(options.giraffe)) if options.giraffe else []        
+    for giraffe in options.giraffe:
+        if giraffe not in ['clip', 'filter', 'full']:
+            raise RuntimeError('Unrecognized value for --giraffe: {}. Must be one of {clip, filter, full}'.format(giraffe))
+        if giraffe == 'clip' and not options.clip:
+            raise RuntimError('--giraffe cannot be set to clip since clipping is disabled')
+        if giraffe == 'filter' and not options.filter:
+            raise RuntimeError('--giraffe cannot be set to filter since filtering is disabled')
         
     # Mess with some toil options to create useful defaults.
     cactus_override_toil_options(options)
@@ -139,27 +164,12 @@ def graphmap_join(options):
             configNode = ET.parse(options.configFile).getroot()
             config = ConfigWrapper(configNode)
             config.substituteAllPredefinedConstantsWithLiterals()
-
-            # load up the beds
-            bed_ids = []
-            if options.clipBed:
-                logger.info("Importing BED files")
-            for bed_path in options.clipBed:
-                bed_ids.append(toil.importFile(makeURL(bed_path)))
                 
             # load up the vgs
             vg_ids = []
             for vg_path in options.vg:
                 logger.info("Importing {}".format(vg_path))
                 vg_ids.append(toil.importFile(makeURL(vg_path)))
-
-            # tack on the decoys
-            if options.decoyGraph:
-                logger.info("Importing decoys {}".format(options.decoyGraph))
-                vg_ids.append(toil.importFile(makeURL(options.decoyGraph)))
-                # we'll treat it like any other graph downstream, except clipping
-                # where we'll check first using the path name
-                options.vg.append(options.decoyGraph)
                 
             # load up the hals
             hal_ids = []
@@ -167,114 +177,63 @@ def graphmap_join(options):
                 logger.info("Importing {}".format(hal_path))
                 hal_ids.append(toil.importFile(makeURL(hal_path)))
 
-            # load up the sequences
-            unclip_seq_id_map = {}
-            if options.unclipSeqFile:
-                seqFile = SeqFile(options.unclipSeqFile)
-                leaves = set([seqFile.tree.getName(node) for node in seqFile.tree.getLeaves()])
-                for genome, seq in seqFile.pathMap.items():
-                    if genome in leaves:
-                        if os.path.isdir(seq):
-                            tmpSeq = getTempFile()
-                            catFiles([os.path.join(seq, subSeq) for subSeq in os.listdir(seq)], tmpSeq)
-                            seq = tmpSeq
-                        seq = makeURL(seq)
-                        logger.info("Importing {}".format(seq))
-                        unclip_seq_id_map[genome] = (seq, toil.importFile(seq))
-
             # run the workflow
-            wf_output = toil.start(Job.wrapJobFn(graphmap_join_workflow, options, config, vg_ids, hal_ids, unclip_seq_id_map, bed_ids))
+            wf_output = toil.start(Job.wrapJobFn(graphmap_join_workflow, options, config, vg_ids, hal_ids))
                 
         #export the split data
-        export_join_data(toil, options, wf_output[0], wf_output[1], wf_output[2])
+        export_join_data(toil, options, wf_output[0], wf_output[1], wf_output[2], wf_output[3], wf_output[4])
 
-def graphmap_join_workflow(job, options, config, vg_ids, hal_ids, unclip_seq_id_map, bed_ids):
+def graphmap_join_workflow(job, options, config, vg_ids, hal_ids):
 
     root_job = Job()
     job.addChild(root_job)
 
-    # concat the bed_files
-    if bed_ids:
-        bed_cat_job = root_job.addChildJobFn(cat_bed_files, bed_ids)
-    bed_id = bed_cat_job.rv() if bed_ids else None
-        
-    # run clip-vg on each input
-    clipped_vg_ids = []
-    clipped_stats_list = []
+    # run the "full" phase to do pre-clipping stuff
+    full_vg_ids = []
     for vg_path, vg_id in zip(options.vg, vg_ids):
-        clip_job = Job.wrapJobFn(clip_vg, options, config, vg_path, vg_id, bed_id,
-                                 disk=vg_id.size * 2, memory=vg_id.size * 4)
-        if bed_id:
-            bed_cat_job.addFollowOn(clip_job)
-        else:
-            root_job.addChild(clip_job)
-        clipped_vg_ids.append(clip_job.rv(0))
-        clipped_stats_list.append(clip_job.rv(1))
+        full_job = Job.wrapJobFn(clip_vg, options, config, vg_path, vg_id, 'full',
+                                disk=vg_id.size * 2, memory=vg_id.size * 4)
+        root_job.addChild(full_job)
+        full_vg_ids.append(full_job.rv(0))
+    prev_job = root_job
     
     # join the ids
-    if not options.preserveIDs:
-        join_job = root_job.addFollowOnJobFn(join_vg, options, config, clipped_vg_ids,
-                                             disk=sum([f.size for f in vg_ids]))
-        clipped_vg_ids = [join_job.rv(i) for i in range(len(vg_ids))]
-    else:
-        join_job = root_job
+    join_job = prev_job.addFollowOnJobFn(join_vg, options, config, full_vg_ids,
+                                         disk=sum([f.size for f in vg_ids]))
+    full_vg_ids = [join_job.rv(i) for i in range(len(vg_ids))]
+    prev_job = join_job
 
-    # join the stats
-    clipped_stats = root_job.addFollowOnJobFn(cat_stats, clipped_stats_list).rv()
-
-    # optional clipping -- we do this down here after joining and normalization so
-    # our graph is id-compatible with a graph that wasn't clipped (but run with same parameters otherwise)
-    if options.vgClipOpts:
+    # run the "clip" phase to do the clip-vg clipping
+    clip_vg_ids = []
+    clipped_stats = None 
+    if options.clip:
         clip_root_job = Job()
-        join_job.addFollowOn(clip_root_job)
-        for i in range(len(vg_ids)):
-            vg_clip_job = clip_root_job.addChildJobFn(vg_clip_vg, options, config, options.vg[i], clipped_vg_ids[i],
-                                                      disk=vg_ids[i].size * 2)
-            join_job.addFollowOn(vg_clip_job)
-            clipped_vg_ids[i] = vg_clip_job.rv()
-        join_job = clip_root_job
+        prev_job.addFollowOn(clip_root_job)
+        clip_vg_stats = []
+        for vg_path, vg_id, input_vg_id in zip(options.vg, full_vg_ids, vg_ids):
+            clip_job = Job.wrapJobFn(clip_vg, options, config, vg_path, vg_id, 'clip',
+                                     disk=input_vg_id.size * 2, memory=input_vg_id.size * 4)
+            clip_root_job.addChild(clip_job)
+            clip_vg_ids.append(clip_job.rv(0))
+            clip_vg_stats.append(clip_job.rv(1))
+ 
+        # join the stats
+        clipped_stats = clip_root_job.addFollowOnJobFn(cat_stats, clip_vg_stats).rv()
+        prev_job = clip_root_job
 
-    # make a gfa for each
-    gfa_root_job = Job()
-    join_job.addFollowOn(gfa_root_job)
-    clipped_gfa_ids = []
-    for i in range(len(options.vg)):
-        vg_path = options.vg[i]
-        clipped_id = clipped_vg_ids[i]
-        vg_id = vg_ids[i]
-        gfa_job = gfa_root_job.addChildJobFn(vg_to_gfa, options, config, vg_path, clipped_id,
-                                             disk=vg_id.size * 5)
-        clipped_gfa_ids.append(gfa_job.rv())
+    # run the "filter" phase to do the vg clip clipping
+    filter_vg_ids = []
+    if options.filter:
+        filter_root_job = Job()
+        prev_job.addFollowOn(filter_root_job)
+        for vg_path, vg_id, input_vg_id in zip(options.vg, clip_vg_ids, vg_ids):
+            filter_job = filter_root_job.addChildJobFn(vg_clip_vg, options, config, vg_path, vg_id, 
+                                                       disk=input_vg_id.size * 2)
+            filter_vg_ids.append(filter_job.rv())
+        prev_job = filter_root_job
 
-    # merge up the gfas and make the various vg indexes
-    gfa_merge_job = gfa_root_job.addFollowOnJobFn(vg_indexes, options, config, clipped_gfa_ids,
-                                                  cores=options.indexCores,
-                                                  disk=sum(f.size for f in vg_ids) * 5)
-    out_dicts = [gfa_merge_job.rv()]
-                                
-    # optional vcf
-    if options.vcf:
-        deconstruct_job = gfa_merge_job.addFollowOnJobFn(make_vcf, options.outName, options.reference, out_dicts[0],
-                                                         max_ref_allele=options.vcfbub,
-                                                         cores=options.indexCores,
-                                                         disk = sum(f.size for f in vg_ids) * 2)
-        out_dicts.append(deconstruct_job.rv())
-
-    # optional vcf with different reference
-    if options.vcfReference:
-        ref_deconstruct_job = gfa_merge_job.addFollowOnJobFn(make_vcf, options.outName, options.vcfReference, out_dicts[0],
-                                                             max_ref_allele=options.vcfbub,
-                                                             tag=options.vcfReference + '.',
-                                                             cores=options.indexCores,
-                                                             disk = sum(f.size for f in vg_ids) * 2)
-        out_dicts.append(ref_deconstruct_job.rv())
-
-    # optional giraffe
-    if options.giraffe:
-        giraffe_job = gfa_merge_job.addFollowOnJobFn(make_giraffe_indexes, options, out_dicts[0],
-                                                     cores=options.giraffeCores,
-                                                     disk = sum(f.size for f in vg_ids) * 4)
-        out_dicts.append(giraffe_job.rv())
+    # set up our whole-genome output
+    out_dicts = []
 
     # optional hal merge
     if hal_ids:
@@ -282,90 +241,83 @@ def graphmap_join_workflow(job, options, config, vg_ids, hal_ids, unclip_seq_id_
                                           cores = 1,
                                           disk=sum(f.size for f in hal_ids) * 2)
         hal_id_dict = hal_merge_job.rv()
-        if unclip_seq_id_map:
-            # optional hal unclip
-            unzip_seq_ids_job = root_job.addChildJobFn(unzip_seqfile, unclip_seq_id_map,
-                                                       disk=sum(f.size for f in hal_ids) * 2)
-            hal_unclip_job = unzip_seq_ids_job.addFollowOnJobFn(unclip_hal, hal_merge_job.rv(), unzip_seq_ids_job.rv(),
-                                                                disk=sum(f.size for f in hal_ids) * 5)
-            hal_merge_job.addFollowOn(hal_unclip_job)
-            hal_id_dict = hal_unclip_job.rv()
-
         out_dicts.append(hal_id_dict)
-    
-    return clipped_vg_ids, clipped_stats, out_dicts
 
-def clip_vg(job, options, config, vg_path, vg_id, bed_id):
+    workflow_phases = [('full', full_vg_ids, join_job)]
+    if options.clip:
+        workflow_phases.append(('clip', clip_vg_ids, clip_root_job))
+    if options.filter:
+        workflow_phases.append(('filter', filter_vg_ids, filter_root_job))        
+    for workflow_phase, phase_vg_ids, phase_root_job in workflow_phases:
+        tag = ''
+        if workflow_phase == 'filter':
+            tag = 'd{}.'.format(options.filter)
+        elif workflow_phase == 'full':
+            tag = 'full.'
+        
+        # make a gfa for each
+        gfa_root_job = Job()
+        phase_root_job.addFollowOn(gfa_root_job)
+        gfa_ids = []
+        for vg_path, vg_id, input_vg_id in zip(options.vg, phase_vg_ids, vg_ids):
+            gfa_job = gfa_root_job.addChildJobFn(vg_to_gfa, options, config, vg_path, vg_id,
+                                                 disk=input_vg_id.size * 5)
+            gfa_ids.append(gfa_job.rv())
+
+        # merge up the gfas and make the various vg indexes
+        gfa_merge_job = gfa_root_job.addFollowOnJobFn(make_vg_indexes, options, config, gfa_ids,
+                                                      tag=tag,
+                                                      cores=options.indexCores,
+                                                      disk=sum(f.size for f in vg_ids) * 5)
+        out_dicts.append(gfa_merge_job.rv())
+        prev_job = gfa_merge_job
+
+        # optional vcf
+        if workflow_phase in options.vcf:
+            for vcf_ref in options.vcfReference:
+                vcftag = vcf_ref + '.' + tag if vcf_ref != options.reference[0] else tag
+                deconstruct_job = prev_job.addFollowOnJobFn(make_vcf, options.outName, vcf_ref, out_dicts[-1],
+                                                            max_ref_allele=options.vcfbub,
+                                                            tag=vcftag,
+                                                            cores=options.indexCores,
+                                                            disk = sum(f.size for f in vg_ids) * 2)
+                out_dicts.append(deconstruct_job.rv())
+
+        # optional giraffe
+        if workflow_phase in options.giraffe:
+            giraffe_job = gfa_merge_job.addFollowOnJobFn(make_giraffe_indexes, options, out_dicts[-1],
+                                                         tag=tag,
+                                                         cores=options.indexCores,
+                                                         disk = sum(f.size for f in vg_ids) * 4)
+            out_dicts.append(giraffe_job.rv())
+
+    
+    return full_vg_ids, clip_vg_ids, clipped_stats, filter_vg_ids, out_dicts
+
+def clip_vg(job, options, config, vg_path, vg_id, phase):
     """ run clip-vg 
     """
+    assert phase in ['full', 'clip']
+    
     work_dir = job.fileStore.getLocalTempDir()
-    is_decoy = vg_path == options.decoyGraph
     vg_path = os.path.join(work_dir, os.path.basename(vg_path))
     job.fileStore.readGlobalFile(vg_id, vg_path)
-    bed_path = os.path.join(work_dir, 'clip-bed.bed')
-    if bed_id:
-        job.fileStore.readGlobalFile(bed_id, bed_path)
 
     clipped_path = vg_path + '.clip'
-    out_path = vg_path + '.out'
     clipped_bed_path = vg_path + '.clip.bed'
 
     graph_event = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap"), "assemblyName", default="_MINIGRAPH_")
 
-    # remove masked unaligned regions with clip-vg
-    drop_mini = False
-    cmd = ['clip-vg', vg_path, '-f']
-    if options.clipLength is not None and not is_decoy:
-        cmd += ['-u', str(options.clipLength)]
-        drop_mini = True
-    if options.clipNonMinigraph:
-        cmd += ['-a', graph_event]
-        drop_mini = True
-    for rs in options.rename:
-        cmd += ['-r', rs]
-    if options.reference:
-        cmd += ['-e', options.reference]
-    if bed_id and not is_decoy:
-        cmd += ['-b', bed_path]
-    cmd += ['-o', clipped_bed_path]
-    if drop_mini:
-        # get rid of minigraph if we're doing any kind of clipping
-        # (keep otherwise, since we may want to use it to clip with -a in the future)
-        cmd += ['-d', graph_event]
-
-    if getOptionalAttrib(findRequiredNode(config.xmlRoot, "hal2vg"), "includeMinigraph", typeFn=bool, default=False):
-        # our vg file has minigraph sequences -- we'll filter them out, along with any nodes
-        # that don't appear in a non-minigraph path
-        cmd += ['-d', graph_event]
-        # but... we'll leave the minigraph path fragments that are aligned to anything else in the vg's
-        cmd += ['-L']
-        
-    cactus_call(parameters=cmd, outfile=clipped_path)
-        
-    # optional normalization.  this will (in theory) correct a lot of small underalignments due to cactus bugs
-    # by zipping up redundant nodes. done before clip-vg otherwise ref paths not guaranteed to be forwardized
-    # todo: would be nice if clip-vg worked on stdin
-    if options.normalizeIterations:
-        normalized_path = clipped_path + '.normalized'
-        mod_cmd = ['vg', 'mod', '-O', '-U', str(options.normalizeIterations), clipped_path]
-        if options.reference:
-            mod_cmd += ['-z', options.reference]
-        cactus_call(parameters=mod_cmd, outfile=normalized_path)
-        # worth it
-        cactus_call(parameters=['vg', 'validate', normalized_path])
-        clipped_path = normalized_path
-
-    # GFAFfix is a tool written just to normalize graphs, and alters a (faster) alternative to vg
-    # (though requires GFA conversion)
-    if options.gfaffix:
-        normalized_path = clipped_path + '.gfaffixed'
+    # optional gfaffixing -- only happens in full
+    if phase == 'full' and getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_join"), "gfaffix", typeFn=bool, default=True):
+        normalized_path = vg_path + '.gfaffixed'
         gfa_in_path = vg_path + '.gfa'
         gfa_out_path = normalized_path + '.gfa'
         # GFAffix's --dont_collapse option doesn't work on W-lines, so we strip them for now with -W
-        cactus_call(parameters=['vg', 'convert', '-W', '-f', clipped_path], outfile=gfa_in_path)
+        cactus_call(parameters=['vg', 'convert', '-W', '-f', vg_path], outfile=gfa_in_path)
         fix_cmd = ['gfaffix', gfa_in_path, '--output_refined', gfa_out_path, '--check_transformation']
         if options.reference:
-            fix_cmd += ['--dont_collapse', options.reference + '*']
+            fix_cmd += ['--dont_collapse', options.reference[0] + '*']
         cactus_call(parameters=fix_cmd)
         # GFAffix strips the header, until this is fixed we need to add it back (for the RS tag)
         gfa_header = cactus_call(parameters=['head', '-1', gfa_in_path], check_output=True).strip()
@@ -374,83 +326,100 @@ def clip_vg(job, options, config, vg_path, vg_id, bed_id):
         conv_cmd = [['vg', 'convert', '-g', '-p', gfa_out_path]]
         if options.reference:
             # GFAFfix can leave uncovered nodes with --dont_collapse.  We filter out here so they dont cause trouble later
-            conv_cmd.append(['vg', 'clip', '-d', '1', '-P', options.reference, '-'])
+            conv_cmd.append(['vg', 'clip', '-d', '1', '-P', options.reference[0], '-'])
         # GFAFfix doesn't unchop, so we do that in vg after
         conv_cmd.append(['vg', 'mod', '-u', '-'])
-        cactus_call(parameters=conv_cmd, outfile=normalized_path)
+        cactus_call(parameters=conv_cmd, outfile=normalized_path)        
+        vg_path = normalized_path
+
+    # run clip-vg no matter what, but we don't actually remove anything in full
+    cmd = ['clip-vg', vg_path, '-f']
+
+    # don't clip the (first) reference, also enforces it's in forward orientation (for rGFA)
+    cmd += ['-e', options.reference[0]]
+
+    if getOptionalAttrib(findRequiredNode(config.xmlRoot, "hal2vg"), "includeMinigraph", typeFn=bool, default=False):
+        # our vg file has minigraph sequences -- we'll filter them out, along with any nodes
+        # that don't appear in a non-minigraph path
+        cmd += ['-d', graph_event]
+        if phase == 'full':
+            # but... we'll leave the minigraph path fragments that are aligned to anything else in the vg's
+            cmd += ['-L']
+
+    if phase == 'clip':
+        if options.clip:
+            cmd += ['-u', str(options.clip)]
+            if getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_join"), "clipNonMinigraph", typeFn=bool, default=True):
+                cmd += ['-a', graph_event]
+            cmd += ['-o', clipped_bed_path]
+
+    # and we sort by id on the first go-around
+    if phase == 'full':
+        cmd = [cmd, ['vg', 'ids', '-s', '-']]
         
-        clipped_path = normalized_path
-
-    # also forwardize just in case
-    if options.reference and (options.normalizeIterations or options.gfaffix):
-        forward_path = clipped_path + '.forward'
-        cmd = ['clip-vg', clipped_path, '-e', options.reference]
-        cactus_call(parameters=cmd, outfile=forward_path)
-        clipped_path = forward_path
-
-    # sort by id
-    if not options.preserveIDs:
-        cmd = ['vg', 'ids', '-s', clipped_path]
-        cactus_call(parameters=cmd, outfile=out_path)
-    else:
-        out_path = clipped_path
+    cactus_call(parameters=cmd, outfile=clipped_path)
 
     # worth it
-    cactus_call(parameters=['vg', 'validate', out_path])
+    cactus_call(parameters=['vg', 'validate', clipped_path])
 
+    if phase == 'full':
+        job.fileStore.deleteGlobalFile(vg_id)
+        
     # keep some stats of the chromosomal vg file:
     # Path Lengths
-    chr_name = os.path.splitext(os.path.basename(vg_path))[0]
-    path_stats_path = vg_path + '.path-stats.tsv'
-    cactus_call(parameters=[['vg', 'paths', '-E', '-v', out_path],
-                            ['awk', '{{print "{}\t" $0}}'.format(chr_name)]],
-                outfile=path_stats_path)
-    # Nodes, edges and total length
-    graph_stats_path = vg_path + '.graph-stats.tsv'
-    cactus_call(parameters=[['vg', 'stats', '-l', '-z', out_path],
-                            ['awk', '{{print "{}\t" $0}}'.format(chr_name)]],
-                outfile=graph_stats_path)
-    # Stick the contig identifier onto the clipped regions bed
-    clipped_bed_chr_path = clipped_bed_path + '.named'
-    cactus_call(parameters=['awk',  '{{print $0 "\t{}"}}'.format(chr_name), clipped_bed_path],
-                outfile=clipped_bed_chr_path)
-    sample_stats_path = vg_path + '.sample-stats.tsv'
-    sample_stats = {}
-    with open(path_stats_path, 'r') as path_stats_file:
-        for line in path_stats_file:
-            toks = line.split()
-            contig_name = toks[1]
-            contig_length = int(toks[2])
-            sample_name = contig_name if '#' not in contig_name else '#'.join(contig_name.split('#')[:2])
-            if sample_name not in sample_stats:
-                sample_stats[sample_name] = contig_length
-            else:
-                sample_stats[sample_name] += contig_length
-    with open(sample_stats_path, 'w') as sample_stats_file:
-        for sample in sorted(sample_stats.keys()):
-            sample_stats_file.write("{}\t{}\t{}\n".format(chr_name, sample, sample_stats[sample]))
+    if phase == 'clip':
+        chr_name = os.path.splitext(os.path.basename(vg_path))[0]
+        path_stats_path = vg_path + '.path-stats.tsv'
+        cactus_call(parameters=[['vg', 'paths', '-E', '-v', clipped_path],
+                                ['awk', '{{print "{}\t" $0}}'.format(chr_name)]],
+                    outfile=path_stats_path)
+        # Nodes, edges and total length
+        graph_stats_path = vg_path + '.graph-stats.tsv'
+        cactus_call(parameters=[['vg', 'stats', '-l', '-z', clipped_path],
+                                ['awk', '{{print "{}\t" $0}}'.format(chr_name)]],
+                    outfile=graph_stats_path)
+        # Stick the contig identifier onto the clipped regions bed
+        clipped_bed_chr_path = clipped_bed_path + '.named'
+        cactus_call(parameters=['awk',  '{{print $0 "\t{}"}}'.format(chr_name), clipped_bed_path],
+                    outfile=clipped_bed_chr_path)
+        sample_stats_path = vg_path + '.sample-stats.tsv'
+        sample_stats = {}
+        with open(path_stats_path, 'r') as path_stats_file:
+            for line in path_stats_file:
+                toks = line.split()
+                contig_name = toks[1]
+                contig_length = int(toks[2])
+                sample_name = contig_name if '#' not in contig_name else '#'.join(contig_name.split('#')[:2])
+                if sample_name not in sample_stats:
+                    sample_stats[sample_name] = contig_length
+                else:
+                    sample_stats[sample_name] += contig_length
+        with open(sample_stats_path, 'w') as sample_stats_file:
+            for sample in sorted(sample_stats.keys()):
+                sample_stats_file.write("{}\t{}\t{}\n".format(chr_name, sample, sample_stats[sample]))
 
-    out_stats = { 'clip-stats.bed' : job.fileStore.writeGlobalFile(clipped_bed_chr_path),
-                  'path-stats.tsv' : job.fileStore.writeGlobalFile(path_stats_path),
-                  'graph-stats.tsv' : job.fileStore.writeGlobalFile(graph_stats_path),
-                  'sample-stats.tsv' : job.fileStore.writeGlobalFile(sample_stats_path) }
-            
-    return job.fileStore.writeGlobalFile(out_path), out_stats
+        out_stats = { 'clip-stats.bed' : job.fileStore.writeGlobalFile(clipped_bed_chr_path),
+                      'path-stats.tsv' : job.fileStore.writeGlobalFile(path_stats_path),
+                      'graph-stats.tsv' : job.fileStore.writeGlobalFile(graph_stats_path),
+                      'sample-stats.tsv' : job.fileStore.writeGlobalFile(sample_stats_path) }
+    else:
+        out_stats = None
+    return job.fileStore.writeGlobalFile(clipped_path), out_stats
 
 def vg_clip_vg(job , options, config, vg_path, vg_id):
     """ run vg clip, chaining multiple invocations if desired.
     """
     work_dir = job.fileStore.getLocalTempDir()
-    is_decoy = vg_path == options.decoyGraph
     vg_path = os.path.join(work_dir, os.path.basename(vg_path))
     job.fileStore.readGlobalFile(vg_id, vg_path)
     clipped_path = vg_path + '.clip'
 
-    clip_cmd = ['vg', 'clip', vg_path, '-P', options.reference] +  options.vgClipOpts[0].split()
-    if len(options.vgClipOpts) > 1:
-        clip_cmd = [clip_cmd]
-        for clip_opts in options.vgClipOpts[1:]:
-            clip_cmd.append(['vg', 'clip', '-', '-P', options.reference] +  clip_opts.split())
+    clip_cmd = ['vg', 'clip', vg_path, '-d', str(options.filter)]
+    for ref in options.reference:
+        clip_cmd += ['-P', ref]
+    min_fragment = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_join"), "minFilterFragment", typeFn=int, default=None)
+    if min_fragment:
+        clip_cmd += ['-d', str(min_fragment)]
 
     cactus_call(parameters=clip_cmd, outfile=clipped_path)
 
@@ -481,18 +450,18 @@ def vg_to_gfa(job, options, config, vg_path, vg_id):
     job.fileStore.readGlobalFile(vg_id, vg_path)
     out_path = vg_path + '.gfa'
 
-    cmd = ['vg', 'convert', '-f', '-Q', options.reference, os.path.basename(vg_path), '-B']
+    cmd = ['vg', 'convert', '-f', '-Q', options.reference[0], os.path.basename(vg_path), '-B']
 
     cactus_call(parameters=cmd, outfile=out_path, work_dir=work_dir)
 
     return job.fileStore.writeGlobalFile(out_path)
 
-def vg_indexes(job, options, config, gfa_ids):
+def make_vg_indexes(job, options, config, gfa_ids, tag=''):
     """ merge of the gfas, then make gbz / snarls / trans
     """ 
     work_dir = job.fileStore.getLocalTempDir()
     vg_paths = []
-    merge_gfa_path = os.path.join(work_dir, 'merged.gfa')
+    merge_gfa_path = os.path.join(work_dir, '{}merged.gfa'.format(tag))
 
     graph_event = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap"), "assemblyName", default="_MINIGRAPH_")
     
@@ -502,44 +471,42 @@ def vg_indexes(job, options, config, gfa_ids):
         job.fileStore.readGlobalFile(gfa_id, gfa_path, mutable=True)
         cmd = ['grep', '-v', '{}^W	{}'.format('^H\|' if i else '', graph_event), gfa_path]
         # add in the additional references here
-        if i == 0 and options.otherReferences:
+        if i == 0 and len(options.reference) > 1:
             # todo: this seems hacky!! also, maybe some path-local information needs changing?
             # if so, will need a new tool (or perhaps interface on vg paths?)
-            cmd = [cmd, ['sed', '-e', '1s/{}/{} {}/'.format(options.reference, options.reference, ' '.join(options.otherReferences)),
+            cmd = [cmd, ['sed', '-e', '1s/{}/{}/'.format(options.reference[0], ' '.join(options.reference)),
                          '-e', '1s/{}//'.format(graph_event)]]
         cactus_call(parameters=cmd, outfile=merge_gfa_path, outappend=True)
         os.remove(gfa_path)
+        job.fileStore.deleteGlobalFile(gfa_id)
 
     # make the gbz
-    gbz_path = os.path.join(work_dir, 'merged.gbz')
+    gbz_path = os.path.join(work_dir, '{}merged.gbz'.format(tag))
     cactus_call(parameters=['vg', 'gbwt', '-G', merge_gfa_path, '--gbz-format', '-g', gbz_path])
 
     # zip the gfa
     cactus_call(parameters=['bgzip', merge_gfa_path, '--threads', str(job.cores)])
     gfa_path = merge_gfa_path + '.gz'
 
-    # worth it
-    cactus_call(parameters=['vg', 'validate', gbz_path])
-
     # make the snarls
-    snarls_path = os.path.join(work_dir, 'merged.snarls')
+    snarls_path = os.path.join(work_dir, '{}merged.snarls'.format(tag))
     cactus_call(parameters=['vg', 'snarls', gbz_path, '-T', '-t', str(job.cores)], outfile=snarls_path)
                             
-    return { 'gfa.gz' : job.fileStore.writeGlobalFile(gfa_path),
-             'gbz' : job.fileStore.writeGlobalFile(gbz_path),
-             'snarls' : job.fileStore.writeGlobalFile(snarls_path) }
+    return { '{}gfa.gz'.format(tag) : job.fileStore.writeGlobalFile(gfa_path),
+             '{}gbz'.format(tag) : job.fileStore.writeGlobalFile(gbz_path),
+             '{}snarls'.format(tag) : job.fileStore.writeGlobalFile(snarls_path) }
 
 def make_vcf(job, out_name, vcf_ref, index_dict, tag='', max_ref_allele=None):
     """ make the vcf
     """ 
     work_dir = job.fileStore.getLocalTempDir()
-    gbz_path = os.path.join(work_dir, os.path.basename(out_name) + '.gbz')
-    snarls_path = os.path.join(work_dir, os.path.basename(out_name) + '.snarls')
+    gbz_path = os.path.join(work_dir, tag + os.path.basename(out_name) + '.gbz')
+    snarls_path = os.path.join(work_dir, tag + os.path.basename(out_name) + '.snarls')
     job.fileStore.readGlobalFile(index_dict['gbz'], gbz_path)
     job.fileStore.readGlobalFile(index_dict['snarls'], snarls_path)
 
     # make the vcf
-    vcf_path = os.path.join(work_dir, 'merged.vcf.gz')
+    vcf_path = os.path.join(work_dir, '{}merged.vcf.gz'.format(tag))
     cactus_call(parameters=[['vg', 'deconstruct', gbz_path, '-P', vcf_ref, '-a', '-r', snarls_path, 
                              '-t', str(job.cores)],
                             ['bgzip', '--threads', str(job.cores)]],
@@ -561,16 +528,16 @@ def make_vcf(job, out_name, vcf_ref, index_dict, tag='', max_ref_allele=None):
 
     return output_dict
     
-def make_giraffe_indexes(job, options, index_dict):
+def make_giraffe_indexes(job, options, index_dict, tag=''):
     """ make giraffe-specific indexes: distance and minimaer """
     work_dir = job.fileStore.getLocalTempDir()
-    gbz_path = os.path.join(work_dir, os.path.basename(options.outName) + '.gbz')
-    snarls_path = os.path.join(work_dir, os.path.basename(options.outName) + '.snarls')
-    job.fileStore.readGlobalFile(index_dict['gbz'], gbz_path)
-    job.fileStore.readGlobalFile(index_dict['snarls'], snarls_path)
+    gbz_path = os.path.join(work_dir, tag + os.path.basename(options.outName) + '.gbz')
+    snarls_path = os.path.join(work_dir, tag + os.path.basename(options.outName) + '.snarls')
+    job.fileStore.readGlobalFile(index_dict['{}gbz'.format(tag)], gbz_path)
+    job.fileStore.readGlobalFile(index_dict['{}snarls'.format(tag)], snarls_path)
 
     # make the distance index
-    dist_path = os.path.join(work_dir, os.path.basename(options.outName) + '.dist')
+    dist_path = os.path.join(work_dir, tag + os.path.basename(options.outName) + '.dist')
     cactus_call(parameters=['vg', 'index', '-t', str(job.cores), '-j', dist_path, '-s', snarls_path, gbz_path])
 
     # make the minimizer index
@@ -578,8 +545,8 @@ def make_giraffe_indexes(job, options, index_dict):
     cactus_call(parameters=['vg', 'minimizer', '-k', '29', '-w', '11', '-t', str(job.cores),
                             '-d', dist_path, '-o', min_path, gbz_path])                            
                             
-    return { 'min' : job.fileStore.writeGlobalFile(min_path),
-             'dist' : job.fileStore.writeGlobalFile(dist_path) }
+    return { '{}min'.format(tag) : job.fileStore.writeGlobalFile(min_path),
+             '{}dist'.format(tag) : job.fileStore.writeGlobalFile(dist_path) }
 
 def merge_hal(job, options, hal_ids):
     """ call halMergeChroms to make one big hal file out of the chromosome hal files """
@@ -603,7 +570,7 @@ def merge_hal(job, options, hal_ids):
            '--progress']
     cactus_call(parameters=cmd, work_dir = work_dir)
 
-    return { 'hal' : job.fileStore.writeGlobalFile(merged_path) }
+    return { 'full.hal' : job.fileStore.writeGlobalFile(merged_path) }
 
 def unzip_seqfile(job, seq_id_map):
     """ halUnclip needs uncompressed everythin, so we do it here relying on extensions """
@@ -657,19 +624,30 @@ def cat_stats(job, stats_dict_list):
         catFiles([job.fileStore.readGlobalFile(sd[key]) for sd in stats_dict_list], merged_dict[key])
         merged_dict[key] = job.fileStore.writeGlobalFile(merged_dict[key])
     return merged_dict
-    
-def export_join_data(toil, options, clip_ids, clip_stats, idx_maps):
+
+def export_join_data(toil, options, full_ids, clip_ids, clip_stats, filter_ids, idx_maps):
     """ download all the output data
     """
 
-    # download the clip vgs
-    clip_base = os.path.join(options.outDir, 'clip-{}'.format(options.outName))
+    # make a directory for the chromosomal vgs
+    clip_base = os.path.join(options.outDir, '{}.chroms'.format(options.outName))
     if not clip_base.startswith('s3://') and not os.path.isdir(clip_base):
         os.makedirs(clip_base)
 
-    for vg_path, vg_id,  in zip(options.vg, clip_ids):
-        toil.exportFile(vg_id, makeURL(os.path.join(clip_base, os.path.basename(vg_path))))
+    # download the "full" vgs
+    for vg_path, full_id,  in zip(options.vg, full_ids):
+        name = os.path.splitext(vg_path)[0] + '.full.vg'
+        toil.exportFile(full_id, makeURL(os.path.join(clip_base, os.path.basename(name))))
 
+    # download the "clip" vgs
+    for vg_path, clip_id,  in zip(options.vg, clip_ids):
+        name = os.path.splitext(vg_path)[0] + '.vg'
+        toil.exportFile(clip_id, makeURL(os.path.join(clip_base, os.path.basename(name))))
+
+    # download the "filter" vgs
+    for vg_path, filter_id,  in zip(options.vg, filter_ids):
+        name = os.path.splitext(vg_path)[0] + '.d{}.vg'.format(options.filter)
+        toil.exportFile(filter_id, makeURL(os.path.join(clip_base, os.path.basename(name))))
     # download the stats files 
     for stats_file in clip_stats.keys():
         toil.exportFile(clip_stats[stats_file], makeURL(os.path.join(clip_base, stats_file)))

--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -358,13 +358,13 @@ class TestCase(unittest.TestCase):
                     name = os.path.basename(toks[1])
                     subprocess.check_call(['wget', toks[1]], cwd=self.tempDir)
                     mg_cmd += [os.path.join(self.tempDir, name)]
-        mg_path = os.path.join(self.tempDir, 'refgraph.gfa')
+        mg_path = os.path.join(self.tempDir, 'refgraph.sv.gfa')
         with open(mg_path, 'w') as mg_file:
             subprocess.check_call(mg_cmd, stdout=mg_file)
 
         # do the mapping
         paf_path = os.path.join(self.tempDir, 'aln.paf')
-        fa_path = os.path.join(self.tempDir, 'refgraph.gfa.fa')
+        fa_path = os.path.join(self.tempDir, 'refgraph.sv.gfa.fa')
         # todo: it'd be nice to have an interface for setting tag to something not latest or commit
         if binariesMode == 'docker':
             cactus_opts += ['--latest']
@@ -398,13 +398,13 @@ class TestCase(unittest.TestCase):
                     events.append(toks[0])
         
         # build the minigraph
-        mg_path = os.path.join(self.tempDir, 'yeast.gfa.gz')
+        mg_path = os.path.join(self.tempDir, 'yeast.sv.gfa.gz')
         mg_cmd = ['cactus-minigraph', self._job_store(binariesMode), seq_file_path, mg_path, '--reference', 'S288C'] + cactus_opts
         subprocess.check_call(mg_cmd)
                 
         # run graphmap in base mode
         paf_path = os.path.join(self.tempDir, 'yeast.paf')
-        fa_path = os.path.join(self.tempDir, 'yeast.gfa.fa')        
+        fa_path = os.path.join(self.tempDir, 'yeast.sv.gfa.fa')        
         subprocess.check_call(['cactus-graphmap', self._job_store(binariesMode), seq_file_path, mg_path, paf_path,
                                '--outputFasta', fa_path, '--delFilter', '2000000'] + cactus_opts + ['--mapCores', '1'])
             


### PR DESCRIPTION
Stacks on #831 (to me merged first)

Right now, the recommended recipe is to run `cactus-graphmap-join` three times to make the `full`, `clipped` and `frequency-filtered` graphs.  This is mentioned in the larger examples, but still pretty confusing and error-prone.  It's also really easy to end up with giraffe indexes that don't work well. Or try to make a distance index with an unclipped graph and run out of memory.  Or do no clipping because it wasn't mentioned in the quick start, etc. 

Anyway, this PR attempts to streamline things
* all three graphs are made with a single invocation of `cactus-graphmap-join`
* there are sensible defaults (vcf from the clipped graph, giraffe indexes from a "d2" filtered graph)
* some cli options are moved into the config (ie gfaffix is on by default unless turned off there)
* tons of older clipping logic (from bed files, unclipping hals) removed entirely as it's no longer maintained.
