### PR TITLE
[Do not merge yet] Incorporate Toil GPU support

### DIFF
--- a/src/cactus/blast/cactus_blast.py
+++ b/src/cactus/blast/cactus_blast.py
@@ -61,6 +61,9 @@ def main():
                         help="The way to run the Cactus binaries", default=None)
     parser.add_argument("--gpu", action="store_true",
                         help="Enable GPU acceleration by using Segaling instead of lastz")
+    parser.add_argument("--gpuCount", type=int,
+                        help="Specify the number of GPUs for each repeatmasking job (will also toggle on --gpu). By default (or if set to 0) all available GPUs are used")
+    
     options = parser.parse_args()
 
     setupBinaries(options)
@@ -71,6 +74,9 @@ def main():
         if not options.pathOverrides or not options.pathOverrideNames or \
            len(options.pathOverrideNames) != len(options.pathOverrides):
             raise RuntimeError('same number of values must be passed to --pathOverrides and --pathOverrideNames')
+    # gpuCount auto-sets gpu so you don't need to use both
+    if options.gpuCount and options.gpuCount > 0:
+        options.gpu = True    
 
     # Mess with some toil options to create useful defaults.
     cactus_override_toil_options(options)

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -19,7 +19,7 @@
 	<!-- The checkAssemblyHub option (if enabled) ensures that the first word contains only alphanumeric or '_', '-', ':', or '.' characters, and is unique. If you don't intend to make an assembly hub, you can turn off this option here. -->
 	<preprocessor memory="littleMemory" preprocessJob="checkUniqueHeaders" checkAssemblyHub="1" active="1"/>
 	<!-- The preprocessor for cactus_lastzRepeatMask masks every seed that is part of more than XX other alignments, this stops a combinatorial explosion in pairwise alignments -->
-	<preprocessor unmask="0" chunkSize="10000000" proportionToSample="0.2" memory="littleMemory" preprocessJob="lastzRepeatMask" minPeriod="50" lastzOpts='--step=3 --ambiguous=iupac,100,100 --ungapped --queryhsplimit=keep,nowarn:1500' gpuLastz="false" active="1"/>
+	<preprocessor unmask="0" chunkSize="10000000" proportionToSample="0.2" memory="littleMemory" preprocessJob="lastzRepeatMask" minPeriod="50" lastzOpts='--step=3 --ambiguous=iupac,100,100 --ungapped --queryhsplimit=keep,nowarn:1500' gpuLastz="false" gpuCount="0" active="1"/>
 	<!-- Softmask alpha-satellite using the dna-brnn tool -->
 	<!-- This preprocessor is off by default, and will replace the lastzRepeatMask preprocessor via command line toggle (or setting active=1)-->
 	<!-- It will attempt to load its included "attcc-alpha.knm" model by default unless a different one is specified below -->
@@ -40,6 +40,7 @@
       with identity lower than 1 - IJC(L). -->
 	<!-- minimumDistance A minimum for L (see above), so we don't filter out alignments with high identity. -->
 	<!-- gpuLastz Use segAlign instead of lastz -->
+	<!-- gpuCount Use this many gpus. defaults to all available if 0 or unspecified -->
 	<!-- lastzMemory The memory to allocate for each blast job -->
 	<!-- runMapQFiltering Filter alignments by score/mapQ, ranking alignments from highest mapQ/score to lowest -->
 	<!-- minimumMapQValue Minimum score/mapQ -->
@@ -62,6 +63,7 @@
 		   identityRatio="3"
 		   minimumDistance="0.01"
 		   gpuLastz="false"
+		   gpuCount="0"			
 		   lastzMemory="littleMemory"
 	       chainMaxGapLength="1000000"
 		   chainGapOpen="5000"

--- a/src/cactus/preprocessor/lastzRepeatMasking/cactus_lastzRepeatMask.py
+++ b/src/cactus/preprocessor/lastzRepeatMasking/cactus_lastzRepeatMask.py
@@ -24,6 +24,7 @@ class RepeatMaskOptions:
             unmaskOutput=False,
             proportionSampled=1.0,
             gpuLastz=False,
+            gpuCount=0,
             gpuLastzInterval=3000000):
         self.fragment = fragment
         self.minPeriod = minPeriod
@@ -32,6 +33,7 @@ class RepeatMaskOptions:
         self.unmaskOutput = unmaskOutput
         self.proportionSampled = proportionSampled
         self.gpuLastz = gpuLastz
+        self.gpuCount = gpuCount
         self.gpuLastzInterval = gpuLastzInterval
 
         self.period = max(1, round(self.proportionSampled * self.minPeriod))
@@ -51,7 +53,8 @@ class LastzRepeatMaskJob(RoundedJob):
             cores = cactus_cpu_count()
         else:
             cores = None
-        RoundedJob.__init__(self, memory=memory, disk=disk, cores=cores, preemptable=True)
+        accelerators = ['cuda:{}'.format(repeatMaskOptions.gpuCount)] if repeatMaskOptions.gpuCount else None            
+        RoundedJob.__init__(self, memory=memory, disk=disk, cores=cores, accelerators=accelerators, preemptable=True)
         self.repeatMaskOptions = repeatMaskOptions
         self.queryID = queryID
         self.targetIDs = targetIDs
@@ -114,6 +117,8 @@ class LastzRepeatMaskJob(RoundedJob):
                 lastz_opts[i + 1] = None
             else:
                 gpu_opts += [lastz_opts[i]]
+        if self.repeatMaskOptions.gpuCount:
+            gpu_opts += ['--num_gpu', str(self.repeatMaskOptions.gpuCount)]
                         
         cmd = ["segalign_repeat_masker",
                targetFile,

--- a/src/cactus/progressive/cactus_progressive.py
+++ b/src/cactus/progressive/cactus_progressive.py
@@ -318,6 +318,8 @@ def main():
                         help="The way to run the Cactus binaries", default=None)
     parser.add_argument("--gpu", action="store_true",
                         help="Enable GPU acceleration by using Segaling instead of lastz")
+    parser.add_argument("--gpuCount", type=int,
+                        help="Specify the number of GPUs for each repeatmasking job (will also toggle on --gpu). By default (or if set to 0) all available GPUs are used")    
     parser.add_argument("--consCores", type=int, 
                         help="Number of cores for each cactus_consolidated job (defaults to all available / maxCores on single_machine)", default=None)
     parser.add_argument("--intermediateResultsUrl",
@@ -350,7 +352,10 @@ def main():
             raise RuntimeError('--consCores required for non single_machine batch systems')
     if options.maxCores is not None and options.consCores > int(options.maxCores):
         raise RuntimeError('--consCores must be <= --maxCores')
-
+    # gpuCount auto-sets gpu so you don't need to use both
+    if options.gpuCount and options.gpuCount > 0:
+        options.gpu = True    
+    
     # Mess with some toil options to create useful defaults.
     cactus_override_toil_options(options)
 

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -843,7 +843,7 @@ class RoundedJob(Job):
     # Default rounding amount: 100 MiB
     roundingAmount = 100*1024*1024
     def __init__(self, memory=None, cores=None, disk=None, preemptable=None,
-                 unitName=None, checkpoint=False):
+                 unitName=None, checkpoint=False, accelerators=None):
         if memory is not None:
             memory = self.roundUp(memory)
         if disk is not None:
@@ -853,7 +853,7 @@ class RoundedJob(Job):
             disk = 1500*1024*1024 + self.roundUp(disk)
         super(RoundedJob, self).__init__(memory=memory, cores=cores, disk=disk,
                                          preemptable=preemptable, unitName=unitName,
-                                         checkpoint=checkpoint)
+                                         checkpoint=checkpoint, accelerators=accelerators)
 
     def roundUp(self, bytesRequirement):
         """

--- a/src/cactus/shared/configWrapper.py
+++ b/src/cactus/shared/configWrapper.py
@@ -248,10 +248,14 @@ class ConfigWrapper:
         if force_activate:
             # apply the gpu override
             findRequiredNode(self.xmlRoot, "blast").attrib["gpuLastz"] = "true"
+            if options.gpuCount:
+                findRequiredNode(self.xmlRoot, "blast").attrib["gpuCount"] = str(options.gpuCount)
             findRequiredNode(self.xmlRoot, "blast").attrib["realign"] = "0"
             for node in self.xmlRoot.findall("preprocessor"):
                 if getOptionalAttrib(node, "preprocessJob") == "lastzRepeatMask":
                     node.attrib["gpuLastz"] = "true"
+                    if options.gpuCount:
+                        node.attrib["gpuCount"] = str(options.gpuCount)
 
         if getOptionalAttrib(findRequiredNode(self.xmlRoot, "blast"), 'gpuLastz', typeFn=bool, default=False):
             # single machine: we give all the cores to segalign
@@ -261,7 +265,7 @@ class ConfigWrapper:
                 else:
                     lastz_cores = cactus_cpu_count()
             else:
-                # todo: toil doesn't support gpu properly yet
+                # todo: segalign can't control number of cores
                 lastz_cores = None
             findRequiredNode(self.xmlRoot, "blast").attrib["cpu"] = str(lastz_cores)
                     

--- a/toil-requirement.txt
+++ b/toil-requirement.txt
@@ -1,1 +1,1 @@
-toil[aws]==5.7.1
+git+https://github.com/DataBiosphere/toil.git@e505923067dbdb362258740ae4c1eda4e27d8708


### PR DESCRIPTION
@adamnovak added the `accelerators` resource to Toil, which allows setting the number of GPUs in each job.  This is vital for getting Cactus with GPU to work on AWS (as it allows dividing cpu and gpu jobs between appropriate instance types).  

This PR updates Cactus to use `accelerators` for jobs that run Segalign.  It does so via the new `--gpuCount` option (and also `gpuCount` properties in the config).  By default, the current functionality is kept: all gpus are used by each segalign job (regardless of what toil thinks) if `--gpu` (or `gpuLastz`) are toggled on.  But the `gpuCount` can be used to finetune things if desired.  

For this to be usable on AWS, [Toil needs to be able to run gpu docker images](https://github.com/DataBiosphere/toil/issues/4282).

Also, [we cannot specify the number of CPU cores that segalign uses](https://github.com/gsneha26/SegAlign/issues/14).  So this will have to be resolved in order to take full advantage of gpu scheduling on large single machine instances (but isn't much of a factor on the cloud where we can stick with one job per instance)

This PR shouldn't be merged until the next Toil release, ideally with that first issue above fixed.  
