### PR TITLE
remove --maxRefGap option from cactus-hal2maf

### DIFF
--- a/src/cactus/maf/cactus_hal2maf.py
+++ b/src/cactus/maf/cactus_hal2maf.py
@@ -61,9 +61,6 @@ def main():
                         help="comma-separated (no spaces) list of target "
                         "genomes (others are excluded) (vist all if empty)",
                         default=None)
-    parser.add_argument("--maxRefGap",
-                        help="maximum gap length in reference", type=int,
-                        default=None)
     parser.add_argument("--noDupes",
                         help="ignore paralogy edges",
                         action="store_true",
@@ -257,8 +254,6 @@ def hal2maf_cmd(hal_path, chunk, chunk_num, options):
         cmd += ' --rootGenome {}'.format(options.rootGenome)
     if options.targetGenomes:
         cmd += ' --targetGenomes {}'.format(options.targetGenomes)
-    if options.maxRefGap:
-        cmd += ' --maxRefGap {}'.format(options.maxRefGap)
     if options.noDupes:
         cmd += ' --noDupes'
     if options.onlyOrthologs:


### PR DESCRIPTION
This option is slow and has been shown to give unexpected results on some large data sets.  So remove it from `cactus-hal2maf` to avoid getting anyone's hopes up.  Keeping in mind that the same functionality is getting performed by the taffy normalization (50bp by default, controllable by the `--gapFill` option).