### PR TITLE
cactus-hal2chains

### DIFF
--- a/BIN-INSTALL.md
+++ b/BIN-INSTALL.md
@@ -23,13 +23,13 @@ python3 -m pip install -U .
 python3 -m pip install -U -r ./toil-requirement.txt
 ```
 
-Some tools required for `hal2assemblyHub.py` are not included and must be downloaded separately.
-They are `wigToBigWig faToTwoBit bedToBigBed bigBedToBed bedSort hgGcPercent`.  More information
+Some tools required for `hal2assemblyHub.py` and/or `cactus-hal2chains` are not included and must be downloaded separately.
+They are `wigToBigWig faToTwoBit bigBedToBed bedSort hgGcPercent axtChain pslPosTarget`.  More information
 can be found [here](https://hgdownload.cse.ucsc.edu/admin/exe/).  Note that some may require
 a license for commercial use.  Static binaries are not available, but the following command
 should set them up successfully on many 64 bit Linux systems:
 ```
-cd bin && for i in wigToBigWig faToTwoBit bedToBigBed bigBedToBed bedSort hgGcPercent axtChain pslPosTarget; do wget -q http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/${i}; chmod ugo+x ${i}; done
+cd bin && for i in wigToBigWig faToTwoBit bigBedToBed bedSort hgGcPercent axtChain pslPosTarget; do wget -q http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/${i}; chmod ugo+x ${i}; done
 ```
 
 ## Testing

--- a/BIN-INSTALL.md
+++ b/BIN-INSTALL.md
@@ -23,13 +23,13 @@ python3 -m pip install -U .
 python3 -m pip install -U -r ./toil-requirement.txt
 ```
 
-Some tools required for `hal2assemblyHub.py` and/or `cactus-hal2chains` are not included and must be downloaded separately.
-They are `wigToBigWig faToTwoBit bigBedToBed bedSort hgGcPercent axtChain pslPosTarget`.  More information
+Some tools required for `hal2assemblyHub.py`, `cactus-hal2chains` and `cactus-maf2bigmaf` are not included and must be downloaded separately.
+They are `wigToBigWig faToTwoBit bedToBigBed bigBedToBed axtChain pslPosTarget bedSort hgGcPercent mafToBigMaf hgLoadMafSummary`.  More information
 can be found [here](https://hgdownload.cse.ucsc.edu/admin/exe/).  Note that some may require
 a license for commercial use.  Static binaries are not available, but the following command
 should set them up successfully on many 64 bit Linux systems:
 ```
-cd bin && for i in wigToBigWig faToTwoBit bigBedToBed bedSort hgGcPercent axtChain pslPosTarget; do wget -q http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/${i}; chmod ugo+x ${i}; done
+cd bin && for i in wigToBigWig faToTwoBit bedToBigBed bigBedToBed axtChain pslPosTarget bedSort hgGcPercent mafToBigMaf hgLoadMafSummary; do wget -q http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/${i}; chmod +x ${i}; done
 ```
 
 ## Testing

--- a/BIN-INSTALL.md
+++ b/BIN-INSTALL.md
@@ -29,7 +29,7 @@ can be found [here](https://hgdownload.cse.ucsc.edu/admin/exe/).  Note that some
 a license for commercial use.  Static binaries are not available, but the following command
 should set them up successfully on many 64 bit Linux systems:
 ```
-cd bin && for i in wigToBigWig faToTwoBit bedToBigBed bigBedToBed bedSort hgGcPercent; do wget -q http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/${i}; chmod ugo+x ${i}; done
+cd bin && for i in wigToBigWig faToTwoBit bedToBigBed bigBedToBed bedSort hgGcPercent axtChain pslPosTarget; do wget -q http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/${i}; chmod ugo+x ${i}; done
 ```
 
 ## Testing

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN find /home/cactus -name include.local.mk -exec rm -f {} \; && \
 	 make -j $(nproc)
 
 # download open-licenses kent binaries used by hal for assembly hubs
-RUN cd /home/cactus/bin && for i in wigToBigWig faToTwoBit bedToBigBed bigBedToBed; do wget -q http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/${i}; chmod ugo+x ${i}; done
+RUN cd /home/cactus/bin && for i in wigToBigWig faToTwoBit bedToBigBed bigBedToBed axtChain pslPosTarget; do wget -q http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/${i}; chmod ugo+x ${i}; done
 
 # bedSort and hgGcPercent are part of a more restricted licence: https://hgdownload.cse.ucsc.edu/admin/exe/
 # if you agree to it, uncomment this line:

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,8 @@ RUN find /home/cactus -name include.local.mk -exec rm -f {} \; && \
 	 cd /home/cactus && rm -rf bin/* && make clean -j $(nproc) && \
 	 make -j $(nproc)
 
-# download open-licenses kent binaries used by hal for assembly hubs
-RUN cd /home/cactus/bin && for i in wigToBigWig faToTwoBit bedToBigBed bigBedToBed axtChain pslPosTarget; do wget -q http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/${i}; chmod ugo+x ${i}; done
+# download open-licenses kent binaries used by hal for assembly hubs and / or chains
+RUN cd /home/cactus/bin && for i in wigToBigWig faToTwoBit bigBedToBed axtChain pslPosTarget; do wget -q http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/${i}; chmod ugo+x ${i}; done
 
 # bedSort and hgGcPercent are part of a more restricted licence: https://hgdownload.cse.ucsc.edu/admin/exe/
 # if you agree to it, uncomment this line:

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,7 @@ RUN find /home/cactus -name include.local.mk -exec rm -f {} \; && \
 	 make -j $(nproc)
 
 # download open-licenses kent binaries used by hal for assembly hubs and / or chains
-RUN cd /home/cactus/bin && for i in wigToBigWig faToTwoBit bigBedToBed axtChain pslPosTarget; do wget -q http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/${i}; chmod ugo+x ${i}; done
-
-# bedSort and hgGcPercent are part of a more restricted licence: https://hgdownload.cse.ucsc.edu/admin/exe/
-# if you agree to it, uncomment this line:
-# RUN cd /home/cactus/bin && for i in bedSort hgGcPercent; do wget -q http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/${i}; chmod ugo+x ${i}; done
+RUN cd /home/cactus/bin && for i in wigToBigWig faToTwoBit bedToBigBed bigBedToBed axtChain pslPosTarget bedSort hgGcPercent mafToBigMaf hgLoadMafSummary; do wget -q http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/${i}; chmod ugo+x ${i}; done
 
 # download tools used for pangenome pipeline
 RUN cd /home/cactus && ./build-tools/downloadPangenomeTools

--- a/build-tools/downloadMafTools
+++ b/build-tools/downloadMafTools
@@ -55,7 +55,7 @@ fi
 cd ${mafBuildDir}
 git clone https://github.com/ComparativeGenomicsToolkit/mafTools.git
 cd mafTools
-git checkout 40cfa5b503a34b8b0b7799678237e2f13ae8bf36
+git checkout 0d2a253a528749bad2c6c0179bd15edd8d56adf6
 find . -name "*.mk" | xargs sed -ie "s/-Werror//g"
 find . -name "Makefile*" | xargs sed -ie "s/-Werror//g"
 # hack in flags support

--- a/doc/progressive.md
+++ b/doc/progressive.md
@@ -118,6 +118,18 @@ Many applications that take MAF as input expect a single row per sample per bloc
 
 Unlike `hal2maf`, `cactus-hal2maf` does not write ancestral genomes by default. To add them to the maf, use `--ancestors`. 
 
+### BigMaf
+
+[UCSC BigMaf](https://genome.ucsc.edu/goldenPath/help/bigMaf.html) is an indexed version of MAF (see above) that can viewed on the Genome Browser. `cactus-maf2bigmaf` can be used to convert MAF (as output by `cactus-hal2maf`) into BigMaf.
+
+```
+cactus-maf2bigmaf ./js ./evolverMammals.maf.gz ./evolverMammals.bigmaf.bb --refGenome simHuman_chr6 --halFile evolverMammals.hal
+```
+
+This will produce the BigMaf file `evolverMammals.bigmaf.bb` along with the summary file `evolverMammals.bigmaf.summary.bb` which is used by the browser for zoomed out summary display.
+
+The chromosome sizes of the reference genome must be provided as input either directly with `--chromSizes` or via the original hal file via `--halFile`.
+
 ### Chains
 
 The [UCSC Chain Format](https://genome.ucsc.edu/goldenPath/help/chain.html) is a concise way to represent pairwise alignments, and is used by the Genome Browser and some of its tools. HAL files can be converted into sets of Chain files using `cactus-hal2chain`.

--- a/doc/progressive.md
+++ b/doc/progressive.md
@@ -143,7 +143,9 @@ cactus-hal2chain ./js ./evolverMammals.hal chains-dir --refGenome simHuman_chr6
 
 will create `./chains-dir` and populate it with a Chain alignment between simHuman and each other leaf genome in evolverMammals.hal.
 
-By default, chains will be created using `halLiftover` [as in CAT](https://github.com/ComparativeGenomicsToolkit/Comparative-Annotation-Toolkit/blob/fc1623da5df1309d2e2f0b9bb0363aaab84708f4/cat/chaining.py#L96-L98). An option `--useHalSynteny` is provided to use that tool instead. 
+By default, chains will be created using `halLiftover` [as in CAT](https://github.com/ComparativeGenomicsToolkit/Comparative-Annotation-Toolkit/blob/fc1623da5df1309d2e2f0b9bb0363aaab84708f4/cat/chaining.py#L96-L98). An option `--useHalSynteny` is provided to use that tool instead.
+
+See here for an all-vs-all script to make chains, including BigChain conversion: https://github.com/human-pangenomics/HPRC_Assembly_Hub/blob/main/chains/wdl/snakesonachain.wdl
 
 ### CAT
 

--- a/doc/progressive.md
+++ b/doc/progressive.md
@@ -114,7 +114,7 @@ Depending on the application, you may want to handle duplication events differen
 
 * "single" : Uses greedy heuristics to pick the copy for each species that results in fewest mutations and block breaks. Recommended when visualizing via BigMaf (see below)
 * "ancestral" : Restricts the duplication relationships shown to only those orthologous to the reference genome according to the HAL tree. There may be multiple orthologs per genome. This relies on the dating of the duplication in the hal tree (ie in which genome it is explicitly self-aligned) and is still a work in progress.
-* "all" : (default) All duplications are written, including ancestral events (orthologs) and paralogs in the reference. 
+* "all" : (default) All duplications are written, including ancestral events (orthologs) and paralogs in the reference. Note that by default, some duplications will be filtered out if they break MAF blocks. To disable this in order to truly catch them all, use `--keepGapCausingDupes`.
 
 Usually a reference genome is specified with `--refGenome` and ancestral genomes are excluded `--noAncestors`. Since the default reference is the root of the alignment, `--noAncestors` can only be specified if a leaf genome is used with `--refGenome`. 
 

--- a/doc/progressive.md
+++ b/doc/progressive.md
@@ -110,17 +110,19 @@ The various batching options can be used to tune distributed runs on very large 
 --chunkSize 1000000 --batchCount 4 --batchCores 32 --batchParallelTaf 8 --batchSystem mesos --provisioner aws --defaultPreemptable --nodeStorage 2000 --maxNodes 4 --nodeTypes r5.8xlarge 
 ```
 
-Many applications that take MAF as input expect a single row per sample per block. In other words, no duplications. By default, `cactus-hal2maf` will output MAF files in this form, using heuristics to try to pick the copy that most resembles the reference and causes fewer block breaks. This behaviour can be changed with the `--dupeMode` option in `cactus-hal2maf`.  The possible values are:
+Depending on the application, you may want to handle duplication events differently when creating the MAF. Three different modes are available via the `--dupeMode` option.
 
-* "single" : This is the default which, as described above, uses greedy heuristics to pick the copy for each species that results in fewest mutations and block breaks.
-* "ancestral" : Duplications are written for species if they can be traced to ancestral genomes in the tree.
-* "all" : All duplications are written, including ancestral (above) and "novel" paralogs in the species in question. 
+* "single" : Uses greedy heuristics to pick the copy for each species that results in fewest mutations and block breaks. Recommended when visualizing via BigMaf (see below)
+* "ancestral" : Restricts the duplication relationships shown to only those orthologous to the reference genome according to the HAL tree. There may be multiple orthologs per genome. This relies on the dating of the duplication in the hal tree (ie in which genome it is explicitly self-aligned) and is still a work in progress.
+* "all" : (default) All duplications are written, including ancestral events (orthologs) and paralogs in the reference. 
 
 Usually a reference genome is specified with `--refGenome` and ancestral genomes are excluded `--noAncestors`. Since the default reference is the root of the alignment, `--noAncestors` can only be specified if a leaf genome is used with `--refGenome`. 
 
 ### BigMaf
 
 [UCSC BigMaf](https://genome.ucsc.edu/goldenPath/help/bigMaf.html) is an indexed version of MAF (see above) that can viewed on the Genome Browser. `cactus-maf2bigmaf` can be used to convert MAF (as output by `cactus-hal2maf`) into BigMaf.
+
+It is recommended to create the maf using the `--noAncestors --dupeMode single` options with `cactus-hal2maf`.
 
 ```
 cactus-maf2bigmaf ./js ./evolverMammals.maf.gz ./evolverMammals.bigmaf.bb --refGenome simHuman_chr6 --halFile evolverMammals.hal

--- a/doc/progressive.md
+++ b/doc/progressive.md
@@ -136,7 +136,7 @@ The [UCSC Chain Format](https://genome.ucsc.edu/goldenPath/help/chain.html) is a
 
 For example
 ```
-cactus-hal2chain ./js ./evolverMammals.hal chains-dir --refGenome simHuman_chr6 --inMemory
+cactus-hal2chain ./js ./evolverMammals.hal chains-dir --refGenome simHuman_chr6 
 ```
 
 will create `./chains-dir` and populate it with a Chain alignment between simHuman and each other leaf genome in evolverMammals.hal.

--- a/doc/progressive.md
+++ b/doc/progressive.md
@@ -100,7 +100,7 @@ Please [cite HAL](https://doi.org/10.1093/bioinformatics/btt128).
 The HAL format represents the alignment in a reference-free, indexed way, but isn't readable by many tools. Many applications will require direct access to alignment columns, which requires "transposing" the row-based HAL format. This is best done by converting to [MAF](https://genome.cse.ucsc.edu/FAQ/FAQformat.html#format5), which can be computationally expensive for larger files. A toil-powered distributed MAF exporter is provided with Cactus.  Note that MAF is a reference-based format, so a reference (which can be any genome, leaf or ancestor, in the HAL file must be specified).
 
 ```
-cactus-hal2maf ./js ./evolverMammals.hal evolverMammals.maf.gz --refGenome simHuman_chr6 --chunkSize 1000000
+cactus-hal2maf ./js ./evolverMammals.hal evolverMammals.maf.gz --refGenome simHuman_chr6 --chunkSize 1000000 --noAncestors
 ```
 
 `cactus-hal2maf`, in addition to providing parallelism with Toil, also adds [TAFFY](https://github.com/ComparativeGenomicsToolkit/taffy)-based normalization and is therefore recommended over running `hal2maf` directly. To better understand the normalzation options, see the [TAFFY](https://github.com/ComparativeGenomicsToolkit/taffy) link above. `cactus-hal2maf` provides an interface to toggle them, and attempts to use sensible defaults. They can be completely deactivated with the `--raw` option. 
@@ -116,7 +116,7 @@ Many applications that take MAF as input expect a single row per sample per bloc
 * "ancestral" : Duplications are written for species if they can be traced to ancestral genomes in the tree.
 * "all" : All duplications are written, including ancestral (above) and "novel" paralogs in the species in question. 
 
-Unlike `hal2maf`, `cactus-hal2maf` does not write ancestral genomes by default. To add them to the maf, use `--ancestors`. 
+Usually a reference genome is specified with `--refGenome` and ancestral genomes are excluded `--noAncestors`. Since the default reference is the root of the alignment, `--noAncestors` can only be specified if a leaf genome is used with `--refGenome`. 
 
 ### BigMaf
 

--- a/doc/progressive.md
+++ b/doc/progressive.md
@@ -110,6 +110,19 @@ The various batching options can be used to tune distributed runs on very large 
 --chunkSize 1000000 --batchCount 4 --batchCores 32 --batchParallelTaf 8 --batchSystem mesos --provisioner aws --defaultPreemptable --nodeStorage 2000 --maxNodes 4 --nodeTypes r5.8xlarge 
 ```
 
+### Chains
+
+The [UCSC Chain Format](https://genome.ucsc.edu/goldenPath/help/chain.html) is a concise way to represent pairwise alignments, and is used by the Genome Browser and some of its tools. HAL files can be converted into sets of Chain files using `cactus-hal2chain`.
+
+For example
+```
+cactus-hal2chain ./js ./evolverMammals.hal chains-dir --refGenome simHuman_chr6 --inMemory
+```
+
+will create `./chains-dir` and populate it with a Chain alignment between simHuman and each other leaf genome in evolverMammals.hal.
+
+By default, chains will be created using `halLiftover` [as in CAT](https://github.com/ComparativeGenomicsToolkit/Comparative-Annotation-Toolkit/blob/fc1623da5df1309d2e2f0b9bb0363aaab84708f4/cat/chaining.py#L96-L98). An option `--useHalSynteny` is provided to use that tool instead. 
+
 ### CAT
 
 You can use the alignment to generate gene annotatations for your assemblies, using the [Comparative Annotation Toolkit](https://github.com/ComparativeGenomicsToolkit/Comparative-Annotation-Toolkit).

--- a/setup.py
+++ b/setup.py
@@ -62,4 +62,5 @@ setup(
                             'cactus-align-batch = cactus.setup.cactus_align:main_batch',
                             'cactus-update-prepare = cactus.update.cactus_update_prepare:main',
                             'cactus-terra-helper = cactus.progressive.cactus_terra_helper:main',
-                            'cactus-hal2maf = cactus.maf.cactus_hal2maf:main']},)
+                            'cactus-hal2maf = cactus.maf.cactus_hal2maf:main',
+                            'cactus-hal2chains = cactus.maf.cactus_hal2chains:main']},)

--- a/setup.py
+++ b/setup.py
@@ -63,4 +63,5 @@ setup(
                             'cactus-update-prepare = cactus.update.cactus_update_prepare:main',
                             'cactus-terra-helper = cactus.progressive.cactus_terra_helper:main',
                             'cactus-hal2maf = cactus.maf.cactus_hal2maf:main',
-                            'cactus-hal2chains = cactus.maf.cactus_hal2chains:main']},)
+                            'cactus-hal2chains = cactus.maf.cactus_hal2chains:main',
+                            'cactus-maf2bigmaf = cactus.maf.cactus_maf2bigmaf:main']},)

--- a/src/cactus/maf/cactus_hal2chains.py
+++ b/src/cactus/maf/cactus_hal2chains.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+
+"""
+This is a script to convert a HAL file into a set of pairwise alignment in UCSC chains format.
+"""
+
+import os, sys
+from argparse import ArgumentParser
+import copy
+import timeit, time
+import math
+import xml.etree.ElementTree as ET
+
+from operator import itemgetter
+
+from cactus.progressive.seqFile import SeqFile
+from cactus.shared.common import setupBinaries, importSingularityImage
+from cactus.shared.common import cactusRootPath
+from cactus.shared.configWrapper import ConfigWrapper
+from cactus.shared.common import makeURL, catFiles
+from cactus.shared.common import enableDumpStack
+from cactus.shared.common import cactus_override_toil_options
+from cactus.shared.common import cactus_call
+from cactus.shared.common import getOptionalAttrib, findRequiredNode
+from cactus.shared.version import cactus_commit
+from toil.job import Job
+from toil.common import Toil
+from toil.statsAndLogging import logger
+from toil.statsAndLogging import set_logging_from_options
+from toil.realtimeLogger import RealtimeLogger
+from cactus.shared.common import cactus_cpu_count
+from toil.lib.humanize import bytes2human
+from sonLib.bioio import getTempDirectory
+
+def main():
+    parser = ArgumentParser()
+    Job.Runner.addToilOptions(parser)
+
+    parser.add_argument("halFile", help = "HAL file to convert to MAF")
+    parser.add_argument("outDir", help = "Output directory")
+
+    parser.add_argument("--refGenome", required=True,
+                        help="name of reference genome (root if empty)",
+                        default=None)
+    parser.add_argument("--targetGenomes",
+                        help="comma-separated (no spaces) list of target "
+                        "genomes (others are excluded) (vist all non-ancestral if empty)",
+                        default=None)
+
+    parser.add_argument("--useHalSynteny",
+                        help="use halSynteny instead of halLiftover. halLiftover is default because that's what CAT uses",
+                        action="store_true")
+    parser.add_argument("--maxAnchorDistance", type=int,
+                        help="set --maxAnchorDistance in halSynteny")
+    parser.add_argument("--minBlockSize", type=int,
+                        help="set --minBlockSize in halSynteny")
+
+    parser.add_argument("--inMemory",
+                       help="use --inMemory for halLiftover and/or halSynteny",
+                       action="store_true")
+    
+    #Progressive Cactus Options
+    parser.add_argument("--configFile", dest="configFile",
+                        help="Specify cactus configuration file",
+                        default=os.path.join(cactusRootPath(), "cactus_progressive_config.xml"))
+    parser.add_argument("--latest", dest="latest", action="store_true",
+                        help="Use the latest version of the docker container "
+                        "rather than pulling one matching this version of cactus")
+    parser.add_argument("--containerImage", dest="containerImage", default=None,
+                        help="Use the the specified pre-built containter image "
+                        "rather than pulling one from quay.io")
+    parser.add_argument("--binariesMode", choices=["docker", "local", "singularity"],
+                        help="The way to run the Cactus binaries", default=None)
+
+    options = parser.parse_args()
+
+    setupBinaries(options)
+    set_logging_from_options(options)
+    enableDumpStack()
+
+    if options.maxAnchorDistance and not options.useHalSynteny:
+        raise RuntimeError('--maxAnchorDistance can only be used with --useHalSynteny')
+    if options.minBlockSize and not options.useHalSynteny:
+        raise RuntimeError('--minBlockSize can only be used with --useHalSynteny')
+    
+    # Mess with some toil options to create useful defaults.
+    cactus_override_toil_options(options)
+
+    logger.info('Cactus Command: {}'.format(' '.join(sys.argv)))
+    logger.info('Cactus Commit: {}'.format(cactus_commit))
+    start_time = timeit.default_timer()
+
+    # make sure we have an outdir
+    if not options.outDir.startswith('s3://') and not os.path.isdir(options.outDir):
+        os.makedirs(options.outDir)
+
+    with Toil(options) as toil:
+        importSingularityImage(options)
+        #Run the workflow
+        if options.restart:
+            maf_id = toil.restart()
+        else:
+            #load cactus config
+            configNode = ET.parse(options.configFile).getroot()
+            config = ConfigWrapper(configNode)
+            config.substituteAllPredefinedConstantsWithLiterals()
+            
+            logger.info("Importing {}".format(options.halFile))
+            hal_id = toil.importFile(options.halFile)            
+            chains_id_dict = toil.start(Job.wrapJobFn(hal2chains_workflow, config, options, hal_id))
+
+        #export the chains
+        for tgt_genome, chain_id in chains_id_dict.items():            
+            toil.exportFile(chain_id, makeURL(os.path.join(options.outDir, tgt_genome + ".chain.gz")))
+        
+    end_time = timeit.default_timer()
+    run_time = end_time - start_time
+    logger.info("cactus-hal2chains has finished after {} seconds".format(run_time))
+
+
+def hal2chains_workflow(job, config, options, hal_id):
+    root_job = Job()
+    job.addChild(root_job)
+    check_tools_job = root_job.addChildJobFn(hal2chains_check_tools)
+    ref_info_job = check_tools_job.addFollowOnJobFn(hal2chains_ref_info, config, options, hal_id)
+    hal2chains_all_job = ref_info_job.addFollowOnJobFn(hal2chains_all, config, options, hal_id, ref_info_job.rv())
+    return hal2chains_all_job.rv()
+
+def hal2chains_check_tools(job):
+    """ make sure we have the required ucsc commands available on the PATH"""
+    for tool in ['axtChain', 'faToTwoBit', 'pslPosTarget']:
+        try:
+            cactus_call(parameters=[tool])
+        except Exception as e:
+            # hacky way to see if the usage info came out of running the command with no arguments
+            if "usage:" in str(e):
+                continue
+        raise RuntimeError('Required tool, {}, not found in PATH. Please download it with wget -q https://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/{}'.format(tool, tool))
+            
+def hal2chains_ref_info(job, config, options, hal_id):
+    """ get the BED and 2bit file for the reference genome from the hal """
+    work_dir = job.fileStore.getLocalTempDir()
+    hal_path = os.path.join(work_dir, os.path.basename(options.halFile.replace(' ', '.')))
+    RealtimeLogger.info("Reading HAL file from job store to {}".format(hal_path))    
+    job.fileStore.readGlobalFile(hal_id, hal_path)
+    RealtimeLogger.info("Computing chromosomes and 2bit ref sequence")
+
+    bed_path = os.path.join(work_dir, options.refGenome + '.bed')
+    cactus_call(parameters=[['halStats', hal_path, '--chromSizes', options.refGenome],
+                            ['awk', '{{print $1 "\t0\t" $2}}']],
+                outfile=bed_path)
+
+    fa_path = os.path.join(work_dir, options.refGenome + '.fa')
+    cactus_call(parameters=['hal2fasta', hal_path, options.refGenome], outfile=fa_path)
+
+    tbit_path = os.path.join(work_dir, options.refGenome + '.2bit')
+    cactus_call(parameters=['faToTwoBit', fa_path, tbit_path])
+
+    genomes=cactus_call(parameters=['halStats', '--genomes', hal_path], check_output=True).split()
+
+    graph_event = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap"), "assemblyName", default="_MINIGRAPH_")
+    leaf_genomes = []
+    for genome in genomes:
+        if genome != options.refGenome and genome != graph_event and \
+           not cactus_call(parameters=['halStats', hal_path, '--children', genome], check_output=True).strip():
+            leaf_genomes.append(genome)
+    
+    return { 'bed' : job.fileStore.writeGlobalFile(bed_path),
+             '2bit' : job.fileStore.writeGlobalFile(tbit_path),
+             'genomes' : genomes,
+             'leaf_genomes' : leaf_genomes }
+
+def hal2chains_all(job, config, options, hal_id, ref_info):
+    """ convert all the genomes in parallel """
+    tgt_genomes = []
+    hal_genomes = set(ref_info['genomes'])
+    if options.targetGenomes:
+        for opt_target_genome in options.targetGenomes.split(','):
+            if option_target_genome not in hal_genomes:
+                raise RuntimeError('--targetGenome {} not found in HAL'.format(option_target_genome))
+            else:
+                tgt_genomes.append(opt_target_genome)
+    else:
+        tgt_genomes = ref_info['leaf_genomes']
+        
+    chains_output_dict = {}
+    for tgt_genome in tgt_genomes:
+        chains_job = job.addChildJobFn(hal2chains_genome, config, options, hal_id, ref_info, tgt_genome,
+                                       disk=int(hal_id.size * 1.2),
+                                       memory=(ref_info['2bit'].size * 10))
+        chains_output_dict[tgt_genome] = chains_job.rv()
+    return chains_output_dict
+    
+def hal2chains_genome(job, config, options, hal_id, ref_info, tgt_genome):
+    """ convert one genome to chains """
+    work_dir = job.fileStore.getLocalTempDir()
+    hal_path = os.path.join(work_dir, os.path.basename(options.halFile.replace(' ', '.')))
+    RealtimeLogger.info("Reading HAL file from job store to {}".format(hal_path))    
+    job.fileStore.readGlobalFile(hal_id, hal_path)
+    RealtimeLogger.info("Computing chains for {}".format(tgt_genome))
+
+    bed_path = os.path.join(work_dir, options.refGenome + '.bed')
+    job.fileStore.readGlobalFile(ref_info['bed'], bed_path)
+    ref_2bit_path = os.path.join(work_dir, options.refGenome + '.2bit')
+    job.fileStore.readGlobalFile(ref_info['2bit'], ref_2bit_path)
+
+    # we need the target sequence for axtChain
+    tgt_fa_path = os.path.join(work_dir, tgt_genome + '.fa')
+    cactus_call(parameters=['hal2fasta', hal_path, tgt_genome], outfile=tgt_fa_path)
+
+    tgt_2bit_path = os.path.join(work_dir, tgt_genome + '.2bit')
+    cactus_call(parameters=['faToTwoBit', tgt_fa_path, tgt_2bit_path])
+    os.remove(tgt_fa_path)
+
+    # the output
+    tgt_chain_path = os.path.join(work_dir, tgt_genome + '.chain.gz')
+
+    # make our hal -> psl -> chain piped command
+
+    cmd = []
+
+    if options.useHalSynteny:
+        hal_synteny_cmd = ['halSynteny', hal_path, '/dev/stdout', '--queryGenome', options.refGenome, '--targetGenome', tgt_genome]
+        if options.inMemory:
+            hal_synteny_cmd.append('--inMemory')
+        if options.maxAnchorDistance:
+            hal_synteny_cmd += ['--maxAnchorDistance', str(options.maxAnchorDistance)]
+        if options.minBlockSize:
+            hal_synteny_cmd += ['--minBlockSize', str(options.minBlockSize)]
+        cmd.append(hal_synteny_cmd)
+    else:
+        hal_liftover_cmd = ['halLiftover', hal_path, options.refGenome, bed_path, tgt_genome, '/dev/stdout', '--outPSL']
+        if options.inMemory:
+            hal_liftover_cmd.append('--inMemory')
+        cmd.append(hal_liftover_cmd)
+
+    cmd.append(['pslPosTarget', '/dev/stdin', '/dev/stdout'])
+
+    cmd.append(['axtChain', '-psl', '-verbose=0', '-linearGap=medium', '/dev/stdin', tgt_2bit_path, ref_2bit_path, '/dev/stdout'])
+
+    cmd.append(['gzip'])
+
+    cactus_call(parameters=cmd, outfile = tgt_chain_path)
+
+    return job.fileStore.writeGlobalFile(tgt_chain_path)
+            

--- a/src/cactus/maf/cactus_hal2chains.py
+++ b/src/cactus/maf/cactus_hal2chains.py
@@ -98,7 +98,7 @@ def main():
         importSingularityImage(options)
         #Run the workflow
         if options.restart:
-            maf_id = toil.restart()
+            chains_id_dict = toil.restart()
         else:
             #load cactus config
             configNode = ET.parse(options.configFile).getroot()

--- a/src/cactus/maf/cactus_hal2chains.py
+++ b/src/cactus/maf/cactus_hal2chains.py
@@ -110,8 +110,9 @@ def main():
             chains_id_dict = toil.start(Job.wrapJobFn(hal2chains_workflow, config, options, hal_id))
 
         #export the chains
-        for tgt_genome, chain_id in chains_id_dict.items():            
-            toil.exportFile(chain_id, makeURL(os.path.join(options.outDir, tgt_genome + ".chain.gz")))
+        for tgt_genome, chain_id in chains_id_dict.items():
+            clean_name = tgt_genome.replace('#', '.').replace(' ', '.')
+            toil.exportFile(chain_id, makeURL(os.path.join(options.outDir, clean_name + ".chain.gz")))
         
     end_time = timeit.default_timer()
     run_time = end_time - start_time

--- a/src/cactus/maf/cactus_hal2chains.py
+++ b/src/cactus/maf/cactus_hal2chains.py
@@ -46,7 +46,6 @@ def main():
                         help="comma-separated (no spaces) list of target "
                         "genomes (others are excluded) (vist all non-ancestral if empty)",
                         default=None)
-
     parser.add_argument("--useHalSynteny",
                         help="use halSynteny instead of halLiftover. halLiftover is default because that's what CAT uses",
                         action="store_true")
@@ -151,11 +150,9 @@ def hal2chains_ref_info(job, config, options, hal_id):
                             ['awk', '{{print $1 "\t0\t" $2}}']],
                 outfile=bed_path)
 
-    fa_path = os.path.join(work_dir, options.refGenome + '.fa')
-    cactus_call(parameters=['hal2fasta', hal_path, options.refGenome], outfile=fa_path)
-
-    tbit_path = os.path.join(work_dir, options.refGenome + '.2bit')
-    cactus_call(parameters=['faToTwoBit', fa_path, tbit_path])
+    tbit_path = os.path.join(work_dir, options.refGenome + '.2bit')    
+    cactus_call(parameters=[['hal2fasta', hal_path, options.refGenome],
+                            ['faToTwoBit', 'stdin', tbit_path]])
 
     genomes=cactus_call(parameters=['halStats', '--genomes', hal_path], check_output=True).split()
 
@@ -206,12 +203,9 @@ def hal2chains_genome(job, config, options, hal_id, ref_info, tgt_genome):
     job.fileStore.readGlobalFile(ref_info['2bit'], ref_2bit_path)
 
     # we need the target sequence for axtChain
-    tgt_fa_path = os.path.join(work_dir, tgt_genome + '.fa')
-    cactus_call(parameters=['hal2fasta', hal_path, tgt_genome], outfile=tgt_fa_path)
-
-    tgt_2bit_path = os.path.join(work_dir, tgt_genome + '.2bit')
-    cactus_call(parameters=['faToTwoBit', tgt_fa_path, tgt_2bit_path])
-    os.remove(tgt_fa_path)
+    tgt_2bit_path = os.path.join(work_dir, tgt_genome + '.2bit')    
+    cactus_call(parameters=[['hal2fasta', hal_path, tgt_genome],
+                            ['faToTwoBit', 'stdin', tgt_2bit_path]])
 
     # the output
     tgt_chain_path = os.path.join(work_dir, tgt_genome + '.chain.gz')

--- a/src/cactus/maf/cactus_hal2maf.py
+++ b/src/cactus/maf/cactus_hal2maf.py
@@ -100,9 +100,9 @@ def main():
                         action="store_true")
 
     parser.add_argument("--maxRefNFrac",
-                        help="(hopefully temporary) partial work around of a current bug that aligns through Ns by filtering out MAF blocks whose reference (first) line has a greater fraction of Ns than the given amount. Should be between 0.0 (filter everything) and 1.0 (filter nothing). [default=0.75]",
+                        help="Filter out MAF blocks whose reference (first) line has a greater fraction of Ns than the given amount. Should be between 0.0 (filter everything) and 1.0 (filter nothing). [default=0.95]",
                         type=float,
-                        default=0.75)
+                        default=0.95)
                         
     #Progressive Cactus Options
     parser.add_argument("--configFile", dest="configFile",

--- a/src/cactus/maf/cactus_hal2maf.py
+++ b/src/cactus/maf/cactus_hal2maf.py
@@ -98,7 +98,12 @@ def main():
     parser.add_argument("--keepGapCausingDupes",
                         help="Turn off taffy norm -d filter that removes duplications that would induce gaps > maximumGapLength",
                         action="store_true")
-    
+
+    parser.add_argument("--maxRefNFrac",
+                        help="(hopefully temporary) partial work around of a current bug that aligns through Ns by filtering out MAF blocks whose reference (first) line has a greater fraction of Ns than the given amount. Should be between 0.0 (filter everything) and 1.0 (filter nothing). [default=0.75]",
+                        type=float,
+                        default=0.75)
+                        
     #Progressive Cactus Options
     parser.add_argument("--configFile", dest="configFile",
                         help="Specify cactus configuration file",
@@ -301,6 +306,8 @@ def taf_cmd(hal_path, chunk, chunk_num, options):
     cmd += ' | {} taffy norm -k -m {} -n {} {} -q {}{} 2> {}.tn.time'.format(time_cmd, options.maximumBlockLengthToMerge, options.maximumGapLength,
                                                                              '' if options.keepGapCausingDupes else '-d',
                                                                              options.fractionSharedRows, time_end, chunk_num)
+    if options.maxRefNFrac:
+        cmd += ' | mafFilter -m - -N {}'.format(options.maxRefNFrac)
     if options.dupeMode == 'single':
         cmd += ' | mafDuplicateFilter -m - -k'
     if chunk[1] != 0:

--- a/src/cactus/maf/cactus_hal2maf.py
+++ b/src/cactus/maf/cactus_hal2maf.py
@@ -45,12 +45,12 @@ def main():
     parser.add_argument("--chunkSize", type=int, help = "Size of chunks to operate on.", required=True)
     parser.add_argument("--batchParallelHal2maf", type=int, help = "Number of hal2maf commands to be executed in parallel in batch. Use to throttle down number of concurrent jobs to save memory. [default=batchCores]", default=None)
     parser.add_argument("--batchParallelTaf", type=int, help = "Number of taf normalization command chains to be executed in parallel in batch. Use to throttle down number of concurrent jobs to save memory. [default=batchCores]", default=None)    
-    parser.add_argument("--raw", action="store_true", help = "Do not run taf-based normalization on the MAF (add --dupeMode all to not filter out any duplications)")
+    parser.add_argument("--raw", action="store_true", help = "Do not run taf-based normalization on the MAF")
 
     # new dupe-handler option
     parser.add_argument("--dupeMode", type=str, choices=["single", "ancestral", "all"],
-                        help="Toggle how to handle duplications: None: heuristically choose most similar homolog; Ancestral: keep only duplications that coalesce in an ancestral sequence; All: keep all duplications, including anestral and novel paralogies in the target genome [default=Single]",
-                        default="single")
+                        help="Toggle how to handle duplications: None: heuristically choose single, most similar homolog; Ancestral: keep only duplications that are also separate in ancestor; All: keep all duplications, including paralogies (self-alignments) in given genome [default=All]",
+                        default="all")
 
     # pass through a subset of hal2maf options
     parser.add_argument("--refGenome", required=True,
@@ -273,7 +273,7 @@ def hal2maf_cmd(hal_path, chunk, chunk_num, options, config):
     if options.targetGenomes:
         cmd += ' --targetGenomes {}'.format(options.targetGenomes)
     if options.dupeMode == 'ancestral':
-        cmd += '--onlyOrthologs'
+        cmd += ' --onlyOrthologs'
     if options.noAncestors:
         cmd += ' --noAncestors'
     cmd += '{} 2> {}.h2m.time'.format(time_end, chunk_num)

--- a/src/cactus/maf/cactus_hal2maf.py
+++ b/src/cactus/maf/cactus_hal2maf.py
@@ -51,10 +51,6 @@ def main():
                         help="Toggle how to handle duplications: None: heuristically choose most similar homolog; Ancestral: keep only duplications that coalesce in an ancestral sequence; All: keep all duplications, including anestral and novel paralogies in the target genome [default=Single]",
                         default="single")
 
-    # ancestors now off by default
-    parser.add_argument("--ancestors", action="store_true",
-                        help="Include Ancestral genomes")
-
     # pass through a subset of hal2maf options
     parser.add_argument("--refGenome", required=True,
                         help="name of reference genome (root if empty)",
@@ -70,6 +66,13 @@ def main():
                         help="comma-separated (no spaces) list of target "
                         "genomes (others are excluded) (vist all if empty)",
                         default=None)
+    parser.add_argument("--noAncestors",
+                        help="don't write ancestral sequences. IMPORTANT: "
+                        "Must be used in conjunction with --refGenome"
+                        " to set a non-ancestral genome as the reference"
+                        " because the default reference is the root.",
+                        action="store_true",
+                        default=False)    
     
     # pass through taffy add-gap-bases options
     parser.add_argument("--gapFill",
@@ -119,6 +122,8 @@ def main():
 
     if options.dupeMode == 'single' and options.raw:
         raise RuntimeError('--dupeMode single requires TAF normalization and therefore is incompatible with --raw')
+    if options.noAncestors and not options.refGenome:
+        raise RuntimeError('(non-ancestral) --refGenome required with --noAncestors')
 
     # apply cpu override                
     if options.batchCores is None:
@@ -260,7 +265,7 @@ def hal2maf_cmd(hal_path, chunk, chunk_num, options):
         cmd += ' --targetGenomes {}'.format(options.targetGenomes)
     if options.dupeMode == 'ancestral':
         cmd += '--onlyOrthologs'
-    if not options.ancestors:
+    if options.noAncestors:
         cmd += ' --noAncestors'
     cmd += '{} 2> {}.h2m.time'.format(time_end, chunk_num)
     if chunk[1] != 0 and options.raw:

--- a/src/cactus/maf/cactus_maf2bigmaf.py
+++ b/src/cactus/maf/cactus_maf2bigmaf.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+
+"""
+This is a script to convert a MAF (from cactus-hal2maf) to BigMaf
+"""
+
+import os, sys
+from argparse import ArgumentParser
+import copy
+import timeit, time
+import math
+import xml.etree.ElementTree as ET
+
+from operator import itemgetter
+
+from cactus.progressive.seqFile import SeqFile
+from cactus.shared.common import setupBinaries, importSingularityImage
+from cactus.shared.common import cactusRootPath
+from cactus.shared.configWrapper import ConfigWrapper
+from cactus.shared.common import makeURL, catFiles
+from cactus.shared.common import enableDumpStack
+from cactus.shared.common import cactus_override_toil_options
+from cactus.shared.common import cactus_call
+from cactus.shared.common import getOptionalAttrib, findRequiredNode
+from cactus.shared.version import cactus_commit
+from toil.job import Job
+from toil.common import Toil
+from toil.statsAndLogging import logger
+from toil.statsAndLogging import set_logging_from_options
+from toil.realtimeLogger import RealtimeLogger
+from cactus.shared.common import cactus_cpu_count
+from toil.lib.humanize import bytes2human
+from sonLib.bioio import getTempDirectory
+
+def main():
+    parser = ArgumentParser()
+    Job.Runner.addToilOptions(parser)
+
+    parser.add_argument("mafFile", help = "MAF file to convert to BigMaf (can be gzipped)")
+    parser.add_argument("outFile", help = "Output bigMaf file (.bb)")
+    parser.add_argument("--refGenome", help = "reference genome to get chrom sizes from", required=True)
+
+    
+    parser.add_argument("--halFile", help = "HAL file to use to get chrom sizes from")
+    parser.add_argument("--chromSizes", help = "File of chromosome sizes (can be obtained with halStats --chromSizes)")
+    
+    #Progressive Cactus Options
+    parser.add_argument("--configFile", dest="configFile",
+                        help="Specify cactus configuration file",
+                        default=os.path.join(cactusRootPath(), "cactus_progressive_config.xml"))
+    parser.add_argument("--latest", dest="latest", action="store_true",
+                        help="Use the latest version of the docker container "
+                        "rather than pulling one matching this version of cactus")
+    parser.add_argument("--containerImage", dest="containerImage", default=None,
+                        help="Use the the specified pre-built containter image "
+                        "rather than pulling one from quay.io")
+    parser.add_argument("--binariesMode", choices=["docker", "local", "singularity"],
+                        help="The way to run the Cactus binaries", default=None)
+
+    options = parser.parse_args()
+
+    setupBinaries(options)
+    set_logging_from_options(options)
+    enableDumpStack()
+
+    if bool(options.halFile) == bool(options.chromSizes):
+        raise RuntimeError('Either --chromSizes or --halFile must be used to get the chromosome sizes, not both')
+    if not options.outFile.endswith('.bb'):
+        raise RuntimeError('output file path must end with .bb')
+    
+    # Mess with some toil options to create useful defaults.
+    cactus_override_toil_options(options)
+
+    logger.info('Cactus Command: {}'.format(' '.join(sys.argv)))
+    logger.info('Cactus Commit: {}'.format(cactus_commit))
+    start_time = timeit.default_timer()
+
+    with Toil(options) as toil:
+        importSingularityImage(options)
+        #Run the workflow
+        if options.restart:
+            bigmaf_id_dict = toil.restart()
+        else:
+            #load cactus config
+            configNode = ET.parse(options.configFile).getroot()
+            config = ConfigWrapper(configNode)
+            config.substituteAllPredefinedConstantsWithLiterals()
+            
+            logger.info("Importing {}".format(options.mafFile))
+            maf_id = toil.importFile(options.mafFile)
+            chrom_sizes_id = None
+            if options.chromSizes:
+                logger.info("Importing {}".format(options.chromSizes))
+                chrom_sizes_id = toil.importFile(options.chromSizes)
+            hal_id = None
+            if options.halFile:
+                logger.info("Importing {}".format(options.halFile))
+                hal_id = toil.importFile(options.halFile)
+                
+            bigmaf_id_dict = toil.start(Job.wrapJobFn(maf2bigmaf_workflow, config, options, maf_id, chrom_sizes_id, hal_id))
+
+        #export the big maf
+        out_bm_path = makeURL(options.outFile)
+        logger.info("Exporting {}".format(out_bm_path))
+        toil.exportFile(bigmaf_id_dict['bb'], out_bm_path)
+        #export the big maf summary
+        out_bms_path = makeURL(os.path.splitext(options.outFile)[0] + '.summary.bb')
+        logger.info("Exporting {}".format(out_bms_path))
+        toil.exportFile(bigmaf_id_dict['summary.bb'], out_bms_path)
+        
+    end_time = timeit.default_timer()
+    run_time = end_time - start_time
+    logger.info("cactus-maf2bigmaf has finished after {} seconds".format(run_time))
+
+
+def maf2bigmaf_workflow(job, config, options, maf_id, chrom_sizes_id, hal_id):
+    root_job = Job()
+    job.addChild(root_job)
+    check_tools_job = root_job.addChildJobFn(maf2bigmaf_check_tools)
+    if not chrom_sizes_id:
+        chrom_sizes_job = check_tools_job.addFollowOnJobFn(maf2bigmaf_chrom_sizes, options, hal_id,
+                                                           disk=hal_id.size)
+        prev_job = chrom_sizes_job
+        chrom_sizes_id = chrom_sizes_job.rv()
+    else:
+        prev_job = check_tools_job
+    if options.mafFile.endswith('.gz'):
+        disk_mult = 10
+    else:
+        disk_mult = 3
+    bigmaf_job = prev_job.addFollowOnJobFn(maf2bigmaf, maf_id, chrom_sizes_id, options,
+                                           disk=disk_mult * maf_id.size)
+    return bigmaf_job.rv()
+
+def maf2bigmaf_check_tools(job):
+    """ make sure we have the required ucsc commands available on the PATH"""
+    for tool in ['mafToBigMaf', 'bedToBigBed', 'hgLoadMafSummary']:
+        try:
+            cactus_call(parameters=[tool])
+        except Exception as e:
+            # hacky way to see if the usage info came out of running the command with no arguments
+            if "usage:" in str(e):
+                continue
+        raise RuntimeError('Required tool, {}, not found in PATH. Please download it with wget -q https://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/{}'.format(tool, tool))
+
+def maf2bigmaf_chrom_sizes(job, options, hal_id):
+    """ get chromsizes from hal"""
+    assert options.refGenome
+    
+    work_dir = job.fileStore.getLocalTempDir()
+    hal_path = os.path.join(work_dir, os.path.basename(options.halFile.replace(' ', '.')))
+    RealtimeLogger.info("Reading HAL file from job store to {}".format(hal_path))    
+    job.fileStore.readGlobalFile(hal_id, hal_path)
+    RealtimeLogger.info("Computing chromosome sizes")
+
+    chrom_sizes = os.path.join(work_dir, options.refGenome + '.chrom_sizes')
+    cactus_call(parameters=['halStats', hal_path, '--chromSizes', options.refGenome],
+                outfile = chrom_sizes)
+    return job.fileStore.writeGlobalFile(chrom_sizes)
+
+# https://genome.ucsc.edu/goldenPath/help/examples/bigMaf.as
+bigMaf_as = \
+'''table bedMaf
+"Bed3 with MAF block"
+    (
+    string chrom;      "Reference sequence chromosome or scaffold"
+    uint   chromStart; "Start position in chromosome"
+    uint   chromEnd;   "End position in chromosome"
+    lstring mafBlock;   "MAF block"
+    )
+'''
+
+# https://genome.ucsc.edu/goldenPath/help/examples/mafSummary.as
+mafSummary_as = \
+'''table mafSummary
+"Positions and scores for alignment blocks"
+    (
+    string chrom;      "Reference sequence chromosome or scaffold"
+    uint   chromStart; "Start position in chromosome"
+    uint   chromEnd;   "End position in chromosome"
+    string src;        "Sequence name or database of alignment"
+    float  score;      "Floating point score."
+    char[1] leftStatus;  "Gap/break annotation for preceding block"
+    char[1] rightStatus; "Gap/break annotation for following block"
+    )
+'''
+
+def maf2bigmaf(job, maf_id, chrom_sizes_id, options):
+    """ do the conversion from https://genome.ucsc.edu/goldenPath/help/bigMaf.html"""
+    work_dir = job.fileStore.getLocalTempDir()
+    maf_path = os.path.join(work_dir, os.path.basename(options.mafFile.replace(' ', '.')))    
+    RealtimeLogger.info("Reading MAF file from job store to {}".format(maf_path))
+    job.fileStore.readGlobalFile(maf_id, maf_path, mutable=True)    
+    chrom_sizes_path = os.path.join(work_dir, options.refGenome + '.chrom_sizes')    
+    job.fileStore.readGlobalFile(chrom_sizes_id, chrom_sizes_path)
+    bigmaf_path = os.path.join(work_dir, os.path.basename(options.outFile))
+    summary_path = os.path.splitext(bigmaf_path)[0] + '.summary.bb'
+
+    # doesn't seem possible to stream right from gzipped maf below
+    if maf_path.endswith('.gz'):
+        cactus_call(parameters=['bgzip', '-df', maf_path])
+        maf_path = os.path.splitext(maf_path)[0]
+                               
+    # make the bigMaf.as file
+    bigmaf_as_path = os.path.join(work_dir, 'bigMaf.as')
+    assert(maf_path != bigmaf_as_path)
+    with open(bigmaf_as_path, 'w') as as_file:
+        as_file.write(bigMaf_as)
+        
+    # make the mafSummary.as file
+    mafsummary_as_path = os.path.join(work_dir, 'mafSummary.as')
+    assert(maf_path != mafsummary_as_path)
+    with open(mafsummary_as_path, 'w') as as_file:
+        as_file.write(mafSummary_as)
+        
+                               
+    # make the bigmaf file
+    bigmaf_txt_path = os.path.join(work_dir, 'bigMaf.txt')
+    cactus_call(parameters=[['mafToBigMaf', options.refGenome, maf_path, 'stdout'],
+                            ['sort', '-k1,1', '-k2,2n']],
+                outfile=bigmaf_txt_path)
+    cactus_call(parameters=['bedToBigBed', '-type=bed3+1', '-as={}'.format(bigmaf_as_path), '-tab', bigmaf_txt_path, chrom_sizes_path, bigmaf_path])
+
+    # make the bigmaf summary file
+    summary_bed_path = os.path.join(work_dir, 'bigMafSummary.bed')
+    cactus_call(parameters=['hgLoadMafSummary', '-minSeqSize=1', '-test', options.refGenome, 'bigMafSummary', maf_path])
+    cactus_call(parameters=[['cut', '-f2-', 'bigMafSummary.tab'],
+                            ['sort', '-k1,1', '-k2,2n']],
+                outfile=summary_bed_path)
+    cactus_call(parameters=['bedToBigBed', '-type=bed3+4', '-as={}'.format(mafsummary_as_path), '-tab', summary_bed_path, chrom_sizes_path, summary_path])
+    
+    return { 'bb' : job.fileStore.writeGlobalFile(bigmaf_path),
+             'summary.bb' : job.fileStore.writeGlobalFile(summary_path) }


### PR DESCRIPTION
This is a stand-alone Toil script to convert a HAL file to a set of pairwise alignments in [UCSC Chain Format](https://genome.ucsc.edu/goldenPath/help/chain.html).

I copied some [logic I found in CAT](https://github.com/ComparativeGenomicsToolkit/Comparative-Annotation-Toolkit/blob/fc1623da5df1309d2e2f0b9bb0363aaab84708f4/cat/chaining.py#L96-L98):
```
   cmd = [['halLiftover', '--outPSL', hal, args.ref_genome, bed_path, target_genome, '/dev/stdout'],
           ['pslPosTarget', '/dev/stdin', '/dev/stdout'],
           ['axtChain', '-psl', '-verbose=0', '-linearGap=medium', '/dev/stdin', target_two_bit, query_two_bit, chain]]
```
I have never personally created nor used Chain output before, so would appreciate feedback by people who have @diekhans @mhaukness-ucsc

Also, I've noticed there are two ways to make PSL with hal. `halLiftover` and `halSynteny`.  `cactus-hal2chains` defaults to the former (as far as I can tell, that's what we've been using?), but the latter can be toggled on instead with `--useHalSynteny`.) They produce different outputs, so @diekhans any explanations we can add to the docs would be greatly appreciated. 