### PR TITLE
Fix taffy / htslib issue

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,7 @@ image: quay.io/comparative-genomics-toolkit/cactus-ci-base:latest
 before_script:
   - whoami
   - sudo apt-get -q -y update
-  - sudo apt-get -q -y install --no-upgrade bcftools parallel libhts-dev tabix
+  - sudo apt-get -q -y install --no-upgrade bcftools parallel libdeflate-dev
   - startdocker || true
   - docker info
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/comparative-genomics-toolkit/ubuntu:22.04 AS builder
 
 # apt dependencies for build
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential git python3 python3-dev python3-pip zlib1g-dev wget libbz2-dev pkg-config libhdf5-dev liblzo2-dev libtokyocabinet-dev wget liblzma-dev libxml2-dev libssl-dev libpng-dev uuid-dev libcurl4-gnutls-dev libffi-dev python3-virtualenv rsync python-is-python3
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential git python3 python3-dev python3-pip zlib1g-dev wget libbz2-dev pkg-config libhdf5-dev liblzo2-dev libtokyocabinet-dev wget liblzma-dev libxml2-dev libssl-dev libpng-dev uuid-dev libcurl4-gnutls-dev libffi-dev python3-virtualenv rsync python-is-python3 libdeflate-dev
 
 # build cactus binaries
 RUN mkdir -p /home/cactus
@@ -65,7 +65,7 @@ RUN rm -rf /home/cactus/hal_lib && \
 FROM quay.io/comparative-genomics-toolkit/ubuntu:22.04
 
 # apt dependencies for runtime
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends git python3 python3-pip python3-distutils zlib1g libbz2-1.0 net-tools libhdf5-103 liblzo2-2 libtokyocabinet9 libkrb5-3 libk5crypto3 time liblzma5 libcurl4 libcurl4-gnutls-dev libxml2 libgomp1 libffi7 parallel
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends git python3 python3-pip python3-distutils zlib1g libbz2-1.0 net-tools libhdf5-103 liblzo2-2 libtokyocabinet9 libkrb5-3 libk5crypto3 time liblzma5 libcurl4 libcurl4-gnutls-dev libxml2 libgomp1 libffi7 parallel libdeflate0
 
 # required for ubuntu22 but won't work anywhere else
 RUN bash -c "if ! command -v catchsegv > /dev/null; then apt-get install glibc-tools; fi"

--- a/build-tools/downloadMafTools
+++ b/build-tools/downloadMafTools
@@ -40,7 +40,7 @@ export HTSLIB_LIBS="$(pwd)/libhts.a -lbz2 -ldeflate -lm -lpthread -lz -llzma -pt
 cd ${mafBuildDir}
 git clone https://github.com/ComparativeGenomicsToolkit/taffy.git
 cd taffy
-git checkout f2328dfdb73be770bd4ea67b8d5f1c6f1b6c9302
+git checkout d8cdc6a32b546bb0574233272c7b2647c0dba5e0
 git submodule update --init --recursive
 export HALDIR=${CWD}/submodules/hal
 make -j ${numcpu}

--- a/build-tools/downloadMafTools
+++ b/build-tools/downloadMafTools
@@ -23,17 +23,24 @@ mkdir -p ${binDir}
 
 # taffy
 cd ${mafBuildDir}
-git clone https://github.com/samtools/htslib.git
-cd htslib
-git checkout 1.16
-git submodule update --init --recursive
+wget -q https://github.com/samtools/samtools/releases/download/1.11/samtools-1.11.tar.bz2
+tar -xf samtools-1.11.tar.bz2
+cd samtools-1.11
+SAMTOOLS_CONFIG_OPTS=""
+if [[ $STATIC_CHECK -eq 1 ]]
+then
+	 SAMTOOLS_CONFIG_OPTS="--disable-shared --enable-static"
+fi
+./configure --without-curses --disable-libcurl --enable-configure-htslib $SAMTOOLS_CONFIG_OPTS
 make -j ${numcpu}
-export HTSLIB_CFLAGS=-I$(pwd)/
-export HTSLIB_LIBS=$(pwd)/libhts.a
+cd htslib-1.11
+make -j ${numcpu} libhts.a
+export HTSLIB_CFLAGS=-I$(pwd)/htslib
+export HTSLIB_LIBS="$(pwd)/libhts.a -lbz2 -ldeflate -lm -lpthread -lz -llzma -pthread -lpthread"
 cd ${mafBuildDir}
 git clone https://github.com/ComparativeGenomicsToolkit/taffy.git
 cd taffy
-git checkout 62356fee8d917dbba3834d9df83411923c512db4
+git checkout f2328dfdb73be770bd4ea67b8d5f1c6f1b6c9302
 git submodule update --init --recursive
 export HALDIR=${CWD}/submodules/hal
 make -j ${numcpu}

--- a/build-tools/downloadMafTools
+++ b/build-tools/downloadMafTools
@@ -35,7 +35,7 @@ fi
 make -j ${numcpu}
 cd htslib-1.11
 make -j ${numcpu} libhts.a
-export HTSLIB_CFLAGS=-I$(pwd)/htslib
+export HTSLIB_CFLAGS=-I$(pwd)
 export HTSLIB_LIBS="$(pwd)/libhts.a -lbz2 -ldeflate -lm -lpthread -lz -llzma -pthread -lpthread"
 cd ${mafBuildDir}
 git clone https://github.com/ComparativeGenomicsToolkit/taffy.git

--- a/build-tools/makeBinRelease
+++ b/build-tools/makeBinRelease
@@ -47,6 +47,7 @@ export LDFLAGS="-static"
 export LIBS="-static"
 
 # throw in gnu parallel since cactus-hal2maf depends on it
+mkdir -p bin
 wget -q http://git.savannah.gnu.org/cgit/parallel.git/plain/src/parallel -O bin/parallel
 chmod +x bin/parallel
 


### PR DESCRIPTION
Enable htslib in taffy included in Cactus, allowing bgzip support.  This should have been on before, but wasn't due to a bug. 