### PR TITLE
Fix --consMemory option

### DIFF
--- a/build-tools/downloadMafTools
+++ b/build-tools/downloadMafTools
@@ -40,7 +40,7 @@ export HTSLIB_LIBS="$(pwd)/libhts.a -lbz2 -ldeflate -lm -lpthread -lz -llzma -pt
 cd ${mafBuildDir}
 git clone https://github.com/ComparativeGenomicsToolkit/taffy.git
 cd taffy
-git checkout d8cdc6a32b546bb0574233272c7b2647c0dba5e0
+git checkout c75ce895b7975e7ac17cb1ce964db3016615de47
 git submodule update --init --recursive
 export HALDIR=${CWD}/submodules/hal
 make -j ${numcpu}

--- a/src/cactus/pipeline/cactus_workflow.py
+++ b/src/cactus/pipeline/cactus_workflow.py
@@ -44,14 +44,14 @@ def cactus_cons_with_resources(job, tree, ancestor_event, config_node, seq_id_ma
         mem = 4e9
     # add function of paf size
     mem += 3 * paf_id.size
-    # and quadratic in sequence size (if doable in gigs)
+    # and quadratic in sequence size (if doable in kb)
     if total_sequence_size > 1024:
-        total_sequence_size_gigs = total_sequence_size / 1024.
+        total_sequence_size_kb = total_sequence_size / 1024.
         if len(seq_id_map) < 6:
-            mem += 1024. * (total_sequence_size_gigs ** 1.75)
+            mem += 1024. * (total_sequence_size_kb ** 1.75)
         else:
             # probably in pangenome mode: go a bit easier
-            mem += 1024. * (total_sequence_size_gigs ** 1.30)
+            mem += 1024. * (total_sequence_size_kb ** 1.30)
     else:
         mem += 4 * total_sequence_size        
     # but we cap things at 512 Gigs

--- a/src/cactus/pipeline/cactus_workflow.py
+++ b/src/cactus/pipeline/cactus_workflow.py
@@ -57,6 +57,8 @@ def cactus_cons_with_resources(job, tree, ancestor_event, config_node, seq_id_ma
     # but we cap things at 512 Gigs
     mem=int(min(mem, 512e09))
 
+    RealtimeLogger.info('Estimating cactus_consolidated({}) memory as {} bytes from {} sequences with total-sequence-size {} and paf-size {}'.format(ancestor_event, mem, len(seq_id_map), total_sequence_size, paf_id.size))
+
     if cons_memory is not None and cons_memory < mem:
         RealtimeLogger.info('Overriding cactus_conslidated memory estimate of {} with {} from --consMemory'.format(
             bytes2human(mem), bytes2human(cons_memory)))


### PR DESCRIPTION
Added this option to get something working, but clearly did not properly test it.  There were two major bugs:
* was interpreted as Kb and not Gb as the help message said
* it was only activated when running `cactus-align` and not `cactus`

This PR should fix both issues.  The interface is changed to be more like Toil's usual memory options.  So it's read as bytes, but you can use `Gb` `Ki` etc to specify different units.  

I do hope to have better resource estimation in before the next release to make this option (which still needs documentation in the manual) more rarely needed. 