### PR TITLE
Rejig taffy build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,9 +27,6 @@ test-job:
     - CGL_DEBUG=ultra make -j 8
     - CACTUS_BINARIES_MODE=local SON_TRACE_DATASETS=$(pwd)/cactusTestData CACTUS_TEST_CHOICE=normal make test
     - make -j 8 hal_test
-    - export CGL_DEBUG=ultra
-    - make taffy_test
-    - unset CGL_DEBUG
     - make clean
     - make docker
     # todo: should we check some kind of gitlab state before doing this?  I think current logic pushes every run....

--- a/.gitmodules
+++ b/.gitmodules
@@ -25,6 +25,3 @@
 [submodule "submodules/lastz"]
 	path = submodules/lastz
 	url = https://github.com/ComparativeGenomicsToolkit/lastz.git
-[submodule "submodules/taffy"]
-	path = submodules/taffy
-	url = https://github.com/ComparativeGenomicsToolkit/taffy.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/comparative-genomics-toolkit/ubuntu:22.04 AS builder
 
 # apt dependencies for build
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential git python3 python3-dev python3-pip zlib1g-dev wget libbz2-dev pkg-config libhdf5-dev liblzo2-dev libtokyocabinet-dev wget liblzma-dev libxml2-dev libssl-dev libpng-dev uuid-dev libcurl4-gnutls-dev libffi-dev python3-virtualenv rsync python-is-python3 libhts-dev
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential git python3 python3-dev python3-pip zlib1g-dev wget libbz2-dev pkg-config libhdf5-dev liblzo2-dev libtokyocabinet-dev wget liblzma-dev libxml2-dev libssl-dev libpng-dev uuid-dev libcurl4-gnutls-dev libffi-dev python3-virtualenv rsync python-is-python3
 
 # build cactus binaries
 RUN mkdir -p /home/cactus
@@ -65,7 +65,7 @@ RUN rm -rf /home/cactus/hal_lib && \
 FROM quay.io/comparative-genomics-toolkit/ubuntu:22.04
 
 # apt dependencies for runtime
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends git python3 python3-pip python3-distutils zlib1g libbz2-1.0 net-tools libhdf5-103 liblzo2-2 libtokyocabinet9 libkrb5-3 libk5crypto3 time liblzma5 libcurl4 libcurl4-gnutls-dev libxml2 libgomp1 libffi7 parallel libdeflate-dev
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends git python3 python3-pip python3-distutils zlib1g libbz2-1.0 net-tools libhdf5-103 liblzo2-2 libtokyocabinet9 libkrb5-3 libk5crypto3 time liblzma5 libcurl4 libcurl4-gnutls-dev libxml2 libgomp1 libffi7 parallel
 
 # required for ubuntu22 but won't work anywhere else
 RUN bash -c "if ! command -v catchsegv > /dev/null; then apt-get install glibc-tools; fi"

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ modules = api setup fasta paf caf bar hal reference pipeline preprocessor
 
 # submodules are in multiple pass to handle dependencies cactus2hal being dependent on
 # both cactus and sonLib
-submodules1 = sonLib cPecan hal taffy matchingAndOrdering pinchesAndCacti abPOA lastz
+submodules1 = sonLib cPecan hal matchingAndOrdering pinchesAndCacti abPOA lastz
 submodules2 = cactus2hal
 submodules = ${submodules1} ${submodules2}
 
@@ -134,8 +134,6 @@ test: ${testModules:%=%_runtest} ${unitTests:%=%_run_unit_test}
 test_blast: ${testModules:%=%_runtest_blast}
 test_nonblast: ${testModules:%=%_runtest_nonblast}
 hal_test: ${halTests:%=%_run_unit_test}
-taffy_test:
-	cd submodules/taffy && ${MAKE} test
 
 # run one test and save output
 %_runtest: ${versionPy}
@@ -256,10 +254,6 @@ suball.hal: suball.sonLib
 	mkdir -p bin
 	-ln -f submodules/hal/bin/* bin/
 	-ln -f submodules/hal/lib/libHal.a submodules/hal/lib/halLib.a
-
-suball.taffy: suball.hal
-	cd submodules/taffy && HALDIR=../hal ${MAKE}
-	-ln -f submodules/taffy/bin/taffy bin/
 
 suball.abPOA:
 	cd submodules/abPOA && ${MAKE}

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ static:
 	${MAKE} all
 
 check-static: static
-	if [ $(shell ls bin/* | grep -v mash | xargs ldd | grep "not a dynamic" | wc -l) = $(shell ls bin/* | grep -v mash | wc -l) ] ; then\
+	if [ $(shell ls bin/* | grep -v mash | xargs ldd 2>& 1 | grep "not a dynamic" | wc -l) = $(shell ls bin/* | grep -v mash | wc -l) ] ; then\
 		echo "ldd verified that all files in bin/ are static";\
 	else\
 		echo "ldd found dynamic linked binary in bin/";\

--- a/build-tools/downloadMafTools
+++ b/build-tools/downloadMafTools
@@ -21,6 +21,29 @@ rm -rf ${mafBuildDir}
 mkdir -p ${mafBuildDir}
 mkdir -p ${binDir}
 
+# taffy
+cd ${mafBuildDir}
+git clone https://github.com/samtools/htslib.git
+cd htslib
+git checkout 1.16
+git submodule update --init --recursive
+make -j ${numcpu}
+export HTSLIB_CFLAGS=-I$(pwd)/
+export HTSLIB_LIBS=$(pwd)/libhts.a
+cd ${mafBuildDir}
+git clone https://github.com/ComparativeGenomicsToolkit/taffy.git
+cd taffy
+git checkout 62356fee8d917dbba3834d9df83411923c512db4
+git submodule update --init --recursive
+export HALDIR=${CWD}/submodules/hal
+make -j ${numcpu}
+if [[ $STATIC_CHECK -ne 1 || $(ldd bin/taffy | grep so | wc -l) -eq 0 ]]
+then
+    mv bin/taffy ${binDir}
+else
+    exit 1
+fi
+
 # mafTools
 cd ${mafBuildDir}
 git clone https://github.com/ComparativeGenomicsToolkit/mafTools.git

--- a/build-tools/makeGpuDockerRelease
+++ b/build-tools/makeGpuDockerRelease
@@ -29,12 +29,12 @@ CFLAGS="" CXXFLAGS="" docker build . -f Dockerfile.segalign -t segalign:local
 sed '0,/FROM/! s/FROM.*/FROM segalign:local/' Dockerfile  | sed -e '0,/FROM/s/FROM.*/FROM nvidia\/cuda:11.4.3-devel-ubuntu20.04 as builder/g' > Dockerfile.gpu
 # enable gpu by default
 sed -i src/cactus/cactus_progressive_config.xml -e 's/gpuLastz="false"/gpuLastz="true"/g' -e 's/realign="1"/realign="0"/'
-docker build . -f Dockerfile.gpu -t ${dockname}:$(getLatestReleaseTag)-gpu
+docker build . -f Dockerfile.gpu -t ${dockname}:${REL_TAG}-gpu
 # disable it again
 sed -i src/cactus/cactus_progressive_config.xml -e 's/gpuLastz="true"/gpuLastz="false"/g' -e 's/realign="0"/realign="1"/'
-read -p "Are you sure you want to push ${dockname}:$(getLatestReleaseTag)-gpu to quay?" yn
+read -p "Are you sure you want to push ${dockname}:${REL_TAG}-gpu to quay?" yn
 case $yn in
-    [Yy]* ) docker push ${dockname}:$(getLatestReleaseTag)-gpu; break;;
+    [Yy]* ) docker push ${dockname}:${REL_TAG}-gpu; break;;
     [Nn]* ) exit;;
     * ) echo "Please answer yes or no.";;
 esac


### PR DESCRIPTION
Was having problems with the release script (and Dockerfile #886).  To simplify things a bit, this PR moves taffy out of submodules and into the maf tools downloader script.  From there is builds against its own htslib to (hopefully) avoid weird conflicts down the road.    