### PR TITLE
[WIP]: Fix chaining

### DIFF
--- a/api/tests/cactusParamsTest.c
+++ b/api/tests/cactusParamsTest.c
@@ -26,8 +26,8 @@ static void testCactusParams(CuTest *testCase) {
     int64_t *l = cactusParams_get_ints(p, &length, 2, "caf", "deannealingRounds");
     CuAssertTrue(testCase, length >= 3);
     CuAssertIntEquals(testCase, l[0], 2);
-    CuAssertIntEquals(testCase, l[1], 4);
-    CuAssertIntEquals(testCase, l[2], 8);
+    CuAssertIntEquals(testCase, l[1], 32);
+    CuAssertIntEquals(testCase, l[2], 512);
 
     // Test moving the root of the search
     cactusParams_set_root(p, 1, "caf");

--- a/api/tests/cactusParamsTest.c
+++ b/api/tests/cactusParamsTest.c
@@ -24,7 +24,7 @@ static void testCactusParams(CuTest *testCase) {
 
     int64_t length;
     int64_t *l = cactusParams_get_ints(p, &length, 2, "caf", "deannealingRounds");
-    CuAssertIntEquals(testCase, 3, length);
+    CuAssertTrue(testCase, length >= 3);
     CuAssertIntEquals(testCase, l[0], 2);
     CuAssertIntEquals(testCase, l[1], 4);
     CuAssertIntEquals(testCase, l[2], 8);

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -122,7 +122,7 @@
 	<!-- minimumBlockDegreeToCheckSupport Apply support filter to blocks of more than this degree (if greater than 0) -->
 	<!-- minimumBlockHomologySupport TODO-->
 	<caf annealingRounds="256"
-		 deannealingRounds="2 4 8 16 32 64"
+		 deannealingRounds="2 4 8 16 32 64 128"
 		 trim="3"
 		 blockTrim="5"
 		 minimumBlockDegree="2"
@@ -134,7 +134,7 @@
 		 maxAdjacencyComponentSizeRatio="50"
 		 minLengthForChromosome="1000000"
 		 proportionOfUnalignedBasesForNewChromosome="0.8"
-		 maximumMedianSequenceLengthBetweenLinkedEnds="1000"
+		 maximumMedianSequenceLengthBetweenLinkedEnds="100000"
 		 removeRecoverableChains="unequalNumberOfIngroupCopies"
 		 maxRecoverableChainsIterations="10"
 		 maxRecoverableChainLength="500000"

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -121,8 +121,8 @@
 	<!-- maxRecoverableChainLength TODO-->
 	<!-- minimumBlockDegreeToCheckSupport Apply support filter to blocks of more than this degree (if greater than 0) -->
 	<!-- minimumBlockHomologySupport TODO-->
-	<caf annealingRounds="256"
-		 deannealingRounds="2 4 8 16 32 64 128"
+	<caf annealingRounds="2048"
+		 deannealingRounds="2 32 512"
 		 trim="3"
 		 blockTrim="5"
 		 minimumBlockDegree="2"

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -121,8 +121,8 @@
 	<!-- maxRecoverableChainLength TODO-->
 	<!-- minimumBlockDegreeToCheckSupport Apply support filter to blocks of more than this degree (if greater than 0) -->
 	<!-- minimumBlockHomologySupport TODO-->
-	<caf annealingRounds="64"
-		 deannealingRounds="2 4 8"
+	<caf annealingRounds="512"
+		 deannealingRounds="2 4 8 16 32 64"
 		 trim="3"
 		 blockTrim="5"
 		 minimumBlockDegree="2"

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -121,7 +121,7 @@
 	<!-- maxRecoverableChainLength TODO-->
 	<!-- minimumBlockDegreeToCheckSupport Apply support filter to blocks of more than this degree (if greater than 0) -->
 	<!-- minimumBlockHomologySupport TODO-->
-	<caf annealingRounds="512"
+	<caf annealingRounds="256"
 		 deannealingRounds="2 4 8 16 32 64"
 		 trim="3"
 		 blockTrim="5"

--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -666,7 +666,7 @@ class TestCase(unittest.TestCase):
         # check the output
         #self._check_stats(self._out_hal(name), delta_pct=0.25)
         #self._check_coverage(self._out_hal(name), delta_pct=0.20)
-        self._check_maf_accuracy(self._out_hal(name), delta=0.04)
+        self._check_maf_accuracy(self._out_hal(name), delta=0.042)
 
     def testEvolverUpdateNodeLocal(self):
         """ Check that the "add a genome to ancestor" modification steps give sane/valid results """
@@ -701,7 +701,7 @@ class TestCase(unittest.TestCase):
         # check the output
         #self._check_stats(self._out_hal("wdl"), delta_pct=0.25)
         #self._check_coverage(self._out_hal("wdl"), delta_pct=0.20)
-        self._check_maf_accuracy(self._out_hal("wdl"), delta=0.04)
+        self._check_maf_accuracy(self._out_hal("wdl"), delta=0.042)
 
     def testEvolverPrepareToil(self):
 
@@ -712,7 +712,7 @@ class TestCase(unittest.TestCase):
         # check the output
         #self._check_stats(self._out_hal(name), delta_pct=0.25)
         #self._check_coverage(self._out_hal(name), delta_pct=0.20)
-        self._check_maf_accuracy(self._out_hal(name), delta=0.04)
+        self._check_maf_accuracy(self._out_hal(name), delta=0.042)
 
     def testEvolverDecomposedLocal(self):
         """ Check that the output of halStats on a hal file produced by running cactus with --binariesMode local is
@@ -725,7 +725,7 @@ class TestCase(unittest.TestCase):
         # check the output
         #self._check_stats(self._out_hal(name), delta_pct=0.25)
         #self._check_coverage(self._out_hal(name), delta_pct=0.20)
-        self._check_maf_accuracy(self._out_hal(name), delta=0.04)
+        self._check_maf_accuracy(self._out_hal(name), delta=0.042)
 
     def testEvolverDecomposedDocker(self):
         """ Check that the output of halStats on a hal file produced by running cactus with --binariesMode docker is
@@ -738,7 +738,7 @@ class TestCase(unittest.TestCase):
         # check the output
         #self._check_stats(self._out_hal(name), delta_pct=0.25)
         #self._check_coverage(self._out_hal(name), delta_pct=0.20)
-        self._check_maf_accuracy(self._out_hal(name), delta=0.04)
+        self._check_maf_accuracy(self._out_hal(name), delta=0.042)
         
     def testEvolverDocker(self):
         """ Check that the output of halStats on a hal file produced by running cactus with --binariesMode docker is
@@ -750,7 +750,7 @@ class TestCase(unittest.TestCase):
         # check the output
         #self._check_stats(self._out_hal("docker"), delta_pct=0.25)
         #self._check_coverage(self._out_hal("docker"), delta_pct=0.20)
-        self._check_maf_accuracy(self._out_hal("docker"), delta=0.04)
+        self._check_maf_accuracy(self._out_hal("docker"), delta=0.042)
 
     def testEvolverInDocker(self):
         """ Check that the output of halStats on a hal file produced by running cactus in docker
@@ -762,7 +762,7 @@ class TestCase(unittest.TestCase):
         # check the output
         #self._check_stats(self._out_hal("docker"), delta_pct=0.25)
         #self._check_coverage(self._out_hal("docker"), delta_pct=0.20)
-        self._check_maf_accuracy(self._out_hal("in_docker"), delta=0.04)
+        self._check_maf_accuracy(self._out_hal("in_docker"), delta=0.042)
         
     def testEvolverPrepareNoOutgroupDocker(self):
 

--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -666,7 +666,7 @@ class TestCase(unittest.TestCase):
         # check the output
         #self._check_stats(self._out_hal(name), delta_pct=0.25)
         #self._check_coverage(self._out_hal(name), delta_pct=0.20)
-        self._check_maf_accuracy(self._out_hal(name), delta=(0.04,0.12))
+        self._check_maf_accuracy(self._out_hal(name), delta=(0.04,0.13))
 
     def testEvolverUpdateNodeLocal(self):
         """ Check that the "add a genome to ancestor" modification steps give sane/valid results """
@@ -679,7 +679,7 @@ class TestCase(unittest.TestCase):
         self._check_valid_hal(self._out_hal(name),
                               expected_tree='((simHuman_chr6:0.144018,(simMouse_chr6:0.084509,simRat_chr6:0.091589,simOrang:1)mr:0.271974,simChimp:1)Anc1:0.020593,(simCow_chr6:0.18908,simDog_chr6:0.16303)Anc2:0.032898)Anc0;')
 
-        self._check_maf_accuracy(self._out_hal(name), delta=(0.1,0.12))
+        self._check_maf_accuracy(self._out_hal(name), delta=(0.1,0.13))
 
     def testEvolverUpdateBranchLocal(self):
         """ Check that the "add a genome to branch" modification steps give sane/valid results """
@@ -690,7 +690,7 @@ class TestCase(unittest.TestCase):
         self._check_valid_hal(self._out_hal(name),
                               expected_tree='((simHuman_chr6:0.144018,((simMouse_chr6:0.084509,simRat_chr6:0.091589)mr:0.171974,simGorilla:0.2)AncGorilla:0.1)Anc1:0.020593,(simCow_chr6:0.18908,simDog_chr6:0.16303)Anc2:0.032898)Anc0;')
 
-        self._check_maf_accuracy(self._out_hal(name), delta=(0.1,0.12))
+        self._check_maf_accuracy(self._out_hal(name), delta=(0.1,0.13))
 
 
     def testEvolverPrepareWDL(self):
@@ -701,7 +701,7 @@ class TestCase(unittest.TestCase):
         # check the output
         #self._check_stats(self._out_hal("wdl"), delta_pct=0.25)
         #self._check_coverage(self._out_hal("wdl"), delta_pct=0.20)
-        self._check_maf_accuracy(self._out_hal("wdl"), delta=(0.04,0.12))
+        self._check_maf_accuracy(self._out_hal("wdl"), delta=(0.04,0.13))
 
     def testEvolverPrepareToil(self):
 
@@ -712,7 +712,7 @@ class TestCase(unittest.TestCase):
         # check the output
         #self._check_stats(self._out_hal(name), delta_pct=0.25)
         #self._check_coverage(self._out_hal(name), delta_pct=0.20)
-        self._check_maf_accuracy(self._out_hal(name), delta=(0.04,0.12))
+        self._check_maf_accuracy(self._out_hal(name), delta=(0.04,0.13))
 
     def testEvolverDecomposedLocal(self):
         """ Check that the output of halStats on a hal file produced by running cactus with --binariesMode local is
@@ -725,7 +725,7 @@ class TestCase(unittest.TestCase):
         # check the output
         #self._check_stats(self._out_hal(name), delta_pct=0.25)
         #self._check_coverage(self._out_hal(name), delta_pct=0.20)
-        self._check_maf_accuracy(self._out_hal(name), delta=(0.04,0.12))
+        self._check_maf_accuracy(self._out_hal(name), delta=(0.04,0.13))
 
     def testEvolverDecomposedDocker(self):
         """ Check that the output of halStats on a hal file produced by running cactus with --binariesMode docker is
@@ -738,7 +738,7 @@ class TestCase(unittest.TestCase):
         # check the output
         #self._check_stats(self._out_hal(name), delta_pct=0.25)
         #self._check_coverage(self._out_hal(name), delta_pct=0.20)
-        self._check_maf_accuracy(self._out_hal(name), delta=(0.04,0.12))
+        self._check_maf_accuracy(self._out_hal(name), delta=(0.04,0.13))
         
     def testEvolverDocker(self):
         """ Check that the output of halStats on a hal file produced by running cactus with --binariesMode docker is
@@ -750,7 +750,7 @@ class TestCase(unittest.TestCase):
         # check the output
         #self._check_stats(self._out_hal("docker"), delta_pct=0.25)
         #self._check_coverage(self._out_hal("docker"), delta_pct=0.20)
-        self._check_maf_accuracy(self._out_hal("docker"), delta=(0.04,0.12))
+        self._check_maf_accuracy(self._out_hal("docker"), delta=(0.04,0.13))
 
     def testEvolverInDocker(self):
         """ Check that the output of halStats on a hal file produced by running cactus in docker
@@ -762,7 +762,7 @@ class TestCase(unittest.TestCase):
         # check the output
         #self._check_stats(self._out_hal("docker"), delta_pct=0.25)
         #self._check_coverage(self._out_hal("docker"), delta_pct=0.20)
-        self._check_maf_accuracy(self._out_hal("in_docker"), delta=(0.04,0.12))
+        self._check_maf_accuracy(self._out_hal("in_docker"), delta=(0.04,0.13))
         
     def testEvolverPrepareNoOutgroupDocker(self):
 

--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -666,7 +666,7 @@ class TestCase(unittest.TestCase):
         # check the output
         #self._check_stats(self._out_hal(name), delta_pct=0.25)
         #self._check_coverage(self._out_hal(name), delta_pct=0.20)
-        self._check_maf_accuracy(self._out_hal(name), delta=0.042)
+        self._check_maf_accuracy(self._out_hal(name), delta=0.04)
 
     def testEvolverUpdateNodeLocal(self):
         """ Check that the "add a genome to ancestor" modification steps give sane/valid results """
@@ -701,7 +701,7 @@ class TestCase(unittest.TestCase):
         # check the output
         #self._check_stats(self._out_hal("wdl"), delta_pct=0.25)
         #self._check_coverage(self._out_hal("wdl"), delta_pct=0.20)
-        self._check_maf_accuracy(self._out_hal("wdl"), delta=0.042)
+        self._check_maf_accuracy(self._out_hal("wdl"), delta=0.04)
 
     def testEvolverPrepareToil(self):
 
@@ -712,7 +712,7 @@ class TestCase(unittest.TestCase):
         # check the output
         #self._check_stats(self._out_hal(name), delta_pct=0.25)
         #self._check_coverage(self._out_hal(name), delta_pct=0.20)
-        self._check_maf_accuracy(self._out_hal(name), delta=0.042)
+        self._check_maf_accuracy(self._out_hal(name), delta=0.04)
 
     def testEvolverDecomposedLocal(self):
         """ Check that the output of halStats on a hal file produced by running cactus with --binariesMode local is
@@ -725,7 +725,7 @@ class TestCase(unittest.TestCase):
         # check the output
         #self._check_stats(self._out_hal(name), delta_pct=0.25)
         #self._check_coverage(self._out_hal(name), delta_pct=0.20)
-        self._check_maf_accuracy(self._out_hal(name), delta=0.042)
+        self._check_maf_accuracy(self._out_hal(name), delta=0.04)
 
     def testEvolverDecomposedDocker(self):
         """ Check that the output of halStats on a hal file produced by running cactus with --binariesMode docker is
@@ -738,7 +738,7 @@ class TestCase(unittest.TestCase):
         # check the output
         #self._check_stats(self._out_hal(name), delta_pct=0.25)
         #self._check_coverage(self._out_hal(name), delta_pct=0.20)
-        self._check_maf_accuracy(self._out_hal(name), delta=0.042)
+        self._check_maf_accuracy(self._out_hal(name), delta=0.04)
         
     def testEvolverDocker(self):
         """ Check that the output of halStats on a hal file produced by running cactus with --binariesMode docker is
@@ -750,7 +750,7 @@ class TestCase(unittest.TestCase):
         # check the output
         #self._check_stats(self._out_hal("docker"), delta_pct=0.25)
         #self._check_coverage(self._out_hal("docker"), delta_pct=0.20)
-        self._check_maf_accuracy(self._out_hal("docker"), delta=0.042)
+        self._check_maf_accuracy(self._out_hal("docker"), delta=0.04)
 
     def testEvolverInDocker(self):
         """ Check that the output of halStats on a hal file produced by running cactus in docker
@@ -762,7 +762,7 @@ class TestCase(unittest.TestCase):
         # check the output
         #self._check_stats(self._out_hal("docker"), delta_pct=0.25)
         #self._check_coverage(self._out_hal("docker"), delta_pct=0.20)
-        self._check_maf_accuracy(self._out_hal("in_docker"), delta=0.042)
+        self._check_maf_accuracy(self._out_hal("in_docker"), delta=0.04)
         
     def testEvolverPrepareNoOutgroupDocker(self):
 

--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -679,7 +679,7 @@ class TestCase(unittest.TestCase):
         self._check_valid_hal(self._out_hal(name),
                               expected_tree='((simHuman_chr6:0.144018,(simMouse_chr6:0.084509,simRat_chr6:0.091589,simOrang:1)mr:0.271974,simChimp:1)Anc1:0.020593,(simCow_chr6:0.18908,simDog_chr6:0.16303)Anc2:0.032898)Anc0;')
 
-        self._check_maf_accuracy(self._out_hal(name), delta=0.1)
+        self._check_maf_accuracy(self._out_hal(name), delta=(0.1,0.12))
 
     def testEvolverUpdateBranchLocal(self):
         """ Check that the "add a genome to branch" modification steps give sane/valid results """
@@ -690,7 +690,7 @@ class TestCase(unittest.TestCase):
         self._check_valid_hal(self._out_hal(name),
                               expected_tree='((simHuman_chr6:0.144018,((simMouse_chr6:0.084509,simRat_chr6:0.091589)mr:0.171974,simGorilla:0.2)AncGorilla:0.1)Anc1:0.020593,(simCow_chr6:0.18908,simDog_chr6:0.16303)Anc2:0.032898)Anc0;')
 
-        self._check_maf_accuracy(self._out_hal(name), delta=0.1)
+        self._check_maf_accuracy(self._out_hal(name), delta=(0.1,0.12))
 
 
     def testEvolverPrepareWDL(self):

--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -513,7 +513,7 @@ class TestCase(unittest.TestCase):
             if skip:
                 if all([header in toks for header in header_fields]):
                     skip = False
-            elif len(toks) > len(header_fields):
+            elif len(toks) >= len(header_fields):
                 output_stats[toks[0]] = toks[1:]
         return output_stats
 
@@ -644,8 +644,8 @@ class TestCase(unittest.TestCase):
 
         sys.stderr.write("Comparing mafcomp accuracy {},{} to baseline accuracy {},{} with threshold {}\n".format(acc[0], acc[1], baseline_acc[0], baseline_acc[1], delta))
 
-        self.assertGreaterEqual(acc[0] + delta, baseline_acc[0])
-        self.assertGreaterEqual(acc[1] + delta, baseline_acc[1])
+        self.assertGreaterEqual(acc[0] + delta[0], baseline_acc[0])
+        self.assertGreaterEqual(acc[1] + delta[1], baseline_acc[1])
 
     def _check_valid_hal(self, halPath, expected_tree=None):
         """ Make sure a hal passes halValidate and has the given tree """
@@ -666,7 +666,7 @@ class TestCase(unittest.TestCase):
         # check the output
         #self._check_stats(self._out_hal(name), delta_pct=0.25)
         #self._check_coverage(self._out_hal(name), delta_pct=0.20)
-        self._check_maf_accuracy(self._out_hal(name), delta=0.04)
+        self._check_maf_accuracy(self._out_hal(name), delta=(0.04,0.12))
 
     def testEvolverUpdateNodeLocal(self):
         """ Check that the "add a genome to ancestor" modification steps give sane/valid results """
@@ -701,7 +701,7 @@ class TestCase(unittest.TestCase):
         # check the output
         #self._check_stats(self._out_hal("wdl"), delta_pct=0.25)
         #self._check_coverage(self._out_hal("wdl"), delta_pct=0.20)
-        self._check_maf_accuracy(self._out_hal("wdl"), delta=0.04)
+        self._check_maf_accuracy(self._out_hal("wdl"), delta=(0.04,0.12))
 
     def testEvolverPrepareToil(self):
 
@@ -712,7 +712,7 @@ class TestCase(unittest.TestCase):
         # check the output
         #self._check_stats(self._out_hal(name), delta_pct=0.25)
         #self._check_coverage(self._out_hal(name), delta_pct=0.20)
-        self._check_maf_accuracy(self._out_hal(name), delta=0.04)
+        self._check_maf_accuracy(self._out_hal(name), delta=(0.04,0.12))
 
     def testEvolverDecomposedLocal(self):
         """ Check that the output of halStats on a hal file produced by running cactus with --binariesMode local is
@@ -725,7 +725,7 @@ class TestCase(unittest.TestCase):
         # check the output
         #self._check_stats(self._out_hal(name), delta_pct=0.25)
         #self._check_coverage(self._out_hal(name), delta_pct=0.20)
-        self._check_maf_accuracy(self._out_hal(name), delta=0.04)
+        self._check_maf_accuracy(self._out_hal(name), delta=(0.04,0.12))
 
     def testEvolverDecomposedDocker(self):
         """ Check that the output of halStats on a hal file produced by running cactus with --binariesMode docker is
@@ -738,7 +738,7 @@ class TestCase(unittest.TestCase):
         # check the output
         #self._check_stats(self._out_hal(name), delta_pct=0.25)
         #self._check_coverage(self._out_hal(name), delta_pct=0.20)
-        self._check_maf_accuracy(self._out_hal(name), delta=0.04)
+        self._check_maf_accuracy(self._out_hal(name), delta=(0.04,0.12))
         
     def testEvolverDocker(self):
         """ Check that the output of halStats on a hal file produced by running cactus with --binariesMode docker is
@@ -750,7 +750,7 @@ class TestCase(unittest.TestCase):
         # check the output
         #self._check_stats(self._out_hal("docker"), delta_pct=0.25)
         #self._check_coverage(self._out_hal("docker"), delta_pct=0.20)
-        self._check_maf_accuracy(self._out_hal("docker"), delta=0.04)
+        self._check_maf_accuracy(self._out_hal("docker"), delta=(0.04,0.12))
 
     def testEvolverInDocker(self):
         """ Check that the output of halStats on a hal file produced by running cactus in docker
@@ -762,7 +762,7 @@ class TestCase(unittest.TestCase):
         # check the output
         #self._check_stats(self._out_hal("docker"), delta_pct=0.25)
         #self._check_coverage(self._out_hal("docker"), delta_pct=0.20)
-        self._check_maf_accuracy(self._out_hal("in_docker"), delta=0.04)
+        self._check_maf_accuracy(self._out_hal("in_docker"), delta=(0.04,0.12))
         
     def testEvolverPrepareNoOutgroupDocker(self):
 
@@ -804,7 +804,7 @@ class TestCase(unittest.TestCase):
         self._run_evolver_primates_star(name, configFile = poa_config_path)
 
         # check the output
-        self._check_maf_accuracy(self._out_hal("local"), delta=0.0025, dataset='primates')
+        self._check_maf_accuracy(self._out_hal("local"), delta=(0.0025,0.0075), dataset='primates')
 
     def testEvolverRefmapLocal(self):
         """ Use the new minimap pangenome pipeline to create an alignment of the primates, then compare with the baseline
@@ -813,7 +813,7 @@ class TestCase(unittest.TestCase):
         self._run_evolver_primates_refmap(name)
 
         # check the output
-        self._check_maf_accuracy(self._out_hal("local"), delta=0.01, dataset='primates')
+        self._check_maf_accuracy(self._out_hal("local"), delta=(0.01,0.01), dataset='primates')
 
     def testEvolverMinigraphLocal(self):
         """ Use the new minigraph pangenome pipeline to create an alignment of the primates, then compare with the baseline
@@ -823,7 +823,7 @@ class TestCase(unittest.TestCase):
 
         # check the output
         # todo: tune config so that delta can be reduced
-        self._check_maf_accuracy(self._out_hal("local"), delta=0.025, dataset='primates')
+        self._check_maf_accuracy(self._out_hal("local"), delta=(0.025,0.025), dataset='primates')
         
     def testYeastPangenomeLocal(self):
         """ Run pangenome pipeline (including contig splitting!) on yeast dataset """


### PR DESCRIPTION
Cactus alignments are too fragmented.  The existing chain length filters, `annealingRouds` and `deannealingRounds` in `<caf>` can drastically improve this, but at a cost to sensitivity. 

One of the main issues is the [evolver](https://doi.org/10.1101%2Fgr.174920.114) test [data](https://github.com/UCSantaCruzComputationalGenomicsLab/cactusTestData/tree/master/evolver/mammals/loci1), which has been used to tune Cactus pretty much since day one and still features heavily in our CI tests.  

This data seems to be enriched for very small duplication-type events. Also, the maf comparison used is column based and won't penalize giant rearrangements much if they feature teeny tiny blocks.  

The result is that the current default chain filtering parameters favour such alignments.  For example, looking at the cow-dog part of the evolver mammals in the browser: 
![Screenshot from 2022-12-16 10-01-41](https://user-images.githubusercontent.com/901102/208129067-8c38b3ed-5b5b-4bac-aae6-07781fdd419e.png)
The top alignment is with this [commit](https://github.com/ComparativeGenomicsToolkit/cactus/commit/ac1fafc027289f9cbac07c0f2da9f153904b5871) which pushes the filter from 64 to 512, and the bottom one is the current defaults.  
According to the evolver test, the bottom alignment has significantly (5%) better recall, but it looks like a total mess.  It's the same story with real primate alignments that I'm testing on now as well.  Looking at the mafcomparator output, it looks like a lot of the delta is driven by these small duplication-type events.  

Anyway, in this PR I'm going to try some different parameters (and post the stats here) on some real datasets and try to come up with better defaults even though they perform worse on evolver. 

