### PR TITLE
Update minigraph to v0.20

### DIFF
--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -59,7 +59,7 @@ fi
 cd ${pangenomeBuildDir}
 git clone https://github.com/lh3/minigraph.git
 pushd minigraph
-git checkout v0.19
+git checkout v0.20
 # hack in flags support
 sed -i Makefile -e 's/CFLAGS=/CFLAGS+=/'
 make -j ${numcpu}


### PR DESCRIPTION
Updates to latest minigraph.  This minigraph version should fix the `l == gc->qe - gc->qs && gc->p->aplen == gc->pe - gc->ps` [assertion error](https://github.com/lh3/minigraph/issues/76) that's come up in a couple issues here:

Resolves #800
Resolves #832