### PR TITLE
clean up pangenome cores options a bit

### DIFF
--- a/doc/pangenome.md
+++ b/doc/pangenome.md
@@ -102,9 +102,10 @@ The Minigraph-Cactus pipeline is run via the `cactus-pangenome` command. It cons
 
 **Before running large jobs, it is important to consider the following options:**
 
-* `--mapCores` the number of cores for each `minigraph` job (default: up to 6)
+* `--mgCores` the number of cores for `minigraph` construction (default: all available)
+* `--mapCores` the number of cores for each `minigraph` mapping job (default: up to 6)
 * `--consCores` the number of cores for each `cactus-consolidated` job (default: all available)
-* `--indexCores` the number of cores for each `vg` indexing job (default: 1)
+* `--indexCores` the number of cores for each `vg` indexing job (default: all available - 1)
 * The various output options: `--gbz`, `--gfa`, `--giraffe`, `--vcf` which are explained in detail below. If you forget to add one of these and are missing the corresponding output, you will need to rerun `cactus-graphmap-join` (or use `vg` to manually make the file yourself).
 
 Reducing `--consCores` will allow more chromosomes to be aligned at once, requiring more memory. VCF export for very large graphs will take a long time unless `--indexCores` is set high, but `--indexCores` should still be at least 1 lower than all cores available to allow some parallelism. 

--- a/doc/pangenome.md
+++ b/doc/pangenome.md
@@ -96,6 +96,24 @@ HG002.2  ./HG002.maternal.fa
 CHM13  ./chm13.fa
 ```
 
+### Reference Sample
+
+The `--reference` option must be used to select a "reference" sample.  This sample will:
+* Never be clipped.
+* Never be self-aligned ie its path in the output graph will be acyclic
+* Only visit nodes in their forward orientations
+* Be a "reference-sense" path in vg/gbz and will therefore be indexably for fast coordinate lookup
+* Be the basis for the output VCF and therefore won't appear as a sample in the VCF
+* Be used to divide the graph into chromosomes
+
+It is therefore extremely important that the reference sample's assembly be **chromosome** scale.  If there are many small contigs in the addition to chromosomes in the reference assembly, then please consider specifying the chromosomes with `--refContigs`. If you still want to keep the other contigs, add `--otherContig chrOther` (see explanation below).
+
+#### Multiple Reference Samples
+
+The `--reference` option can accept multiple samples (separated by space). If multiple samples are specified beyond the first, they will be clipped as usual, but end up as "reference-sense" paths in the vg/gbz output.  They can also be used as basis for VCF, and VCF files can be created based on them with the `--vcfReference` sample.
+
+For example, for human data one might consider using `--reference CHM13 GRCh38 GRCh37 --vcfReference CHM13 GRC3h8`.  This will make a graph referenced on CHM13, but will promote GRCh38 and GRCh38 to reference-sense paths so that they could be used, for example, to project BAMs on in `vg giraffe`.  Two VCFs will be output, one based on CHM13 and one based on GRCh38. 
+
 ### Pipeline
 
 The Minigraph-Cactus pipeline is run via the `cactus-pangenome` command. It consists of five stages which can also be run individually (below). `cactus-pangenome` writes output files into `--outDir` at the end of each stage. So different stages can be rerun with if necessary using the lower-level commands.

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -129,7 +129,7 @@ def graphmap_join_validate_options(options):
     if options.batchSystem.lower() in ['single_machine', 'singleMachine']:
         if not options.indexCores:
             options.indexCores = sys.maxsize
-        options.indexCores = min(options.indexCores, cactus_cpu_count(), int(options.maxCores) if options.maxCores else sys.maxsize)
+        options.indexCores = min(options.indexCores, max(1, cactus_cpu_count() - 1), int(options.maxCores) if options.maxCores else sys.maxsize)
     else:
         if not options.indexCores:
             raise RuntimeError("--indexCores required run *not* running on single machine batch system")


### PR DESCRIPTION
* add new `--mgCores` option (default all cores) to specify cores for minigraph construction
* `--mapCores` is kept as is but now only applies to `minigraph` mapping
* documentation fixed to reflect fact that `--indexCores` does not, in fact, default to 1
* `--indexCores` changed from defaulting to all available to all available minus 1

At the end of the day, this should lead to more useful default behaviour of `cactus-pangenome` on single machine. 