### PR TITLE
Get rid of --gpuCount option

### DIFF
--- a/build-tools/makeGpuDockerRelease
+++ b/build-tools/makeGpuDockerRelease
@@ -28,10 +28,10 @@ CFLAGS="" CXXFLAGS="" docker build . -f Dockerfile.segalign -t segalign:local
 # important, if the build image in Dockerfile.segaling changes, the line below needs to be updated too
 sed '0,/FROM/! s/FROM.*/FROM segalign:local/' Dockerfile  | sed -e '0,/FROM/s/FROM.*/FROM nvidia\/cuda:11.4.3-devel-ubuntu20.04 as builder/g' > Dockerfile.gpu
 # enable gpu by default
-sed -i src/cactus/cactus_progressive_config.xml -e 's/gpuLastz="false"/gpuLastz="true"/g' -e 's/realign="1"/realign="0"/'
+sed -i src/cactus/cactus_progressive_config.xml -e 's/gpu="0"/gpu="all"/g' -e 's/realign="1"/realign="0"/'
 docker build . -f Dockerfile.gpu -t ${dockname}:${REL_TAG}-gpu
 # disable it again
-sed -i src/cactus/cactus_progressive_config.xml -e 's/gpuLastz="true"/gpuLastz="false"/g' -e 's/realign="0"/realign="1"/'
+sed -i src/cactus/cactus_progressive_config.xml -e 's/gpu="all"/gpu="0"/g' -e 's/realign="0"/realign="1"/'
 read -p "Are you sure you want to push ${dockname}:${REL_TAG}-gpu to quay?" yn
 case $yn in
     [Yy]* ) docker push ${dockname}:${REL_TAG}-gpu; break;;

--- a/doc/progressive.md
+++ b/doc/progressive.md
@@ -214,7 +214,7 @@ Here is an example of some settings that have worked on a mammalian-sized genome
 ```
 cactus-prepare --wdl mammals.txt --noLocalInputs --preprocessBatchSize 5 \
                --preprocessDisk 375Gi --preprocessCores 32 --preprocessMemory 120Gi \
-               --blastDisk 375Gi --blastCores 32 --gpu --gpuCount 8 --blastMemory 120Gi \
+               --blastDisk 375Gi --blastCores 32 --gpu 8 --blastMemory 120Gi \
                --alignDisk 375Gi --alignCores 64 --alignMemory 416Gi \
                --halAppendDisk 3000Gi  --defaultMemory 104Gi  > mammals.wdl
 ```
@@ -248,6 +248,8 @@ Cactus supports incrementally updating existing alignments to add, remove, or up
 ## GPU Acceleration
 
 [SegAlign](https://github.com/ComparativeGenomicsToolkit/SegAlign), a GPU-accelerated version of lastz, can be used in the "preprocess" and "blast" phases to speed up the runtime considerably, provided the right hardware is available. Unlike lastz, the input sequences do not need to be chunked before running SegAlign, so it also reduces the number of Toil jobs substantially.  The [GPU-enabled Docker releases](https://github.com/ComparativeGenomicsToolkit/cactus/releases) have SegAlign turned on by default and require no extra options from the user.  Otherwise, it is possible to [manually install it](https://github.com/ComparativeGenomicsToolkit/SegAlign#-dependencies) and then enable it in `cactus` using the `--gpu` command line option. One effective way of ensuring that only GPU-enabled parts of the workflow are run on GPU nodes is on Terra with `cactus-prepare --gpu --wdl` (see above example).
+
+By default `--gpu` will give all available GPUs to each SegAlign job. This can be tuned by passing in a numeric value, ex `--gpu 8` to assign 8 GPUs to each SegAlign job.  In non-single-machine batch systems, it is mandatory to set an exact value with `--gpu`.  
 
 GPUs must
 * support CUDA

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -18,8 +18,8 @@
 	<!-- **NEW** It now enforces sequences are globally unique by adding "id=<event name>|" to each one -->
 	<!-- The checkAssemblyHub option (if enabled) ensures that the first word contains only alphanumeric or '_', '-', ':', or '.' characters, and is unique. If you don't intend to make an assembly hub, you can turn off this option here. -->
 	<preprocessor memory="littleMemory" preprocessJob="checkUniqueHeaders" checkAssemblyHub="1" active="1"/>
-	<!-- The preprocessor for cactus_lastzRepeatMask masks every seed that is part of more than XX other alignments, this stops a combinatorial explosion in pairwise alignments -->
-	<preprocessor unmask="0" chunkSize="10000000" proportionToSample="0.2" memory="littleMemory" preprocessJob="lastzRepeatMask" minPeriod="50" lastzOpts='--step=3 --ambiguous=iupac,100,100 --ungapped --queryhsplimit=keep,nowarn:1500' gpuLastz="false" gpuCount="0" active="1"/>
+	<!-- The preprocessor for cactus_lastzRepeatMask masks every seed that is part of more than XX other alignments, this stops a combinatorial explosion in pairwise alignments. gpu sets the number of gpus (if >0, use segalign in stead of lastz. can be set to 'all' for all available GPUs) -->
+	<preprocessor unmask="0" chunkSize="10000000" proportionToSample="0.2" memory="littleMemory" preprocessJob="lastzRepeatMask" minPeriod="50" lastzOpts='--step=3 --ambiguous=iupac,100,100 --ungapped --queryhsplimit=keep,nowarn:1500' gpu="0" active="1"/>
 	<!-- Softmask alpha-satellite using the dna-brnn tool -->
 	<!-- This preprocessor is off by default, and will replace the lastzRepeatMask preprocessor via command line toggle (or setting active=1)-->
 	<!-- It will attempt to load its included "attcc-alpha.knm" model by default unless a different one is specified below -->
@@ -39,8 +39,7 @@
      Let IJC(L) be the inverse of the Jukes Cantor distance, expressed as the fraction of bases substituted. We filter all alignments
       with identity lower than 1 - IJC(L). -->
 	<!-- minimumDistance A minimum for L (see above), so we don't filter out alignments with high identity. -->
-	<!-- gpuLastz Use segAlign instead of lastz -->
-	<!-- gpuCount Use this many gpus. defaults to all available if 0 or unspecified -->
+	<!-- gpu Toggle on segAlign instead of lastz and set the number of gpus for each segalign job. 0: disable segalign, 'all': use all availabled GPUs-->
 	<!-- lastzMemory The memory to allocate for each blast job -->
 	<!-- runMapQFiltering Filter alignments by score/mapQ, ranking alignments from highest mapQ/score to lowest -->
 	<!-- minimumMapQValue Minimum score/mapQ -->
@@ -62,8 +61,7 @@
 		   filterByIdentity="0"
 		   identityRatio="3"
 		   minimumDistance="0.01"
-		   gpuLastz="false"
-		   gpuCount="0"			
+		   gpu="0"
 		   lastzMemory="littleMemory"
 	       chainMaxGapLength="1000000"
 		   chainGapOpen="5000"

--- a/src/cactus/progressive/cactus_progressive.py
+++ b/src/cactus/progressive/cactus_progressive.py
@@ -24,7 +24,6 @@ from toil.statsAndLogging import set_logging_from_options
 from toil.realtimeLogger import RealtimeLogger
 from toil.job import Job
 from toil.common import Toil
-from toil.lib.accelerators import count_nvidia_gpus
 
 from cactus.shared.common import getOptionalAttrib
 from cactus.shared.common import findRequiredNode
@@ -317,10 +316,7 @@ def main():
                         "rather than pulling one from quay.io")
     parser.add_argument("--binariesMode", choices=["docker", "local", "singularity"],
                         help="The way to run the Cactus binaries", default=None)
-    parser.add_argument("--gpu", action="store_true",
-                        help="Enable GPU acceleration by using Segaling instead of lastz")
-    parser.add_argument("--gpuCount", type=int,
-                        help="Specify the number of GPUs for each repeatmasking job (will also toggle on --gpu). By default (or if set to 0) all available GPUs are used")    
+    parser.add_argument("--gpu", nargs='?', const='all', default=None, help="toggle on GPU-enabled lastz, and specify number of GPUs (all available if no value provided)")
     parser.add_argument("--consCores", type=int, 
                         help="Number of cores for each cactus_consolidated job (defaults to all available / maxCores on single_machine)", default=None)
     parser.add_argument("--intermediateResultsUrl",
@@ -353,17 +349,6 @@ def main():
             raise RuntimeError('--consCores required for non single_machine batch systems')
     if options.maxCores is not None and options.consCores > int(options.maxCores):
         raise RuntimeError('--consCores must be <= --maxCores')
-    # gpuCount auto-sets gpu so you don't need to use both
-    if options.gpuCount:
-        options.gpu = True
-    # default to all gpus available (like we did before the gpu count option)
-    if options.gpu and not options.gpuCount:
-        if options.batchSystem.lower() in ['single_machine', 'singlemachine']:
-            options.gpuCount = count_nvidia_gpus()
-            if not options.gpuCount:
-                raise RuntimeError('Unable to automatically determine number of GPUs: Please set with --gpuCount')
-        else:
-            raise RuntimeError('--gpuCount required in order to use GPUs on non single_machine batch systems')
     
     # Mess with some toil options to create useful defaults.
     cactus_override_toil_options(options)


### PR DESCRIPTION
We used to have the `--gpu` option that toggled on gpus.  Then I added `--gpuCount` in #844 when testing out Toil's new accelerators resource.  But I don't think we really need the two separate options going forward, so before the next reelase this PR gets rid of `--gpuCount`.  The logic is now

* `--gpu`: toggle on segalign and give it all available gpus (same logic as always)
* `--gpu N`: toggle on segalign and give it `N` gpus (required when not using single machine)
* `--gpu 0` or don't specify `--gpu`: use lastz instead of segalign. 

The GPU enabled docker releases will keep having `--gpu` set by default (ie using all available GPUs unless otherwise set). 
