### PR TITLE
Adapt to newest deconstruct interface

### DIFF
--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -279,7 +279,7 @@ fi
 # vg
 cd ${pangenomeBuildDir}
 #wget -q https://github.com/vgteam/vg/releases/download/v1.47.0/vg
-wget -q http://public.gi.ucsc.edu/~hickey/vg-patch/vg.c2078c66439eae667833b9e71eb3b9789864b684 -O vg
+wget -q http://public.gi.ucsc.edu/~hickey/vg-patch/vg.0d21fd30674aebe3aa40e03a1396fc4cc348accb -O vg
 chmod +x vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd vg | grep so | wc -l) -eq 0 ]]
 then

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -339,12 +339,14 @@
 	<!-- minimizerOptions: options for vg minimizer -->
 	<!-- minFilterFragment: discard fragments that result from the vg clip frequency filter if they are smaller than this -->
 	<!-- removeStubs: remove any nodes dangling off reference paths (ie softclips) -->
+	<!-- GFANodeIDsInVCF: write all node IDs in the VCF (variant names, AT fields etc.) in the (unchopped) GFA namespace by way of the GBZ translation table -->
 	<graphmap_join
 		 gfaffix="1"
 		 clipNonMinigraph="1"		 
 		 minimizerOptions="-k 29 -w 11"
 		 minFilterFragment="1000"
 		 removeStubs="1"
+		 GFANodeIDsInVCF="1"
 		 />
 	<!-- hal2vg options -->
 	<!-- includeMinigraph: include minigraph node sequences as paths in output (note that cactus-graphmap-join will still remove them by default) -->


### PR DESCRIPTION
`vg deconstruct` won't use GFA (unchopped) node ids in the VCF by default anymore as of https://github.com/vgteam/vg/pull/3879.  

This PR adapts minigraph-cactus toggle this on by default (being consistent with how `cactus-graphmap-join` has always worked).  It can now be disabled in the config via `GFANodeIDsInVCF`.  

As mentioned in https://github.com/vgteam/vg/issues/3873, it may just be simplest to pre-chop everything to have a gfa consistent with the vg indexes.  This could at the very least be an option..