### PR TITLE
Fix temp file path issue with gpu repeatmasking

### DIFF
--- a/src/cactus/preprocessor/lastzRepeatMasking/cactus_lastzRepeatMask.py
+++ b/src/cactus/preprocessor/lastzRepeatMasking/cactus_lastzRepeatMask.py
@@ -138,7 +138,7 @@ class LastzRepeatMaskJob(RoundedJob):
                         raise RuntimeError('{} exited 0 but keyword "{}" found in stderr'.format(cmd, keyword))
 
         # scrape the segalign output into one big file, making an effort to read in numeric order
-        merged_path = fileStore.getLocalTempFile()
+        merged_path = os.path.join(self.work_dir, self.repeatMaskOptions.eventName + '.mergedpath')
         with open(merged_path, "a") as merged_file:
             for work_file in sorted(os.listdir(alignment_dir), key = lambda x : int(re.sub("[^0-9]", "", x))):
                 # segalign_repeat_masker makes files that look like "tmp10.block0.intervals"


### PR DESCRIPTION
When trying to clean up the lastz repeatmasking logs to make them easier to debug (#852) I managed to break gpu repeatmasking (#881).  Which is ironic as the whole point was for debugging gpu repeatmasking crashes...   Anyway, even a tiny GPU being available for CI testing would go a long way (perhaps when we get the new cluster). 

Resolves #881