### PR TITLE
fixing empty 'add' parameter during the call of 'cactus_update_prepare'

### DIFF
--- a/src/cactus/update/cactus_update_prepare.py
+++ b/src/cactus/update/cactus_update_prepare.py
@@ -1065,6 +1065,10 @@ def main():
         parser.print_help()
         sys.exit(1)
 
+    if not options.subcommand:
+        add_parser.print_help()
+        sys.exit(1)
+    
     # From cactus-prepare
     setupBinaries(options)
     set_logging_from_options(options)


### PR DESCRIPTION
Fixing issue #753 

After the fix,
```bash
python3 cactus_update_prepare.py add                                                                                                                                                                                                                      
usage: cactus_update_prepare.py {add,replace} [-h] [Options] add [-h] {node,branch} ...

positional arguments:
  {node,branch}  Methods to add a new genome
    node         Adding a new genome to a node (aka, the adding-to-a-node approach)
    branch       Adding a new genome to a branch (aka, the adding-to-a-branch approach)

optional arguments:
  -h, --help     show this help message and exit
```
also
```bash
python3 cactus_update_prepare.py add node                                                                                                                                                                                                                 
usage: cactus_update_prepare.py {add,replace} [-h] [Options] add node [-h] [--halOptions HALOPTIONS] [--outDir OUTDIR] [--outSeqFile OUTSEQFILE] [--jobStore JOBSTORE] [--latest] [--containerImage CONTAINERIMAGE]
                                                                      [--binariesMode {docker,local,singularity}] [--skip-backup] [--skip-halValidate] [--cactus-prepare-options CACTUS_PREPARE_OPTIONS] [--logCritical] [--logError] [--logWarning]
                                                                      [--logDebug] [--logInfo] [--logOff] [--logLevel {Critical,Error,Warning,Debug,Info,critical,error,warning,debug,info,CRITICAL,ERROR,WARNING,DEBUG,INFO}] [--logFile LOGFILE]
                                                                      [--rotatingLogging] --genome GENOME_NAME
                                                                      inHal inFasta
cactus_update_prepare.py {add,replace} [-h] [Options] add node: error: the following arguments are required: inHal, inFasta, --genome
```
and
```bash
python3 cactus_update_prepare.py add branch                                                                                                                                                                                                              
usage: cactus_update_prepare.py {add,replace} [-h] [Options] add branch [-h] [--halOptions HALOPTIONS] [--outDir OUTDIR] [--outSeqFile OUTSEQFILE] [--jobStore JOBSTORE] [--latest] [--containerImage CONTAINERIMAGE]
                                                                        [--binariesMode {docker,local,singularity}] [--skip-backup] [--skip-halValidate] [--cactus-prepare-options CACTUS_PREPARE_OPTIONS] [--logCritical] [--logError] [--logWarning]
                                                                        [--logDebug] [--logInfo] [--logOff] [--logLevel {Critical,Error,Warning,Debug,Info,critical,error,warning,debug,info,CRITICAL,ERROR,WARNING,DEBUG,INFO}] [--logFile LOGFILE]
                                                                        [--rotatingLogging] --parentGenome GENOME_NAME --childGenome GENOME_NAME [--ancestorName GENOME_NAME] [--topBranchLength BRANCH_LENGTH] [--forceBottomBranchLength BRANCH_LENGTH]
                                                                        inHal inFasta
```