### PR TITLE
fix up multiple reference sample support

### DIFF
--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -279,7 +279,7 @@ fi
 # vg
 cd ${pangenomeBuildDir}
 #wget -q https://github.com/vgteam/vg/releases/download/v1.48.0/vg
-wget -q http://public.gi.ucsc.edu/~hickey/vg-patch/vg.36af48e471039f019f58ac61f8eaa7f4eb316f44 -O vg
+wget -q http://public.gi.ucsc.edu/~hickey/vg-patch/vg.e388c36817811c6934368b6c139e78a44128c7ea -O vg
 chmod +x vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd vg | grep so | wc -l) -eq 0 ]]
 then

--- a/src/cactus/refmap/cactus_minigraph.py
+++ b/src/cactus/refmap/cactus_minigraph.py
@@ -122,22 +122,26 @@ def main():
     run_time = end_time - start_time
     logger.info("cactus-minigraph has finished after {} seconds".format(run_time))
 
-def check_sample_names(sample_names, reference):
+def check_sample_names(sample_names, references):
     """ make sure we have a workable set of sample names """
 
     # make sure we have the reference
-    if reference is not None:
-        if reference not in sample_names:
-            raise RuntimeError("Specified reference not in seqfile")
+    if references:
+        assert type(references) in [list, str]
+        if type(references) is str:
+            references = [references]
+        for reference in references:
+            if reference not in sample_names:
+                raise RuntimeError("Specified reference not in seqfile")
 
-        # graphmap-join uses reference names as prefixes, so make sure we don't get into trouble with that
-        reference_base = os.path.splitext(reference)[0]
-        for sample in sample_names:
-            sample_base = os.path.splitext(sample)[0]
-            if sample != reference and sample_base.startswith(reference_base):
-                raise RuntimeError("Input sample {} is prefixed by given reference {}. ".format(sample_base, reference_base) +    
-                                   "This is not supported by this version of Cactus, " +
-                                   "so one of these samples needs to be renamed to continue")
+            # graphmap-join uses reference names as prefixes, so make sure we don't get into trouble with that
+            reference_base = os.path.splitext(reference)[0]
+            for sample in sample_names:
+                sample_base = os.path.splitext(sample)[0]
+                if sample != reference and sample_base.startswith(reference_base):
+                    raise RuntimeError("Input sample {} is prefixed by given reference {}. ".format(sample_base, reference_base) +    
+                                       "This is not supported by this version of Cactus, " +
+                                       "so one of these samples needs to be renamed to continue")
 
     # the "." character is overloaded to specify haplotype, make sure that it makes sense
     for sample in sample_names:

--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -466,15 +466,15 @@ class TestCase(unittest.TestCase):
 
         chroms = ['chrI', 'chrII', 'chrIII', 'chrIV', 'chrV', 'chrVI', 'chrVII', 'chrVIII', 'chrIX', 'chrX', 'chrXI', 'chrXIV', 'chrXV']
         cactus_pangenome_cmd = ['cactus-pangenome', self._job_store(binariesMode), orig_seq_file_path, '--outDir', join_path, '--outName', 'yeast',
-                                '--refContigs'] + chroms + ['--reference', 'S288C', '--vcf', '--giraffe', 'clip', 'filter',
-                                                            '--indexCores', '4', '--consCores', '2']
+                                '--refContigs'] + chroms + ['--reference', 'S288C', 'DBVPG6044', '--vcf', '--vcfReference','DBVPG6044', 'S288C', 
+                                                            '--giraffe', 'clip', 'filter',  '--indexCores', '4', '--consCores', '2']
         subprocess.check_call(cactus_pangenome_cmd + cactus_opts)
 
         #compatibility with older test        
         subprocess.check_call(['mkdir', '-p', os.path.join(self.tempDir, 'chroms')])
         subprocess.check_call(['mv', os.path.join(join_path, 'chrom-subproblems', 'contig_sizes.tsv'), os.path.join(self.tempDir, 'chroms')])
 
-    def _check_yeast_pangenome(self, binariesMode):
+    def _check_yeast_pangenome(self, binariesMode, other_ref=None):
         """ yeast pangenome chromosome by chromosome pipeline
         """
 
@@ -489,21 +489,25 @@ class TestCase(unittest.TestCase):
         assert len(events) == 6
 
         join_path = os.path.join(self.tempDir, 'join')
-        vcf_path = os.path.join(join_path, 'yeast.vcf.gz')
+        vcf_paths = [os.path.join(join_path, 'yeast.vcf.gz')]
+        if other_ref:
+            vcf_paths.append(os.path.join(join_path, 'yeast.{}.vcf.gz'.format(other_ref)))
 
         # check that we have some alts for each sample in the VCF
-        vcf_allele_threshold = 40000
         for event in events:
-            if event == "S288C":
+            if event == "S288C" or event == other_ref:
                 continue
-            allele = 1
-            event = event.split(".")[0]
-            proc = subprocess.Popen('bcftools view {} -s {} -a -H | awk \'{{print $10}}\' | grep {} | wc -l'.format(vcf_path, event, allele),
-                                    shell=True, stdout=subprocess.PIPE)
-            output, errors = proc.communicate()
-            sts = proc.wait()
-            num_alleles = int(output.strip())
-            self.assertGreaterEqual(num_alleles, vcf_allele_threshold)
+            refs = [event, other_ref] if other_ref else [event]
+            for vcf_path, vcf_ref in zip(vcf_paths, refs):
+                vcf_allele_threshold = 40000 if vcf_ref == 'S288C' else 14000
+                allele = 1
+                event = event.split(".")[0]
+                proc = subprocess.Popen('bcftools view {} -s {} -a -H | awk \'{{print $10}}\' | grep {} | wc -l'.format(vcf_path, event, allele),
+                                        shell=True, stdout=subprocess.PIPE)
+                output, errors = proc.communicate()
+                sts = proc.wait()
+                num_alleles = int(output.strip())
+                self.assertGreaterEqual(num_alleles, vcf_allele_threshold)
 
         # make sure we have about the right sequence counts in the hal
         hal_path = os.path.join(join_path, 'yeast.full.hal')
@@ -921,7 +925,7 @@ class TestCase(unittest.TestCase):
         self._run_yeast_pangenome(name)
         
         # check the output
-        self._check_yeast_pangenome(name)
+        self._check_yeast_pangenome(name, other_ref='DBVPG6044')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
`cactus-pangenome` changed to accept multiple samples via `--reference`.  Only the first one is treated as a true reference (left unclipped and guaranteed forward and acyclic), but the others will end up as REFERENCE sense paths in the final GBZ graph.  This makes it easier to use them for indexed coordinates.  

All such paths can be optionally used to make VCFs via the `--vcfReference` option (one VCF per reference).  Because of potential cycles, these VCFs will not be as accurate and VCFs on the first reference, but they should still be quite good.  