### PR TITLE
remove stubs (by default) in pg clipping

### DIFF
--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -278,7 +278,8 @@ fi
 
 # vg
 cd ${pangenomeBuildDir}
-wget -q https://github.com/vgteam/vg/releases/download/v1.46.0/vg
+#wget -q https://github.com/vgteam/vg/releases/download/v1.47.0/vg
+wget -q http://public.gi.ucsc.edu/~hickey/vg-patch/vg.c2078c66439eae667833b9e71eb3b9789864b684 -O vg
 chmod +x vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd vg | grep so | wc -l) -eq 0 ]]
 then

--- a/doc/pangenome.md
+++ b/doc/pangenome.md
@@ -135,7 +135,7 @@ then work with `pp/seqfile` for the remaining commands.
 `cactus-graphmap-join` merges chromosome graphs created by `cactus-align-batch`, and also normalizes, clips and filters the graph in addition to producing some useful indexes.  It can produce up to three graphs (now in a single invocation), and a variety of indexes for any combination of them. The three graphs are the
 
 * `full` graph: This graph is normalized, but no sequence is removed. It and its indexes will have `.full` in their filenames. 
-* `clip` graph: This is the default graph. Stretches of sequence `>10kb` that were not aligned to the underlying SV/minigraph are removed.
+* `clip` graph: This is the default graph. Stretches of sequence `>10kb` that were not aligned to the underlying SV/minigraph are removed. "Dangling" nodes (ie that don't have an edge on each side) that aren't on the reference path are also removed, so that each chromosome only has two tips in the graph.
 * `filter` graph: This graph is made by removing nodes covered by fewer than 2 haplotypes from the `clip` graph.  It and its indexes will have `.d2` in their filenames.
 
 The `clip` graph is a subgraph of the `full` graph and the `filter` graph is a subgraph of the `clip` graph. Put another way, any node in the `filter` graph exists with the exact same ID and sequence in the `clip` graph, etc. 
@@ -586,3 +586,8 @@ A: So current toolchains can work with your graphs.  But clipping and filtering 
 **Q**: I get an error to the effect of `ERROR: No matching distribution found for toil[aws]==xxxx` when trying to install Toil.
 
 **A**: This is probably happening because you are using Python 3.6. Toil and Cactus require Python >= 3.7.  Use `python3 --version` to check your Python version.
+
+
+**Q**: `cactus-align-batch` spawns too many `cactus-align` jobs and runs out of memory. How do I fix this?
+
+**A**: You can control the number of jobs with `--alignCores` and `--maxCores` which set the cores per align job and total cores, respectively.  So to only do two align jobs at a time using 8 cores total, you can set `--alignCores 4 --maxCores 8`.

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -338,11 +338,13 @@
 	<!-- clipNonMinigraph: clip out regions if the don't align to minigraph (if disabled, clip if they don't align to anything) -->
 	<!-- minimizerOptions: options for vg minimizer -->
 	<!-- minFilterFragment: discard fragments that result from the vg clip frequency filter if they are smaller than this -->
+	<!-- removeStubs: remove any nodes dangling off reference paths (ie softclips) -->
 	<graphmap_join
 		 gfaffix="1"
 		 clipNonMinigraph="1"		 
 		 minimizerOptions="-k 29 -w 11"
 		 minFilterFragment="1000"
+		 removeStubs="1"
 		 />
 	<!-- hal2vg options -->
 	<!-- includeMinigraph: include minigraph node sequences as paths in output (note that cactus-graphmap-join will still remove them by default) -->

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -402,6 +402,12 @@ def clip_vg(job, options, config, vg_path, vg_id, phase):
         for ref in options.reference:
             clip_cmd += ['-P', ref]
         cmd.append(clip_cmd)
+        if phase == 'clip' and getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_join"), "removeStubs", typeFn=bool, default=True):
+            # todo: could save a little time by making vg clip smart enough to do two things at once
+            stub_cmd = ['vg', 'clip', '-s', '-']
+            for ref in options.reference:
+                stub_cmd += ['-P', ref]
+            cmd.append(stub_cmd)
 
     # and we sort by id on the first go-around
     if phase == 'full':


### PR DESCRIPTION
This forces everything to be a bubble. If something is dangling (and it's not the beginning of a ref chromosome) after graphmap and align, it gets clipped out by default now in join. 

We could soften this to allow dangling nodes from minigraph, but I don't think it would make a difference since minigraph doesn't produce them either (I think). 

The rationale is that the dangling nodes are probably not helping any current applications. And by mucking up the snarl structure, they are potentially making things like indexing more difficult than need be. 

The old logic, where stubs are kept, can be activated by toggling off `removeStubs` in the config. 