### PR TITLE
Include mafTools

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,7 +28,6 @@ test-job:
     - CACTUS_BINARIES_MODE=local SON_TRACE_DATASETS=$(pwd)/cactusTestData CACTUS_TEST_CHOICE=normal make test
     - make -j 8 hal_test
     - export CGL_DEBUG=ultra
-    - make taf_test
     - unset CGL_DEBUG
     - make clean
     - make docker
@@ -36,6 +35,7 @@ test-job:
     - docker login --username $QUAY_USERNAME --password $QUAY_PASSWORD quay.io
     - make push_only
     - numcpu=8 build-tools/downloadPangenomeTools
+    - numcpu=8 build-tools/downloadMafTools	 
     - python3.8 -m pip install -U .	 
     - make -j 8 evolver_test
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,8 +27,6 @@ test-job:
     - CGL_DEBUG=ultra make -j 8
     - CACTUS_BINARIES_MODE=local SON_TRACE_DATASETS=$(pwd)/cactusTestData CACTUS_TEST_CHOICE=normal make test
     - make -j 8 hal_test
-    - export CGL_DEBUG=ultra
-    - unset CGL_DEBUG
     - make clean
     - make docker
     # todo: should we check some kind of gitlab state before doing this?  I think current logic pushes every run....

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,6 +34,7 @@ test-job:
     # todo: should we check some kind of gitlab state before doing this?  I think current logic pushes every run....
     - docker login --username $QUAY_USERNAME --password $QUAY_PASSWORD quay.io
     - make push_only
+    - make -j 8	 
     - numcpu=8 build-tools/downloadPangenomeTools
     - numcpu=8 build-tools/downloadMafTools	 
     - python3.8 -m pip install -U .	 

--- a/.gitmodules
+++ b/.gitmodules
@@ -25,6 +25,3 @@
 [submodule "submodules/lastz"]
 	path = submodules/lastz
 	url = https://github.com/ComparativeGenomicsToolkit/lastz.git
-[submodule "submodules/taf"]
-	path = submodules/taf
-	url = https://github.com/ComparativeGenomicsToolkit/taf.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,9 @@ RUN cd /home/cactus/bin && for i in wigToBigWig faToTwoBit bedToBigBed bigBedToB
 # download tools used for pangenome pipeline
 RUN cd /home/cactus && ./build-tools/downloadPangenomeTools
 
+# download tools used for working with MAF
+RUN cd /home/cactus && ./build-tools/downloadMafTools
+
 # remove test executables
 RUN cd /home/cactus && rm -f ${binPackageDir}/bin/*test ${binPackageDir}/bin/*tests ${binPackageDir}/bin/*Test ${binPackageDir}/bin/*Tests
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/comparative-genomics-toolkit/ubuntu:22.04 AS builder
 
 # apt dependencies for build
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential git python3 python3-dev python3-pip zlib1g-dev wget libbz2-dev pkg-config libhdf5-dev liblzo2-dev libtokyocabinet-dev wget liblzma-dev libxml2-dev libssl-dev libpng-dev uuid-dev libcurl4-gnutls-dev libffi-dev python3-virtualenv rsync
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential git python3 python3-dev python3-pip zlib1g-dev wget libbz2-dev pkg-config libhdf5-dev liblzo2-dev libtokyocabinet-dev wget liblzma-dev libxml2-dev libssl-dev libpng-dev uuid-dev libcurl4-gnutls-dev libffi-dev python3-virtualenv rsync python-is-python3
 
 # build cactus binaries
 RUN mkdir -p /home/cactus

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ modules = api setup fasta paf caf bar hal reference pipeline preprocessor
 
 # submodules are in multiple pass to handle dependencies cactus2hal being dependent on
 # both cactus and sonLib
-submodules1 = sonLib cPecan hal taf matchingAndOrdering pinchesAndCacti abPOA lastz
+submodules1 = sonLib cPecan hal matchingAndOrdering pinchesAndCacti abPOA lastz
 submodules2 = cactus2hal
 submodules = ${submodules1} ${submodules2}
 
@@ -134,8 +134,6 @@ test: ${testModules:%=%_runtest} ${unitTests:%=%_run_unit_test}
 test_blast: ${testModules:%=%_runtest_blast}
 test_nonblast: ${testModules:%=%_runtest_nonblast}
 hal_test: ${halTests:%=%_run_unit_test}
-taf_test:
-	cd submodules/taf && make test
 
 # run one test and save output
 %_runtest: ${versionPy}
@@ -156,57 +154,55 @@ taf_test:
 ${versionPy}:
 	echo "cactus_commit = '${git_commit}'" >$@
 
-bin/mafComparator:
-	rm -rf submodules/mafTools
-	cd submodules && git clone https://github.com/ComparativeGenomicsToolkit/mafTools.git && cd mafTools && git checkout cf144382b3c5a672d58a6798eebe23979c9a6b1f
-	cd submodules/mafTools && sed -i -e 's/-Werror//g' inc/common.mk lib/Makefile && sed -i -e 's/mafExtractor//g' Makefile && make
-	cp submodules/mafTools/bin/mafComparator bin/
+${CWD}/test/mammals-truth.maf:
 	cd ${CWD}/test && wget -q https://raw.githubusercontent.com/UCSantaCruzComputationalGenomicsLab/cactusTestData/master/evolver/mammals/loci1/all.maf -O mammals-truth.maf
+
+${CWD}/test/primates-truth.maf:
 	cd ${CWD}/test && wget -q https://raw.githubusercontent.com/UCSantaCruzComputationalGenomicsLab/cactusTestData/master/evolver/primates/loci1/all.maf -O primates-truth.maf
 
-evolver_test: all bin/mafComparator
+evolver_test: all ${CWD}/test/mammals-truth.maf
 # note: make docker needs to be run beforehand
 	PYTHONPATH="${CWD}/submodules/" CACTUS_DOCKER_ORG=evolvertestdocker CACTUS_USE_LATEST=1 ${PYTHON} -m pytest ${pytestOpts} test/evolverTest.py
 
-evolver_test_local: all bin/mafComparator
+evolver_test_local: all ${CWD}/test/mammals-truth.maf
 	PYTHONPATH="${CWD}/submodules/" CACTUS_BINARIES_MODE=local CACTUS_DOCKER_MODE=0 ${PYTHON} -m pytest ${pytestOpts} -s test/evolverTest.py::TestCase::testEvolverLocal
 
-evolver_test_prepare_wdl: all bin/mafComparator
+evolver_test_prepare_wdl: all ${CWD}/test/mammals-truth.maf
 	PYTHONPATH="${CWD}/submodules/" CACTUS_BINARIES_MODE=local CACTUS_DOCKER_MODE=0 ${PYTHON} -m pytest ${pytestOpts} -s test/evolverTest.py::TestCase::testEvolverPrepareWDL
 
-evolver_test_prepare_toil: all bin/mafComparator
+evolver_test_prepare_toil: all ${CWD}/test/mammals-truth.maf
 	PYTHONPATH="${CWD}/submodules/" CACTUS_BINARIES_MODE=local CACTUS_DOCKER_MODE=0 ${PYTHON} -m pytest ${pytestOpts} -s test/evolverTest.py::TestCase::testEvolverPrepareToil
 
-evolver_test_decomposed_local: all bin/mafComparator
+evolver_test_decomposed_local: all ${CWD}/test/mammals-truth.maf
 	PYTHONPATH="${CWD}/submodules/" CACTUS_BINARIES_MODE=local CACTUS_DOCKER_MODE=0 ${PYTHON} -m pytest ${pytestOpts} -s test/evolverTest.py::TestCase::testEvolverDecomposedLocal
 
-evolver_test_decomposed_docker: all bin/mafComparator
+evolver_test_decomposed_docker: all ${CWD}/test/mammals-truth.maf
 #note make docker needs to be run beforehand
 	PYTHONPATH="${CWD}/submodules/" CACTUS_DOCKER_ORG=evolvertestdocker CACTUS_USE_LATEST=1 ${PYTHON} -m pytest ${pytestOpts} -s test/evolverTest.py::TestCase::testEvolverDecomposedDocker
 
-evolver_test_docker: all bin/mafComparator
+evolver_test_docker: all ${CWD}/test/mammals-truth.maf
 	PYTHONPATH="${CWD}/submodules/" CACTUS_BINARIES_MODE=local CACTUS_DOCKER_MODE=0 ${PYTHON} -m pytest ${pytestOpts} -s test/evolverTest.py::TestCase::testEvolverDocker
 
-evolver_test_prepare_no_outgroup_docker: all bin/mafComparator
+evolver_test_prepare_no_outgroup_docker: all ${CWD}/test/mammals-truth.maf
 #note make docker needs to be run beforehand
 	PYTHONPATH="${CWD}/submodules/" CACTUS_DOCKER_ORG=evolvertestdocker CACTUS_USE_LATEST=1 ${PYTHON} -m pytest ${pytestOpts} -s test/evolverTest.py::TestCase::testEvolverPrepareNoOutgroupDocker
 
-evolver_test_prepare_no_outgroup_local: all bin/mafComparator
+evolver_test_prepare_no_outgroup_local: all ${CWD}/test/mammals-truth.maf
 	PYTHONPATH="${CWD}/submodules/" CACTUS_BINARIES_MODE=local CACTUS_DOCKER_MODE=0 ${PYTHON} -m pytest ${pytestOpts} -s test/evolverTest.py::TestCase::testEvolverPrepareNoOutgroupLocal
 
-evolver_test_update_node_local: bin/mafComparator
+evolver_test_update_node_local: ${CWD}/test/mammals-truth.maf
 	PYTHONPATH="${CWD}/submodules/" CACTUS_BINARIES_MODE=local CACTUS_DOCKER_MODE=0 ${PYTHON} -m pytest ${pytestOpts} -s test/evolverTest.py::TestCase::testEvolverUpdateNodeLocal
 
-evolver_test_update_branch_local: bin/mafComparator
+evolver_test_update_branch_local: ${CWD}/test/mammals-truth.maf
 	PYTHONPATH="${CWD}/submodules/" CACTUS_BINARIES_MODE=local CACTUS_DOCKER_MODE=0 ${PYTHON} -m pytest ${pytestOpts} -s test/evolverTest.py::TestCase::testEvolverUpdateBranchLocal
 
-evolver_test_poa_local: all bin/mafComparator
+evolver_test_poa_local: all ${CWD}/test/mammals-truth.maf
 	PYTHONPATH="${CWD}/submodules/" CACTUS_BINARIES_MODE=local CACTUS_DOCKER_MODE=0 ${PYTHON} -m pytest ${pytestOpts} -s test/evolverTest.py::TestCase::testEvolverPOALocal
 
-evolver_test_refmap_local: all bin/mafComparator
+evolver_test_refmap_local: all ${CWD}/test/primates-truth.maf
 	PYTHONPATH="${CWD}/submodules/" CACTUS_BINARIES_MODE=local CACTUS_DOCKER_MODE=0 ${PYTHON} -m pytest ${pytestOpts} -s test/evolverTest.py::TestCase::testEvolverRefmapLocal
 
-evolver_test_minigraph_local: all bin/mafComparator
+evolver_test_minigraph_local: all ${CWD}/test/primates-truth.maf
 	PYTHONPATH="${CWD}/submodules/" CACTUS_BINARIES_MODE=local CACTUS_DOCKER_MODE=0 ${PYTHON} -m pytest ${pytestOpts} -s test/evolverTest.py::TestCase::testEvolverMinigraphLocal
 
 evolver_test_all_local: evolver_test_local evolver_test_prepare_toil evolver_test_decomposed_local evolver_test_prepare_no_outgroup_local evolver_test_poa_local evolver_test_refmap_local evolver_test_minigraph_local
@@ -258,10 +254,6 @@ suball.hal: suball.sonLib
 	mkdir -p bin
 	-ln -f submodules/hal/bin/* bin/
 	-ln -f submodules/hal/lib/libHal.a submodules/hal/lib/halLib.a
-
-suball.taf: suball.hal
-	cd submodules/taf && HALDIR=../hal make
-	-ln -f submodules/taf/bin/*taf* bin/
 
 suball.abPOA:
 	cd submodules/abPOA && ${MAKE}

--- a/README.md
+++ b/README.md
@@ -77,4 +77,9 @@ In order to run the Minigraph-Cactus pipeline, you must also run
 build-tools/downloadPangenomeTools
 ```
 
+In order to run many of tests, you must also run
+```
+build-tools/downloadMafTools
+```
+
 In order to toggle between local and Docker binaries, use the `--binariesMode` command line option. If `--binariesMode` is not specified, local binaries will be used if found in `PATH`, otherwise a Docker image will be used.

--- a/build-tools/downloadMafTools
+++ b/build-tools/downloadMafTools
@@ -44,7 +44,7 @@ done
 cd ${mafBuildDir}
 git clone https://github.com/ComparativeGenomicsToolkit/mafTools.git
 cd mafTools
-git checkout f37c25fd09a89bb189b22e314bd170f2fddd8f39
+git checkout 40cfa5b503a34b8b0b7799678237e2f13ae8bf36
 find . -name "*.mk" | xargs sed -ie "s/-Werror//g"
 find . -name "Makefile*" | xargs sed -ie "s/-Werror//g"
 # hack in flags support

--- a/build-tools/downloadMafTools
+++ b/build-tools/downloadMafTools
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Download and statically build tools needed for MAF processing
+# - mafTools
+# - taf
+
+# set this to one to make sure everything gets built statically (necessary for binary release)
+STATIC_CHECK=$1
+
+set -beEu -o pipefail
+
+mafBuildDir=$(realpath -m build-maf-tools)
+binDir=$(pwd)/bin
+# just use cactusRootPath for now
+dataDir=$(pwd)/src/cactus
+CWD=$(pwd)
+# works on MacOS and Linux
+if [ -z ${numcpu+x} ]; then
+	 numcpu=$(getconf _NPROCESSORS_ONLN)
+fi
+
+set -x
+rm -rf ${mafBuildDir}
+mkdir -p ${mafBuildDir}
+mkdir -p ${binDir}
+
+#taf
+cd ${mafBuildDir}
+git clone https://github.com/ComparativeGenomicsToolkit/taf.git --recursive
+cd taf
+git checkout f95fe49b9abbd75cfed4b87aa95f81289052ecd6
+HALDIR=${CWD}/submodules/hal make
+# make sure taf tests remain triggered in CI
+HALDIR=${CWD}/submodules/hal make test
+for tt in `ls bin/taf* bin/maf*`; do
+	 if [[ $STATIC_CHECK -ne 1 || $(ldd ${tt} | grep so | wc -l) -eq 0 ]]
+	 then
+		  mv ${tt} ${binDir}
+	 else
+		  exit 1
+	 fi
+done
+
+# mafTools
+cd ${mafBuildDir}
+git clone https://github.com/ComparativeGenomicsToolkit/mafTools.git
+cd mafTools
+git checkout f37c25fd09a89bb189b22e314bd170f2fddd8f39
+find . -name "*.mk" | xargs sed -ie "s/-Werror//g"
+find . -name "Makefile*" | xargs sed -ie "s/-Werror//g"
+# hack in flags support
+sed -i inc/common.mk -e 's/cflags =/cflags = ${CFLAGS}/g'
+# and sonLib path
+sed -i inc/common.mk -e "s#sonLibPath = .*#sonLibPath = ${CWD}/submodules/sonLib/lib#g"
+make
+for mt in `ls bin/maf*`; do
+	 if [[ $STATIC_CHECK -ne 1 || $(ldd ${mt} | grep so | wc -l) -eq 0 ]]
+	 then
+		  mv ${mt} ${binDir}
+	 else
+		  exit 1
+	 fi
+done
+
+
+cd ${CWD}
+rm -rf ${mafBuildDir}
+
+set +x

--- a/build-tools/downloadMafTools
+++ b/build-tools/downloadMafTools
@@ -30,7 +30,7 @@ cd taf
 git checkout f95fe49b9abbd75cfed4b87aa95f81289052ecd6
 HALDIR=${CWD}/submodules/hal make
 # make sure taf tests remain triggered in CI
-HALDIR=${CWD}/submodules/hal make test
+make test
 for tt in `ls bin/taf* bin/maf*`; do
 	 if [[ $STATIC_CHECK -ne 1 || $(ldd ${tt} | grep so | wc -l) -eq 0 ]]
 	 then

--- a/build-tools/makeBinRelease
+++ b/build-tools/makeBinRelease
@@ -96,6 +96,9 @@ then
 	 build-tools/downloadPangenomeTools 1
 fi
 
+# download tools for working with MAF
+build-tools/downloadMafTools 1
+
 binPackageDir=cactus-bin-${REL_TAG}
 rm -rf ${binPackageDir}
 mkdir ${binPackageDir}


### PR DESCRIPTION
The immortal mafTools now included in the release binaries and docker image via `downloadMafTools`.  taf is also downloaded via this script and no longer a submodule. 

