### PR TITLE
Include maftools in bin/ via downloadMafTools

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,7 +35,9 @@ test-job:
     # todo: should we check some kind of gitlab state before doing this?  I think current logic pushes every run....
     - docker login --username $QUAY_USERNAME --password $QUAY_PASSWORD quay.io
     - make push_only
+    - make -j 8	 
     - numcpu=8 build-tools/downloadPangenomeTools
+    - numcpu=8 build-tools/downloadMafTools	 
     - python3.8 -m pip install -U .	 
     - make -j 8 evolver_test
   artifacts:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/comparative-genomics-toolkit/ubuntu:22.04 AS builder
 
 # apt dependencies for build
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential git python3 python3-dev python3-pip zlib1g-dev wget libbz2-dev pkg-config libhdf5-dev liblzo2-dev libtokyocabinet-dev wget liblzma-dev libxml2-dev libssl-dev libpng-dev uuid-dev libcurl4-gnutls-dev libffi-dev python3-virtualenv rsync
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential git python3 python3-dev python3-pip zlib1g-dev wget libbz2-dev pkg-config libhdf5-dev liblzo2-dev libtokyocabinet-dev wget liblzma-dev libxml2-dev libssl-dev libpng-dev uuid-dev libcurl4-gnutls-dev libffi-dev python3-virtualenv rsync python-is-python3
 
 # build cactus binaries
 RUN mkdir -p /home/cactus
@@ -36,6 +36,9 @@ RUN cd /home/cactus/bin && for i in wigToBigWig faToTwoBit bedToBigBed bigBedToB
 
 # download tools used for pangenome pipeline
 RUN cd /home/cactus && ./build-tools/downloadPangenomeTools
+
+# download tools used for working with MAF
+RUN cd /home/cactus && ./build-tools/downloadMafTools
 
 # remove test executables
 RUN cd /home/cactus && rm -f ${binPackageDir}/bin/*test ${binPackageDir}/bin/*tests ${binPackageDir}/bin/*Test ${binPackageDir}/bin/*Tests

--- a/Makefile
+++ b/Makefile
@@ -156,57 +156,55 @@ taf_test:
 ${versionPy}:
 	echo "cactus_commit = '${git_commit}'" >$@
 
-bin/mafComparator:
-	rm -rf submodules/mafTools
-	cd submodules && git clone https://github.com/ComparativeGenomicsToolkit/mafTools.git && cd mafTools && git checkout cf144382b3c5a672d58a6798eebe23979c9a6b1f
-	cd submodules/mafTools && sed -i -e 's/-Werror//g' inc/common.mk lib/Makefile && sed -i -e 's/mafExtractor//g' Makefile && make
-	cp submodules/mafTools/bin/mafComparator bin/
+${CWD}/test/mammals-truth.maf:
 	cd ${CWD}/test && wget -q https://raw.githubusercontent.com/UCSantaCruzComputationalGenomicsLab/cactusTestData/master/evolver/mammals/loci1/all.maf -O mammals-truth.maf
+
+${CWD}/test/primates-truth.maf:
 	cd ${CWD}/test && wget -q https://raw.githubusercontent.com/UCSantaCruzComputationalGenomicsLab/cactusTestData/master/evolver/primates/loci1/all.maf -O primates-truth.maf
 
-evolver_test: all bin/mafComparator
+evolver_test: all ${CWD}/test/mammals-truth.maf ${CWD}/test/primates-truth.maf
 # note: make docker needs to be run beforehand
 	PYTHONPATH="${CWD}/submodules/" CACTUS_DOCKER_ORG=evolvertestdocker CACTUS_USE_LATEST=1 ${PYTHON} -m pytest ${pytestOpts} test/evolverTest.py
 
-evolver_test_local: all bin/mafComparator
+evolver_test_local: all ${CWD}/test/mammals-truth.maf
 	PYTHONPATH="${CWD}/submodules/" CACTUS_BINARIES_MODE=local CACTUS_DOCKER_MODE=0 ${PYTHON} -m pytest ${pytestOpts} -s test/evolverTest.py::TestCase::testEvolverLocal
 
-evolver_test_prepare_wdl: all bin/mafComparator
+evolver_test_prepare_wdl: all ${CWD}/test/mammals-truth.maf
 	PYTHONPATH="${CWD}/submodules/" CACTUS_BINARIES_MODE=local CACTUS_DOCKER_MODE=0 ${PYTHON} -m pytest ${pytestOpts} -s test/evolverTest.py::TestCase::testEvolverPrepareWDL
 
-evolver_test_prepare_toil: all bin/mafComparator
+evolver_test_prepare_toil: all ${CWD}/test/mammals-truth.maf
 	PYTHONPATH="${CWD}/submodules/" CACTUS_BINARIES_MODE=local CACTUS_DOCKER_MODE=0 ${PYTHON} -m pytest ${pytestOpts} -s test/evolverTest.py::TestCase::testEvolverPrepareToil
 
-evolver_test_decomposed_local: all bin/mafComparator
+evolver_test_decomposed_local: all ${CWD}/test/mammals-truth.maf
 	PYTHONPATH="${CWD}/submodules/" CACTUS_BINARIES_MODE=local CACTUS_DOCKER_MODE=0 ${PYTHON} -m pytest ${pytestOpts} -s test/evolverTest.py::TestCase::testEvolverDecomposedLocal
 
-evolver_test_decomposed_docker: all bin/mafComparator
+evolver_test_decomposed_docker: all ${CWD}/test/mammals-truth.maf
 #note make docker needs to be run beforehand
 	PYTHONPATH="${CWD}/submodules/" CACTUS_DOCKER_ORG=evolvertestdocker CACTUS_USE_LATEST=1 ${PYTHON} -m pytest ${pytestOpts} -s test/evolverTest.py::TestCase::testEvolverDecomposedDocker
 
-evolver_test_docker: all bin/mafComparator
+evolver_test_docker: all ${CWD}/test/mammals-truth.maf
 	PYTHONPATH="${CWD}/submodules/" CACTUS_BINARIES_MODE=local CACTUS_DOCKER_MODE=0 ${PYTHON} -m pytest ${pytestOpts} -s test/evolverTest.py::TestCase::testEvolverDocker
 
-evolver_test_prepare_no_outgroup_docker: all bin/mafComparator
+evolver_test_prepare_no_outgroup_docker: all ${CWD}/test/mammals-truth.maf
 #note make docker needs to be run beforehand
 	PYTHONPATH="${CWD}/submodules/" CACTUS_DOCKER_ORG=evolvertestdocker CACTUS_USE_LATEST=1 ${PYTHON} -m pytest ${pytestOpts} -s test/evolverTest.py::TestCase::testEvolverPrepareNoOutgroupDocker
 
-evolver_test_prepare_no_outgroup_local: all bin/mafComparator
+evolver_test_prepare_no_outgroup_local: all ${CWD}/test/mammals-truth.maf
 	PYTHONPATH="${CWD}/submodules/" CACTUS_BINARIES_MODE=local CACTUS_DOCKER_MODE=0 ${PYTHON} -m pytest ${pytestOpts} -s test/evolverTest.py::TestCase::testEvolverPrepareNoOutgroupLocal
 
-evolver_test_update_node_local: bin/mafComparator
+evolver_test_update_node_local: ${CWD}/test/mammals-truth.maf
 	PYTHONPATH="${CWD}/submodules/" CACTUS_BINARIES_MODE=local CACTUS_DOCKER_MODE=0 ${PYTHON} -m pytest ${pytestOpts} -s test/evolverTest.py::TestCase::testEvolverUpdateNodeLocal
 
-evolver_test_update_branch_local: bin/mafComparator
+evolver_test_update_branch_local: ${CWD}/test/mammals-truth.maf
 	PYTHONPATH="${CWD}/submodules/" CACTUS_BINARIES_MODE=local CACTUS_DOCKER_MODE=0 ${PYTHON} -m pytest ${pytestOpts} -s test/evolverTest.py::TestCase::testEvolverUpdateBranchLocal
 
-evolver_test_poa_local: all bin/mafComparator
+evolver_test_poa_local: all ${CWD}/test/primates-truth.maf
 	PYTHONPATH="${CWD}/submodules/" CACTUS_BINARIES_MODE=local CACTUS_DOCKER_MODE=0 ${PYTHON} -m pytest ${pytestOpts} -s test/evolverTest.py::TestCase::testEvolverPOALocal
 
-evolver_test_refmap_local: all bin/mafComparator
+evolver_test_refmap_local: all ${CWD}/test/primates-truth.maf
 	PYTHONPATH="${CWD}/submodules/" CACTUS_BINARIES_MODE=local CACTUS_DOCKER_MODE=0 ${PYTHON} -m pytest ${pytestOpts} -s test/evolverTest.py::TestCase::testEvolverRefmapLocal
 
-evolver_test_minigraph_local: all bin/mafComparator
+evolver_test_minigraph_local: all ${CWD}/test/primates-truth.maf
 	PYTHONPATH="${CWD}/submodules/" CACTUS_BINARIES_MODE=local CACTUS_DOCKER_MODE=0 ${PYTHON} -m pytest ${pytestOpts} -s test/evolverTest.py::TestCase::testEvolverMinigraphLocal
 
 evolver_test_all_local: evolver_test_local evolver_test_prepare_toil evolver_test_decomposed_local evolver_test_prepare_no_outgroup_local evolver_test_poa_local evolver_test_refmap_local evolver_test_minigraph_local

--- a/build-tools/downloadMafTools
+++ b/build-tools/downloadMafTools
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Download and statically build tools needed for MAF processing
+
+# set this to one to make sure everything gets built statically (necessary for binary release)
+STATIC_CHECK=$1
+
+set -beEu -o pipefail
+
+mafBuildDir=$(realpath -m build-maf-tools)
+binDir=$(pwd)/bin
+# just use cactusRootPath for now
+dataDir=$(pwd)/src/cactus
+CWD=$(pwd)
+# works on MacOS and Linux
+if [ -z ${numcpu+x} ]; then
+	 numcpu=$(getconf _NPROCESSORS_ONLN)
+fi
+
+set -x
+rm -rf ${mafBuildDir}
+mkdir -p ${mafBuildDir}
+mkdir -p ${binDir}
+
+# mafTools
+cd ${mafBuildDir}
+git clone https://github.com/ComparativeGenomicsToolkit/mafTools.git
+cd mafTools
+git checkout 40cfa5b503a34b8b0b7799678237e2f13ae8bf36
+find . -name "*.mk" | xargs sed -ie "s/-Werror//g"
+find . -name "Makefile*" | xargs sed -ie "s/-Werror//g"
+# hack in flags support
+sed -i inc/common.mk -e 's/cflags =/cflags = ${CFLAGS}/g'
+# and sonLib path
+sed -i inc/common.mk -e "s#sonLibPath = .*#sonLibPath = ${CWD}/submodules/sonLib/lib#g"
+make
+for mt in `ls bin/maf*`; do
+	 if [[ $STATIC_CHECK -ne 1 || $(ldd ${mt} | grep so | wc -l) -eq 0 ]]
+	 then
+		  mv ${mt} ${binDir}
+	 else
+		  exit 1
+	 fi
+done
+
+
+cd ${CWD}
+rm -rf ${mafBuildDir}
+
+set +x

--- a/build-tools/makeBinRelease
+++ b/build-tools/makeBinRelease
@@ -96,6 +96,9 @@ then
 	 build-tools/downloadPangenomeTools 1
 fi
 
+# download tools for working with MAF
+build-tools/downloadMafTools 1
+
 binPackageDir=cactus-bin-${REL_TAG}
 rm -rf ${binPackageDir}
 mkdir ${binPackageDir}


### PR DESCRIPTION
I also wanted to refactor to download TAF the same way while still running the TAF tests, but ran into a [cryptic error](https://ucsc-ci.com/comparativegenomicstoolkit/cactus/-/jobs/26714) that'll have to be dealt with some other time. 