### PR TITLE
Autodetect gpu count in order to default to all gpus with --gpu option

### DIFF
--- a/src/cactus/blast/cactus_blast.py
+++ b/src/cactus/blast/cactus_blast.py
@@ -18,7 +18,6 @@ from cactus.shared.configWrapper import ConfigWrapper
 from cactus.shared.common import makeURL, catFiles
 from cactus.shared.common import enableDumpStack
 from cactus.shared.common import cactus_override_toil_options
-from cactus.shared.common import cactus_gpu_count
 from cactus.shared.version import cactus_commit
 
 from cactus.paf.local_alignment import sanitize_then_make_paf_alignments
@@ -27,6 +26,7 @@ from toil.job import Job
 from toil.common import Toil
 from toil.statsAndLogging import logger
 from toil.statsAndLogging import set_logging_from_options
+from toil.lib.accelerators import count_nvidia_gpus
 
 from sonLib.nxnewick import NXNewick
 from sonLib.bioio import getTempDirectory, getTempFile
@@ -81,7 +81,7 @@ def main():
     # default to all gpus available (like we did before the gpu count option)
     if options.gpu and not options.gpuCount:
         if options.batchSystem.lower() in ['single_machine', 'singlemachine']:
-            options.gpuCount = cactus_gpu_count()
+            options.gpuCount = count_nvidia_gpus()
             if not options.gpuCount:
                 raise RuntimeError('Unable to automatically determine number of GPUs: Please set with --gpuCount')
         else:

--- a/src/cactus/preprocessor/cactus_preprocessor.py
+++ b/src/cactus/preprocessor/cactus_preprocessor.py
@@ -32,10 +32,10 @@ from cactus.shared.common import setupBinaries, importSingularityImage
 from cactus.shared.common import enableDumpStack
 from cactus.shared.common import unzip_gzs
 from cactus.shared.common import zip_gzs
-from cactus.shared.common import cactus_gpu_count
 from cactus.shared.version import cactus_commit
 from toil.statsAndLogging import set_logging_from_options
 from toil.realtimeLogger import RealtimeLogger
+from toil.lib.accelerators import count_nvidia_gpus
 
 from cactus.shared.common import cactus_override_toil_options
 from cactus.preprocessor.checkUniqueHeaders import checkUniqueHeaders
@@ -478,7 +478,7 @@ def main():
     # default to all gpus available (like we did before the gpu count option)
     if options.gpu and not options.gpuCount:
         if options.batchSystem.lower() in ['single_machine', 'singlemachine']:
-            options.gpuCount = cactus_gpu_count()
+            options.gpuCount = count_nvidia_gpus()
             if not options.gpuCount:
                 raise RuntimeError('Unable to automatically determine number of GPUs: Please set with --gpuCount')
         else:

--- a/src/cactus/progressive/cactus_progressive.py
+++ b/src/cactus/progressive/cactus_progressive.py
@@ -18,12 +18,13 @@ from argparse import ArgumentParser
 from base64 import b64encode
 
 from toil.lib.bioio import getTempFile
-from cactus.shared.common import cactus_cpu_count, cactus_gpu_count
+from cactus.shared.common import cactus_cpu_count
 from toil.statsAndLogging import logger
 from toil.statsAndLogging import set_logging_from_options
 from toil.realtimeLogger import RealtimeLogger
 from toil.job import Job
 from toil.common import Toil
+from toil.lib.accelerators import count_nvidia_gpus
 
 from cactus.shared.common import getOptionalAttrib
 from cactus.shared.common import findRequiredNode
@@ -358,7 +359,7 @@ def main():
     # default to all gpus available (like we did before the gpu count option)
     if options.gpu and not options.gpuCount:
         if options.batchSystem.lower() in ['single_machine', 'singlemachine']:
-            options.gpuCount = cactus_gpu_count()
+            options.gpuCount = count_nvidia_gpus()
             if not options.gpuCount:
                 raise RuntimeError('Unable to automatically determine number of GPUs: Please set with --gpuCount')
         else:

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -65,14 +65,6 @@ def cactus_cpu_count():
         pass
     return num_cpus
 
-def cactus_gpu_count():
-    """ Since v5.8.0, Toil needs a gpu count to use the gpu.  In order to default to all available, we use this"""
-    try:
-        smi_out = subprocess.check_output(['nvidia-smi', '-L']).decode('utf-8').strip()
-        return len(smi_out.split('\n'))
-    except:
-        return 0
-
 def cactus_override_toil_options(options):
     """  Mess with some toil options to create useful defaults. """
     if options.retryCount is None and options.batchSystem.lower() not in ['single_machine', 'singleMachine']:


### PR DESCRIPTION
I want to keep the `--gpu` option backward compatible.  Meaning that it gives SegAlign all available GPUs.  But with Toil v5.8.0, each job has to know how many GPUs it gets.  In order to default to all available, we need to count them.  

So this PR makes cactus use `nvidia-smi` to get the number of GPUs and defaults to that.  (only applicable to single machine -- any other batch system won't run unless the user specifies a gpuCount)