### PR TITLE
More robust handling of dots in sample names

### DIFF
--- a/src/cactus/refmap/cactus_graphmap.py
+++ b/src/cactus/refmap/cactus_graphmap.py
@@ -34,6 +34,7 @@ from toil.statsAndLogging import set_logging_from_options
 from toil.realtimeLogger import RealtimeLogger
 from cactus.shared.common import cactus_cpu_count
 from cactus.progressive.progressive_decomposition import compute_outgroups, parse_seqfile, get_subtree, get_spanning_subtree, get_event_set
+from cactus.refmap.cactus_minigraph import check_sample_names
 from sonLib.nxnewick import NXNewick
 from sonLib.bioio import getTempDirectory
 
@@ -139,16 +140,14 @@ def graph_map(options):
                 # dont need to import this
                 event_set.remove(graph_event)
 
-            # check --reference input
+            # validate the sample names
+            check_sample_names(input_seq_map.keys(), options.reference)
+                
+            # check --reference input (a bit redundant to above, but does additional leaf check)
             if options.reference:
                 leaves = [mc_tree.getName(leaf) for leaf in mc_tree.getLeaves()]
                 if options.reference not in leaves:
                     raise RuntimeError("Genome specified with --reference, {}, not found in tree leaves".format(options.reference))
-                for sample in input_seq_map.keys():
-                    if sample != options.reference and sample.startswith(options.reference):
-                        raise RuntimeError("Input sample {} is prefixed by given reference {}. ".format(sample, options.reference) +                        
-                                           "This is not supported by this version of Cactus, " +
-                                           "so one of these samples needs to be renamed to continue")
             
             if options.refFromGFA:
                 if not options.reference:

--- a/src/cactus/refmap/cactus_graphmap_split.py
+++ b/src/cactus/refmap/cactus_graphmap_split.py
@@ -27,6 +27,7 @@ from cactus.shared.version import cactus_commit
 from cactus.preprocessor.fileMasking import get_mask_bed_from_fasta
 from cactus.preprocessor.checkUniqueHeaders import sanitize_fasta_headers
 from cactus.refmap.cactus_graphmap import filter_paf
+from cactus.refmap.cactus_minigraph import check_sample_names
 from toil.job import Job
 from toil.common import Toil
 from toil.statsAndLogging import logger
@@ -138,12 +139,8 @@ def cactus_graphmap_split(options):
             if options.reference and options.reference not in leaves:
                 raise RuntimeError("Name given with --reference {} not found in seqfile".format(options.reference))
 
-            if options.reference:
-                for sample in seqFile.pathMap.keys():
-                    if sample != options.reference and sample.startswith(options.reference):
-                        raise RuntimeError("Input sample {} is prefixed by given reference {}. ".format(sample, options.reference) +
-                                           "This is not supported by this version of Cactus, " +
-                                           "so one of these samples needs to be renamed to continue")
+            # validate the sample names
+            check_sample_names(input_seq_map.keys(), options.reference)
                         
             for genome, seq in seqFile.pathMap.items():
                 if genome in leaves:

--- a/src/cactus/refmap/cactus_graphmap_split.py
+++ b/src/cactus/refmap/cactus_graphmap_split.py
@@ -140,7 +140,7 @@ def cactus_graphmap_split(options):
                 raise RuntimeError("Name given with --reference {} not found in seqfile".format(options.reference))
 
             # validate the sample names
-            check_sample_names(input_seq_map.keys(), options.reference)
+            check_sample_names(seqFile.pathMap.keys(), options.reference)
                         
             for genome, seq in seqFile.pathMap.items():
                 if genome in leaves:

--- a/src/cactus/refmap/cactus_pangenome.py
+++ b/src/cactus/refmap/cactus_pangenome.py
@@ -30,7 +30,6 @@ from cactus.shared.common import cactus_override_toil_options
 from cactus.shared.common import cactus_call
 from cactus.shared.common import getOptionalAttrib, findRequiredNode
 from cactus.shared.version import cactus_commit
-from cactus.refmap.cactus_graphmap_join import unzip_seqfile
 from cactus.preprocessor.checkUniqueHeaders import sanitize_fasta_headers
 from toil.job import Job
 from toil.common import Toil
@@ -40,6 +39,7 @@ from toil.realtimeLogger import RealtimeLogger
 from cactus.shared.common import cactus_cpu_count
 
 from cactus.refmap.cactus_minigraph import minigraph_construct_workflow
+from cactus.refmap.cactus_minigraph import check_sample_names
 from cactus.refmap.cactus_graphmap import minigraph_workflow
 from cactus.refmap.cactus_graphmap_split import graphmap_split_workflow, export_split_data
 from cactus.setup.cactus_align import make_batch_align_jobs, batch_align_jobs
@@ -169,14 +169,9 @@ def main():
             # load the seqfile
             seqFile = SeqFile(options.seqFile)
             input_seq_map = seqFile.pathMap
-            
-            if options.reference not in input_seq_map:
-                raise RuntimeError("Specified reference not in seqfile")
-            for sample in input_seq_map.keys():
-                if sample != options.reference and sample.startswith(options.reference):
-                    raise RuntimeError("Input sample {} is prefixed by given reference {}. ".format(sample, options.reference) +                        
-                                       "This is not supported by this version of Cactus, " +
-                                       "so one of these samples needs to be renamed to continue")
+
+            # validate the sample names
+            check_sample_names(input_seq_map.keys(), options.reference)
 
             # apply cpu override                
             if options.mapCores is not None:

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -30,6 +30,7 @@ from cactus.shared.common import cactusRootPath
 from cactus.shared.version import cactus_commit
 from cactus.shared.configWrapper import ConfigWrapper
 from cactus.refmap.cactus_graphmap import filter_paf
+from cactus.refmap.cactus_minigraph import check_sample_names
 from cactus.preprocessor.checkUniqueHeaders import sanitize_fasta_headers
 
 from toil.job import Job
@@ -248,6 +249,10 @@ def make_align_job(options, toil, config_wrapper=None, chrom_name=None):
         if options.root not in input_seq_map:
             raise RuntimeError("--includeRoot specified but root, {},  not found in input Seqfile".format(options.root))
         event_set.add(options.root)
+
+    if options.reference and options.pangenome:
+        # validate the sample names
+        check_sample_names(input_seq_map.keys(), options.reference)
         
     # apply path overrides.  this was necessary for wdl which doesn't take kindly to
     # text files of local paths (ie seqfile).  one way to fix would be to add support


### PR DESCRIPTION
This fixes a bug where ".<haplotype>" suffixes on reference sample names would lead to errors in `cactus-graphmap-join` due to the various conversions in vg. 

It also adds better error checking up front make sure that if you have a "." in a sample name, then it won't lead to any trouble downstream.

A sample name is valid now if it either contains no `.` or if its last `.` is followed by an integer. 

Anyone using `Cactus <= v2.5.0` should keep all `.`'s out of their reference sample names. 

Resolves #993