### PR TITLE
Update cactus_hal2maf.py

### DIFF
--- a/src/cactus/maf/cactus_hal2maf.py
+++ b/src/cactus/maf/cactus_hal2maf.py
@@ -313,7 +313,7 @@ def taf_cmd(hal_path, chunk, chunk_num, options):
     if options.maximumGapLength is not None:
         norm_opts += ' -n {}'.format(options.maximumGapLength)
     if options.filterGapCausingDupes:
-        norm_opts += ' -d'
+        norm_opts += ' -d '
     if options.fractionSharedRows is not None:
         norm_opts += '-q {}'.format(options.fractionSharedRows)
     cmd += ' | {} taffy norm -k {}{} 2> {}.tn.time'.format(time_cmd, norm_opts, time_end, chunk_num)


### PR DESCRIPTION
[2023-06-02T12:32:24+0800] [MainThread] [I] [toil-rt] First of 93 commands in parallel batch: set -eo pipefail && gzip -dc 0.maf.gz | (time -p  taffy view) 2> 0.m2t.time | (time -p  taffy add-gap-bases -a Oryza.hal ) 2> 0.tagp.time | (time -p  taffy norm -k -m 1000 -n 1000 -d-q 0.6) 2> 0.tn.time | mafFilter -m - -N 0.95 | mafFilter -m - -l 2 | mafDuplicateFilter -m - -k | bgzip > 0.maf.norm.gz && mv 0.maf.norm.gz 0.maf.gz

[2023-06-02T12:32:26+0800] [MainThread] [E] [toil.statsAndLogging] norm: invalid option -- '-'