### PR TITLE
Add check to ancestor labeller to not add duplicates

### DIFF
--- a/src/cactus/progressive/multiCactusTree.py
+++ b/src/cactus/progressive/multiCactusTree.py
@@ -35,6 +35,11 @@ class MultiCactusTree(NXTree):
     # fill in unlabeled node ids with a breadth-first
     # traversal numbering from the root
     def nameUnlabeledInternalNodes(self, prefix = "Anc", startIdx = 0):
+        # make sure we don't duplicate any pre-existing labels
+        existing_labels = set()
+        for node in self.breadthFirstTraversal():
+            if not self.isLeaf(node) and self.hasName(node):
+                existing_labels.add(self.getName(node))        
         count = startIdx
         numInternal = 0
         width = 0
@@ -44,9 +49,13 @@ class MultiCactusTree(NXTree):
         if numInternal > 0:
             width = int(math.log10(numInternal)) + 1
         for node in self.breadthFirstTraversal():
-            if not self.isLeaf(node) and not self.hasName(node):
-                self.setName(node, "%s%s" % (prefix, str(count).zfill(width)))
-                count += 1
+            if not self.isLeaf(node):
+                while not self.hasName(node):
+                    new_name = "%s%s" % (prefix, str(count).zfill(width))
+                    if new_name not in existing_labels:
+                        self.setName(node, new_name)
+                        existing_labels.add(new_name)
+                    count += 1
             self.nameToId[self.getName(node)] = node
 
     # identify roots of subclades in the tree and

--- a/src/cactus/progressive/multiCactusTree.py
+++ b/src/cactus/progressive/multiCactusTree.py
@@ -38,7 +38,7 @@ class MultiCactusTree(NXTree):
         # make sure we don't duplicate any pre-existing labels
         existing_labels = set()
         for node in self.breadthFirstTraversal():
-            if not self.isLeaf(node) and self.hasName(node):
+            if self.hasName(node):
                 existing_labels.add(self.getName(node))        
         count = startIdx
         numInternal = 0


### PR DESCRIPTION
Progressive Cactus automatically assigns names to ancestral nodes: Anc0, Anc1 etc.  But if you give it a tree with one of those names already used, and that name is used on a *different* node than would be assigned automatically, then it would just make a tree with two instances of that node name.  And because this happens after the duplicate node-name check, cactus would continue until crashing with a cryptic assertion failure. 

This PR fixes this bug -- it now checks that newly added node names are unique before adding them.  

