### PR TITLE
Better tree name checking in cactus

### DIFF
--- a/src/cactus/progressive/cactus_progressive.py
+++ b/src/cactus/progressive/cactus_progressive.py
@@ -385,7 +385,7 @@ def main():
             config_wrapper.substituteAllPredefinedConstantsWithLiterals()
             # apply gpu override
             config_wrapper.initGPU(options)
-            mc_tree, input_seq_map, og_candidates = parse_seqfile(options.seqFile, config_wrapper)
+            mc_tree, input_seq_map, og_candidates = parse_seqfile(options.seqFile, config_wrapper, root_name = options.root)
             logger.info('Tree: {}'.format(NXNewick().writeString(mc_tree)))
             og_map = compute_outgroups(mc_tree, config_wrapper, set(og_candidates), options.root)
             event_set = get_event_set(mc_tree, config_wrapper, og_map, options.root, subtree=False)

--- a/src/cactus/progressive/progressive_decomposition.py
+++ b/src/cactus/progressive/progressive_decomposition.py
@@ -38,7 +38,7 @@ def parse_seqfile(seqfile_path, config_wrapper, root_name = None, default_branch
     parse the seqfile
     returns (tree, event->path map, og list (from *'s in seqfile)
     """
-    seq_file = SeqFile(seqfile_path)
+    seq_file = SeqFile(seqfile_path, root_name = root_name)
     if default_branch_length is not None:
         seq_file.branchLen = default_branch_length
 


### PR DESCRIPTION
I just got burned by a typo in a species name in the input tree.  Running via cactus-prepare/cactus-blast/cactus-align this would be a fatal error.  But with just cactus, it just silently forgets about the species and keeps on going.  This is apparently [intentional](https://github.com/ComparativeGenomicsToolkit/cactus/blob/2b2918de27e9cc585f2bc87df79574e269d1adfc/src/cactus/progressive/seqFile.py#L172-L199).

This PR changes things so that only species outside the given root behave this way, and that the message goes through the logger.   