### PR TITLE
Toggle taffy norm dupe filter off by default

### DIFF
--- a/doc/progressive.md
+++ b/doc/progressive.md
@@ -114,7 +114,7 @@ Depending on the application, you may want to handle duplication events differen
 
 * "single" : Uses greedy heuristics to pick the copy for each species that results in fewest mutations and block breaks. Recommended when visualizing via BigMaf (see below)
 * "ancestral" : Restricts the duplication relationships shown to only those orthologous to the reference genome according to the HAL tree. There may be multiple orthologs per genome. This relies on the dating of the duplication in the hal tree (ie in which genome it is explicitly self-aligned) and is still a work in progress. For example, in a tree with `((human,chimp),gorilla)`, if a duplication in human is collapsed (ie a single copy) in the human-chimp ancestor, then it would not show up on the human-referenced MAF using this option. But if the duplication is not collapsed in this ancestor (presumably because each copy has an ortholog in chimp and gorilla), then it will be in the MAF because the duplication event was higher in the tree.
-* "all" : (default) All duplications are written, including ancestral events (orthologs) and paralogs in the reference. Note that by default, some duplications will be filtered out if they break MAF blocks. To disable this in order to truly catch them all, use `--keepGapCausingDupes`.
+* "all" : (default) All duplications are written, including ancestral events (orthologs) and paralogs in the reference. 
 
 Usually a reference genome is specified with `--refGenome` and ancestral genomes are excluded `--noAncestors`. Since the default reference is the root of the alignment, `--noAncestors` can only be specified if a leaf genome is used with `--refGenome`. 
 

--- a/src/cactus/maf/cactus_hal2maf.py
+++ b/src/cactus/maf/cactus_hal2maf.py
@@ -95,8 +95,8 @@ def main():
                         type=float,
                         default=0.6)
 
-    parser.add_argument("--keepGapCausingDupes",
-                        help="Turn off taffy norm -d filter that removes duplications that would induce gaps > maximumGapLength",
+    parser.add_argument("--filterGapCausingDupes",
+                        help="Turn on (experimental) taffy norm -d filter that removes duplications that would induce gaps > maximumGapLength",
                         action="store_true")
 
     parser.add_argument("--maxRefNFrac",
@@ -304,7 +304,7 @@ def taf_cmd(hal_path, chunk, chunk_num, options):
     cmd = 'set -eo pipefail && {} {}.maf.gz | {} taffy view{} 2> {}.m2t.time'.format(read_cmd, chunk_num, time_cmd, time_end, chunk_num)
     cmd += ' | {} taffy add-gap-bases -a {} -m {}{} 2> {}.tagp.time'.format(time_cmd, hal_path, options.gapFill, time_end, chunk_num)
     cmd += ' | {} taffy norm -k -m {} -n {} {} -q {}{} 2> {}.tn.time'.format(time_cmd, options.maximumBlockLengthToMerge, options.maximumGapLength,
-                                                                             '' if options.keepGapCausingDupes else '-d',
+                                                                             '-d' if options.filterGapCausingDupes else '',
                                                                              options.fractionSharedRows, time_end, chunk_num)
     if options.maxRefNFrac:
         cmd += ' | mafFilter -m - -N {}'.format(options.maxRefNFrac)


### PR DESCRIPTION
Despite working pretty well on a lot of data, this option does not seem ready for prime time, leading to segafults, for example, on a giant chrY maf.  

This PR turns it back off by default.  Once it's fixed it can go on by default with `--dupeMode single`. 