### PR TITLE
Update to patched vg for vg clip fix

### DIFF
--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -278,7 +278,8 @@ fi
 
 # vg
 cd ${pangenomeBuildDir}
-wget -q https://github.com/vgteam/vg/releases/download/v1.45.0/vg
+#wget -q https://github.com/vgteam/vg/releases/download/v1.46.0/vg
+wget -q http://public.gi.ucsc.edu/~hickey/vg-patch/vg.82d6aca28f81c16135ee4542645c20d3a9bd9203 -O vg
 chmod +x vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd vg | grep so | wc -l) -eq 0 ]]
 then


### PR DESCRIPTION
There's a recent(ish) bug in `vg clip` that can crash on the last edge of a path.  This was brought to light here: #920. 

This PR switches to a custom-built vg that has a patch for this. 