### PR TITLE
fix cactus-blast --restart

### DIFF
--- a/src/cactus/blast/cactus_blast.py
+++ b/src/cactus/blast/cactus_blast.py
@@ -88,7 +88,7 @@ def runCactusBlastOnly(options):
         importSingularityImage(options)
         #Run the workflow
         if options.restart:
-            outWorkFlowArgs = toil.restart()
+            paf_id = toil.restart()
         else:
 
             # load up the seqfile and figure out the outgroups and schedule


### PR DESCRIPTION
These --restart bugs find there way into the code during refactors and big merges because the CI tests can't check for them.  Thanks #960 for flagging this one. 