### PR TITLE
Fix crash during export when no clip graph produced

### DIFF
--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -763,9 +763,10 @@ def export_join_data(toil, options, full_ids, clip_ids, clip_stats, filter_ids, 
                 name = os.path.splitext(vg_path)[0] + '.d{}.vg'.format(options.filter)
                 toil.exportFile(filter_id, makeURL(os.path.join(clip_base, os.path.basename(name))))
                 
-    # download the stats files 
-    for stats_file in clip_stats.keys():
-        toil.exportFile(clip_stats[stats_file], makeURL(os.path.join(options.outDir, '{}.{}'.format(options.outName, stats_file))))
+    # download the stats files
+    if clip_stats:
+        for stats_file in clip_stats.keys():
+            toil.exportFile(clip_stats[stats_file], makeURL(os.path.join(options.outDir, '{}.{}'.format(options.outName, stats_file))))
         
     # download everything else
     for idx_map in idx_maps:


### PR DESCRIPTION
Some stats files made by clipping get exported from Toil at the end of the worfklow.  The problem is that it would crash if they don't exist (!).  The work-around is to always make a `clip` graph, but this patch will fix it properly.  Crazy that it took this long for this to get noticed...

resolves #1005