### PR TITLE
Shorter default branch length in pangenome mode

### DIFF
--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -391,16 +391,24 @@
 		 hal2vgOptions="--progress --inMemory"
 		 />
   	<multi_cactus>
+	        <!-- stategy: outgroup selection algorithm, can be one of greedy, greedyLeaves or greedyPreference -->
+		<!-- threshold: depth increases by at most k per outgroup -->
+		<!-- ancestor_quality_fraction: min fraction of children of ancestor in candidateSet in order for the ancestor to be an outgroup candidate -->
+		<!-- max_num_outgroups: maximum number of outgroups per alignment job-->	  
 		<outgroup
 			strategy="greedyPreference"
 			threshold="0"
 			ancestor_quality_fraction="0.75"
 			max_num_outgroups="2"
-		/>
+			/>
+
+		<!-- default_internal_node_prefix: internal nodes of the tree are labeled with this prefix then a BFS order number -->
+		<!-- default_branch_len: use this branch length if information is missing from the input tree -->
+		<!-- default_branch_len_pangenome: use this branch length (for implicit star tree) in pangenome mode -->
 	 	<decomposition
-	 		self_alignment="false"
 	 		default_internal_node_prefix="Anc"
-			max_parallel_subtrees="50000"
+			default_branch_len="1"
+			default_branch_len_pangenome="0.025"
 	 	/>
   	</multi_cactus>
 	<consolidated></consolidated>

--- a/src/cactus/preprocessor/cactus_preprocessor.py
+++ b/src/cactus/preprocessor/cactus_preprocessor.py
@@ -478,7 +478,8 @@ def main():
     options.ignore.append(graph_event)
 
     # toggle on the gpu
-    ConfigWrapper(configNode).initGPU(options)
+    config_wrapper = ConfigWrapper(configNode)
+    config_wrapper.initGPU(options)
 
     # apply pangenome overrides
     if options.pangenome:
@@ -492,8 +493,8 @@ def main():
     
     # mine the paths out of the seqfiles
     if options.inSeqFile:
-        inSeqFile = SeqFile(options.inSeqFile)
-        outSeqFile = SeqFile(options.outSeqFile)
+        inSeqFile = SeqFile(options.inSeqFile, defaultBranchLen=config_wrapper.getDefaultBranchLen(options.pangenome))
+        outSeqFile = SeqFile(options.outSeqFile, defaultBranchLen=config_wrapper.getDefaultBranchLen(options.pangenome))
 
         if not inNames:
             inNames = [inSeqFile.tree.getName(node) for node in inSeqFile.tree.getLeaves()]

--- a/src/cactus/progressive/progressive_decomposition.py
+++ b/src/cactus/progressive/progressive_decomposition.py
@@ -33,14 +33,12 @@ from sonLib.nxnewick import NXNewick
 from toil.statsAndLogging import logger
 
 
-def parse_seqfile(seqfile_path, config_wrapper, root_name = None, default_branch_length = None):
+def parse_seqfile(seqfile_path, config_wrapper, root_name = None, pangenome = False):
     """
     parse the seqfile
     returns (tree, event->path map, og list (from *'s in seqfile)
     """
-    seq_file = SeqFile(seqfile_path, root_name = root_name)
-    if default_branch_length is not None:
-        seq_file.branchLen = default_branch_length
+    seq_file = SeqFile(seqfile_path, root_name = root_name, defaultBranchLen=config_wrapper.getDefaultBranchLen(pangenome=pangenome))
 
     mc_tree = MultiCactusTree(seq_file.tree)
     mc_tree.nameUnlabeledInternalNodes(config_wrapper.getDefaultInternalNodePrefix())

--- a/src/cactus/refmap/cactus_graphmap.py
+++ b/src/cactus/refmap/cactus_graphmap.py
@@ -108,7 +108,7 @@ def graph_map(options):
         else:
             # load up the seqfile and figure out the outgroups and schedule
             config_wrapper.substituteAllPredefinedConstantsWithLiterals()
-            mc_tree, input_seq_map, og_candidates = parse_seqfile(options.seqFile, config_wrapper)
+            mc_tree, input_seq_map, og_candidates = parse_seqfile(options.seqFile, config_wrapper, pangenome=True)
             og_map = compute_outgroups(mc_tree, config_wrapper, set(og_candidates))
             event_set = get_event_set(mc_tree, config_wrapper, og_map, mc_tree.getRootName())
 

--- a/src/cactus/refmap/cactus_graphmap_split.py
+++ b/src/cactus/refmap/cactus_graphmap_split.py
@@ -127,7 +127,7 @@ def cactus_graphmap_split(options):
             graph_event = getOptionalAttrib(findRequiredNode(config_node, "graphmap"), "assemblyName", default="_MINIGRAPH_")
 
             # load the seqfile
-            seqFile = SeqFile(options.seqFile)
+            seqFile = SeqFile(options.seqFile, defaultBranchLen=config.getDefaultBranchLen(pangenome=True))
 
             #import the graph
             logger.info("Importing {}".format(options.minigraphGFA))

--- a/src/cactus/refmap/cactus_minigraph.py
+++ b/src/cactus/refmap/cactus_minigraph.py
@@ -83,7 +83,7 @@ def main():
             graph_event = getOptionalAttrib(findRequiredNode(config_node, "graphmap"), "assemblyName", default="_MINIGRAPH_")
 
             # load the seqfile
-            seqFile = SeqFile(options.seqFile)
+            seqFile = SeqFile(options.seqFile, defaultBranchLen=config_wrapper.getDefaultBranchLen(pangenome=True))
             input_seq_map = seqFile.pathMap
 
             # validate the sample names

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -255,7 +255,7 @@ def make_align_job(options, toil, config_wrapper=None, chrom_name=None):
         config_wrapper.substituteAllPredefinedConstantsWithLiterals()
         config_wrapper.initGPU(options)
     mc_tree, input_seq_map, og_candidates = parse_seqfile(options.seqFile, config_wrapper,
-                                                          default_branch_length = 0.025 if options.pangenome else None)
+                                                          pangenome=options.pangenome)
     og_map = compute_outgroups(mc_tree, config_wrapper, set(og_candidates))
     event_set = get_event_set(mc_tree, config_wrapper, og_map, options.root if options.root else mc_tree.getRootName())
     if options.includeRoot:

--- a/src/cactus/shared/configWrapper.py
+++ b/src/cactus/shared/configWrapper.py
@@ -91,14 +91,6 @@ class ConfigWrapper:
             maxNumOutgroups = int(ogElem.attrib["max_num_outgroups"])
         return maxNumOutgroups
 
-    def getDoSelfAlignment(self):
-        decompElem = self.getDecompositionElem()
-        doSelf = self.defaultDoSelf
-        if decompElem is not None and "self_alignment" in decompElem.attrib:
-            doSelf = decompElem.attrib["self_alignment"].lower()
-        assert doSelf == "true" or doSelf == "false"
-        return doSelf == "true"
-
     def getDefaultInternalNodePrefix(self):
         decompElem = self.getDecompositionElem()
         prefix = self.defaultInternalNodePrefix
@@ -107,6 +99,13 @@ class ConfigWrapper:
             prefix = decompElem.attrib["default_internal_node_prefix"]
         assert len(prefix) > 0
         return prefix
+
+    def getDefaultBranchLen(self, pangenome=False):
+        decompElem = self.getDecompositionElem()
+        if pangenome:
+            return float(decompElem.attrib["default_branch_len_pangenome"])
+        else:
+            return float(decompElem.attrib["default_branch_len"])
 
     def getBuildHal(self):
         halElem = self.xmlRoot.find("hal")
@@ -133,21 +132,6 @@ class ConfigWrapper:
         halElem = self.xmlRoot.find("hal")
         assert halElem is not None
         halElem.attrib["buildFasta"] = str(int(buildFasta))
-
-    def getMaxParallelSubtrees(self):
-        decompElem = self.getDecompositionElem()
-        maxParallelSubtrees = self.defaultMaxParallelSubtrees
-        if decompElem is not None and\
-               "max_parallel_subtrees" in decompElem.attrib:
-            maxParallelSubtrees = int(
-                decompElem.attrib["max_parallel_subtrees"])
-        assert maxParallelSubtrees > 0
-        return maxParallelSubtrees
-
-    def setMaxParallelSubtrees(self, maxParallel):
-        decompElem = self.getDecompositionElem()
-        assert decompElem is not None
-        decompElem.attrib["max_parallel_subtrees"] = str(maxParallel)
 
     def getKtserverMemory(self, default=sys.maxsize):
         ktServerElem = self.xmlRoot.find("ktserver")


### PR DESCRIPTION
Users aren't asked for an input tree when making pangenomes, but under the hood a star tree is used.  This default tree uses the default branch lengths, which have always been "1" in cactus.  

But now that branch lengths affect chaining, we probably want to make sure they're more sensible for pangenomes.  This PR moves default branch length specification into the config.xml, where two values are kept, one for progressive (which remains 1), and one for pangenome which is 0.025 (which is what cactus-align used to hardcode it to). 

