### PR TITLE
Use mash distance to determine minigraph construction order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ static:
 	${MAKE} all
 
 check-static: static
-	if [ $(shell ldd bin/* | grep "not a dynamic" | wc -l) = $(shell ls bin/* | wc -l) ] ; then\
+	if [ $(shell ls bin/* | grep -v mash | xargs ldd | grep "not a dynamic" | wc -l) = $(shell ls bin/* | grep -v mash | wc -l) ] ; then\
 		echo "ldd verified that all files in bin/ are static";\
 	else\
 		echo "ldd found dynamic linked binary in bin/";\

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Cactus uses many different algorithms and individual code contributions, princip
 - Heng Li for [minigraph](https://github.com/lh3/minigraph), [minimap2](https://github.com/lh3/minimap2), [gfatools](https://github.com/lh3/gfatools) and [dna-brnn](https://github.com/lh3/dna-rnn)
 - Dany Doerr for [GFAffix](https://github.com/marschall-lab/GFAffix), used to optionally clean pangenome graphs.
 - The vg team for [vg](https://github.com/vgteam/vg), used to process pangenome graphs.
+- The authors of [Mash](https://github.com/marbl/Mash)
 
 ## Mailing List
 

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -312,6 +312,17 @@ else
 	 exit 1
 fi
 
+# mash
+cd ${pangenomeBuildDir}
+wget -q https://github.com/marbl/Mash/releases/download/v2.3/mash-Linux64-v2.3.tar
+tar -xf mash-Linux64-v2.3.tar
+cd mash-Linux64-v2.3
+mv mash ${binDir}
+# note:
+# disabling the static check as this binary is not fully static.
+# but.. I can't figure out how to build proper static binary from
+# source and this one seems broadly compatible with many systems...
+
 cd ${CWD}
 rm -rf ${pangenomeBuildDir}
 

--- a/doc/pangenome.md
+++ b/doc/pangenome.md
@@ -107,7 +107,7 @@ CHM13  ./chm13.fa
 
 ### Pipeline
 
-1) `cactus-minigraph <jobStore> <seqFile> <outputGFA> --reference`: Construct a minigraph in GFA format (may be gzipped) from a set of FASTA files (may also be gzipped).  This is a very thin wrapper over `minigraph -cxggs`.  The reference is added first and the remainder of samples are added in decreasing order of size.  Use the `--mapCores` option to specify the number of cores.
+1) `cactus-minigraph <jobStore> <seqFile> <outputGFA> --reference`: Construct a minigraph in GFA format (may be gzipped) from a set of FASTA files (may also be gzipped).  This is a very thin wrapper over `minigraph -cxggs`.  The reference is added first and the remainder of samples are added in decreasing order of decreasing mash distance to the reference (see the `minigraphSortInput` parameter in the XML config to change or disable this).  Use the `--mapCores` option to specify the number of cores.
 
 2) `cactus-graphmap <jobStore> <seqFile> <inputGFA> <outputPAF> --reference`: Map each input assembly back to the graph using `minigraph`.  The number of cores for each mapping job can be set with `--mapCores`.  
 

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -279,7 +279,7 @@
 	<!-- assemblyName: special name of "virtual" minigraph assembly, which is just the list of sequences from the graph. -->
 	<!-- minigraphMapOptions: flags to pass to minigraph for mapping -->
 	<!-- minigraphConstructOptions: flags to pass to minigraph for construction -->
-	<!-- minigraphSortBySize: Add genomes by order of their size (except for reference which is first) when constructing minigraph. -->
+	<!-- minigraphSortInput: Method used to determine input order. Valid values are "mash", "size", "none" / "0" which refer to (decreasing) mash distance to reference, (decreasing) size or no sorting (order in seqfile), respectively -->
 	<!-- minMAPQ: ignore minigraph alignments with mapping quality less than this -->
 	<!-- minGAFBlockLength: ignore minigraph alignments with block length less than this -->
 	<!-- minGAFQueryOverlapFilter: if 2 or more query regions in blocks of at least this size, filter them out. -->
@@ -300,7 +300,7 @@
 		 assemblyName="_MINIGRAPH_"
 		 minigraphMapOptions="-c -xasm"
 		 minigraphConstructOptions="-c -xggs"
-		 minigraphSortBySize="1"
+		 minigraphSortInput="mash"
 		 minMAPQ="5"
 		 minGAFBlockLength="250000"
 		 minGAFQueryOverlapFilter="0"


### PR DESCRIPTION
Previously, it was using genome size.  But this was giving pretty counterintuitive results when making a pangenome of different species.  

So now genomes are now added in order of how close they are to the reference as determined by `mash dist`. 

This can be toggled in the config using the `minigraphSortInput` attribute.  It's set to "mash" by default, but can be changed to "size" to go back to using size.  Any other value, ex "0", will just use the ordering from the seqfile. 