### PR TITLE
Fix error when filter specified without clip

### DIFF
--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -279,7 +279,7 @@ fi
 # vg
 cd ${pangenomeBuildDir}
 #wget -q https://github.com/vgteam/vg/releases/download/v1.48.0/vg
-wget -q http://public.gi.ucsc.edu/~hickey/vg-patch/vg.d8e674c8af917e04f147c3b858c01d7fbfcfa6da -O vg
+wget -q http://public.gi.ucsc.edu/~hickey/vg-patch/vg.e7d9fd3932dec93faf968f21b56e39f1df662f2d -O vg
 chmod +x vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd vg | grep so | wc -l) -eq 0 ]]
 then


### PR DESCRIPTION
Previously, running `cactus-pangenome` with something like `--gfa filter` would lead to a crash, since the `clip` graph on which the `filter` graph depends wouldn't be created.  This fixes that by making sure that all dependencies are produced as necessary. 