### PR TITLE
More visibility for python 3.7 requirement. 

### DIFF
--- a/BIN-INSTALL.md
+++ b/BIN-INSTALL.md
@@ -19,8 +19,8 @@ echo "export PATH=$(pwd)/bin:\$PATH" >> cactus_env/bin/activate
 echo "export PYTHONPATH=$(pwd)/lib:\$PYTHONPATH" >> cactus_env/bin/activate
 source cactus_env/bin/activate
 python3 -m pip install -U setuptools pip
-python3 -m pip install -U -r ./toil-requirement.txt
 python3 -m pip install -U .
+python3 -m pip install -U -r ./toil-requirement.txt
 ```
 
 Some tools required for `hal2assemblyHub.py` are not included and must be downloaded separately.

--- a/BIN-INSTALL.md
+++ b/BIN-INSTALL.md
@@ -12,7 +12,7 @@ cd "cactus-bin-${REL_TAG}"
 
 ## Setup
 
-To build a python virtualenv and activate, do the following steps (Ubuntu 18.04 users should use `-p python3.8` below):
+To build a python virtualenv and activate, do the following steps. This requires Python version >= 3.7 (so Ubuntu 18.04 users should use `-p python3.8` below):
 ```
 virtualenv -p python3 cactus_env
 echo "export PATH=$(pwd)/bin:\$PATH" >> cactus_env/bin/activate

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ echo "export PATH=$(pwd)/bin:\$PATH" >> cactus_env/bin/activate
 echo "export PYTHONPATH=$(pwd)/lib:\$PYTHONPATH" >> cactus_env/bin/activate
 source cactus_env/bin/activate
 python3 -m pip install -U setuptools pip
-python3 -m pip install -U -r ./toil-requirement.txt
 python3 -m pip install -U .
+python3 -m pip install -U -r ./toil-requirement.txt
 ```
 
 If you have Docker installed, you can now run Cactus.  All binaries, such as `lastz` and `cactus-consolidated` will be run via Docker.  Singularity binaries can be used in place of docker binaries with the `--binariesMode singularity` flag.  Note, you must use Singularity 2.3 - 2.6 or Singularity 3.1.0+. Singularity 3 versions below 3.1.0 are incompatible with cactus (see [issue #55](https://github.com/ComparativeGenomicsToolkit/cactus/issues/55) and [issue #60](https://github.com/ComparativeGenomicsToolkit/cactus/issues/60)).

--- a/doc/pangenome.md
+++ b/doc/pangenome.md
@@ -539,4 +539,6 @@ Q: I hate the idea of clipping and filtering sequence from my graph.  Why do I h
 
 A: So current toolchains can work with your graphs.  But clipping and filtering is optional in `cactus-graphmap-join`, just specify `full` for the various outputs (keeping in mind that much satellite sequence won't be aligned to anything).
 
+**Q**: I get an error to the effect of `ERROR: No matching distribution found for toil[aws]==xxxx` when trying to install Toil.
 
+**A**: This is probably happening because you are using Python 3.6. Toil and Cactus require Python >= 3.7.  Use `python3 --version` to check your Python version.

--- a/doc/progressive.md
+++ b/doc/progressive.md
@@ -310,3 +310,7 @@ That said, cactus can handle multifurcations up to a point: runtime increases qu
 **Q**: But what if I want to use `--gpu` on my cluster? When I try from inside the GPU-enabled container, none of my cluster commands (ex `qsub`) are available.
 
 **A**: Install the Cactus binary release as described in the instructions on the Releases page.  But run Cactus with `--binariesMode docker` (or `singularity`).  This will let Cactus run SegAlign (and all other binaries) directly from the container, while itself running from the Python virtualenv.
+
+**Q**: I get an error to the effect of `ERROR: No matching distribution found for toil[aws]==xxxx` when trying to install Toil.
+
+**A**: This is probably happening because you are using Python 3.6. Toil and Cactus require Python >= 3.7.  Use `python3 --version` to check your Python version.

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     # We use the __file__ attribute so this package isn't zip_safe.
     zip_safe = False,
 
-    python_requires = '>=3.6',
+    python_requires = '>=3.7',
 
     install_requires = [
         'decorator',


### PR DESCRIPTION
Toil (and therefore Cactus) requires python >= 3.7. Something I've recently forgotten [forgetten](https://github.com/ComparativeGenomicsToolkit/cactus/issues/897#issuecomment-1378598668) when trying to help people with issues stemming from [being on python 3.6](https://github.com/DataBiosphere/toil/issues/4315#issuecomment-1416381653).

This PR adds a few more mentions in the docs...