### PR TITLE
update abpoa and enable it in legacy binaries

### DIFF
--- a/bar/impl/poaBarAligner.c
+++ b/bar/impl/poaBarAligner.c
@@ -582,7 +582,7 @@ Msa *msa_make_partial_order_alignment(char **seqs, int *seq_lens, int64_t seq_no
 
         int test_cols = 0;
         uint8_t** test_msa = NULL;
-        abpoa_msa(ab, abpt, msa->seq_no, NULL, msa->seq_lens, bseqs, NULL);
+        abpoa_msa(ab, abpt, msa->seq_no, NULL, msa->seq_lens, bseqs, NULL, NULL);
         // abpoa's interface has changed a bit -- instead of passing in pointers to the results, they
         // end up in the ab->abc struct -- we extract them here
         test_msa = ab->abc->msa_base;
@@ -601,7 +601,7 @@ Msa *msa_make_partial_order_alignment(char **seqs, int *seq_lens, int64_t seq_no
         free(test_msa);
 #else
         // perform abpoa-msa
-        abpoa_msa(ab, abpt, msa->seq_no, NULL, msa->seq_lens, bseqs, NULL);
+        abpoa_msa(ab, abpt, msa->seq_no, NULL, msa->seq_lens, bseqs, NULL, NULL);
         // abpoa's interface has changed a bit -- instead of passing in pointers to the results, they
         // end up in the ab->abc struct -- we extract them here
         msa->msa_seq = ab->abc->msa_base;

--- a/build-tools/makeBinRelease
+++ b/build-tools/makeBinRelease
@@ -30,13 +30,10 @@ git submodule update --init --recursive
 if [ -z ${CACTUS_LEGACY_ARCH+x} ]
 then
 # Make sure abpoa doesn't build with -march=native, but something more portable
-# Todo: It would be more portable to use "sse41", but that leads to segfaults in rare cases
-# https://github.com/yangao07/abPOA/issues/26
+# Using avx2 in normal release and sse41 (which can be much slower on big problems) for legacy release	 
 	 export avx2=1
 else
-	 export sse2=1
-	 # haven't tested abpoa on older architectures, turn it off by default
-	 sed -i src/cactus/cactus_progressive_config.xml -e 's/partialOrderAlignment="1"/partialOrderAlignment="0"/g'
+	 export sse41=1
 fi
 
 # hack lastz to build static.
@@ -89,12 +86,7 @@ export ENABLE_PHYLOP=1
 make -j $(nproc) check-static
 
 # download all external tools used for pangenome pipeline
-# (only works for newer architectures as vg and some other binaries are built with -march=nehalem)
-# todo: should try to just use nocona for everything and make one release 
-if [ -z ${CACTUS_LEGACY_ARCH+x} ]	
-then
-	 build-tools/downloadPangenomeTools 1
-fi
+build-tools/downloadPangenomeTools 1
 
 # download tools for working with MAF
 build-tools/downloadMafTools 1


### PR DESCRIPTION
Now that [this bug](https://github.com/yangao07/abPOA/issues/26) is fixed, abPOA should work reliably with sse4.1 instructions.  

I was going to enable them by default, but the test data in that issue above is still almost 50% slower on sse4.1 than avx2 (on same machine).  So will keep using avx2 by default, but enable abPOA via sse4.1 in the "legacy" binaries.  And future releases will have minigraph-cactus support in these legacy binaries (whereas before it was just progressive cactus w/ pecan).  