### PR TITLE
Penalize N mismatches in abPOA

### DIFF
--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -216,7 +216,7 @@
 			partialOrderAlignmentMaskFilter="-1"
 			partialOrderAlignmentBandConstant="300"
 			partialOrderAlignmentBandFraction="0.05"
-			partialOrderAlignmentSubMatrix="91 -114 -61 -123 0 -114 100 -125 -61 0 -61 -125 100 -114 0 -123 -61 -114 91 0 0 0 0 0 0"
+			partialOrderAlignmentSubMatrix="91 -114 -61 -123 -100 -114 100 -125 -61 -100 -61 -125 100 -114 -100 -123 -61 -114 91 -100 -100 -100 -100 -100 100"
 			partialOrderAlignmentGapOpenPenalty1="400"
 			partialOrderAlignmentGapExtensionPenalty1="30"
 			partialOrderAlignmentGapOpenPenalty2="1200"


### PR DESCRIPTION
We've been seeing alignments across stretches of Ns in pangenome alignments (ex #859). I noticed first noticed this when making a test mouse pangenome (https://s3-us-west-2.amazonaws.com/human-pangenomics/index.html?prefix=publications/mc_2022/mc_pangenomes/30-mouse-mc-2022-09-23). 

It's also come up when visualizing MAFs from Progressive Cactus. 

Anyway, finally looking at it now, and it seems a fairly simple issue with the abPOA scoring matrix we're using:
```
91 -114 -61 -123 0
-114 100 -125 -61 0
-61 -125 100 -114 0
-123 -61 -114 91 0
0 0 0 0 0
```
The last row/column is for N, and they are being treated as ambiguous bases that can align to anything.  This makes sense in and of itself, but for most assemblies coming into Cactus, Ns are gaps and aligning too them only serves to confuse.  

Looking at the default lastz parameters we are using, they always have
```
--ambiguous=iupac,100,100
```
which from the [lastz documentation](https://www.bx.psu.edu/~rsharris/lastz/README.lastz-1.04.15.html#options_scoring) is specifying a 100 reward for matching two identical ambiguous chracters (N) included and a -100 penalty for mismatch.  This sounds reasonable for treating Ns as gaps so this PR, applies the same 100/-100 scores to the above matrix, giving

```
91 -114 -61 -123 -100
-114 100 -125 -61 -100
-61 -125 100 -114 -100
-123 -61 -114 91 -100
-100 -100 -100 -100 100
```

This change should keep big stretches of Ns out of the alignment blocks, but it won't keep them from mucking up pangenomes -- that will require a specific filter somewhere in `cactus-graphmap-join`. 