### PR TITLE
add chop option for pangenomes

### DIFF
--- a/doc/pangenome.md
+++ b/doc/pangenome.md
@@ -130,6 +130,8 @@ Reducing `--consCores` will allow more chromosomes to be aligned at once, requir
 
 By default, `cactus` attempts to automatically determine the amount of memory to request for each job.  This estimate can be too conservative for `cactus-consolidated` jobs. You can override it with `--consMemory`. 
 
+**IMPORTANT**: If you are going to make use of the vg node IDs across the various output files, consider using the `--chop` option to `cactus-pangenome` to force all files to use the chopped IDs (see [Node Chopping](#node-chopping) below). 
+
 **PLEASE NOTE** While many Minigraph-Cactus parameters' default values were tuned on high-quality human assemblies from the HPRC where ample benchmarking data was available, we believe they will be suitable for other datasets and species, so long as the contigs can be mapped with [minigraph](https://github.com/lh3/minigraph). By default, [small contigs are filtered out](https://github.com/ComparativeGenomicsToolkit/cactus/blob/v2.4.4/src/cactus/cactus_progressive_config.xml#L319-L335) during chromosome assignment using more stringent thresholds. This might lead to a surprisingly low sensitivity on small, fragmented, diverse assemblies or difficult-to-assemble regions. Users wishing to *keep* these contigs in their graph can use the following option:
 
 * `--permissiveContigFilter`
@@ -195,6 +197,10 @@ The `--vcf` option will produce two VCFs for each selected graph type. One VCF i
 The GBZ format uses 10 bits to store offsets within nodes, which imposees a 1024bp node length limit. Nodes are therefore chopped up as requried in the `.gbz` output (described above) to respect this limit. The index files derived from the `.gbz`: `.snarls`, `.dist`, and `.min` will share the `.gbz` graph's chopped ID space. 
 
 The `.gfa.gz` and node IDs referred to in the `.vcf.gz` file (via the variant IDs, AT and PS tags) are not chopped and therefore inconsistent with the `.gbz`.  This can be very confusing when trying to, for example, locate a variant in the `vcf.gz` back in the `.gbz` using node IDs: Node `X` in `.vcf.gz` and node `X` in `.gbz` will often both exist but can be totally different parts of the graph. 
+
+If you are working with the node IDs, and / or do not care if the nodes are chopped in the GFA, the simplest thing to do is use the `--chop` option for `cactus-pangenome` / `cactus-graphmap-join`.  This option will limit all nodes to a maximum length of 1024bp in all graph files which means that none will be renamed during GBZ construction.
+
+Otherwise, see below for how you can use the GBZ's built-in mapping to toggle between node ID spaces:
 
 If you would rather have a VCF with consistent IDs to the GBZ as opposed to GFA, you can toggle this via the config XML
 ```

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -120,6 +120,9 @@ def graphmap_join_options(parser):
     parser.add_argument("--giraffe", nargs='*', default=None, help = "Generate Giraffe (.dist, .min) indexes for the given graph type(s). Valid types are 'full', 'clip' and 'filter'. If not type specified, 'filter' will be used (will fall back to 'clip' than full if filtering, clipping disabled, respectively). Multiple types can be provided seperated by a space")
     parser.add_argument("--indexCores", type=int, default=None, help = "cores for general indexing and VCF constructions (defaults to the same as --maxCores)")
 
+    parser.add_argument("--chop", type=int, nargs='?', const=1024, default=None,
+                        help="chop all graph nodes to be at most this long (default=1024 specified without value). By default, nodes are only chopped for GBZ-derived formats, but left unchopped in the GFA, VCF, etc. If this option is used, the GBZ and GFA should have consistent IDs") 
+
 def graphmap_join_validate_options(options):
     """ make sure the options make sense and fill in sensible defaults """
     if options.hal and len(options.hal) != len(options.vg):
@@ -445,6 +448,10 @@ def clip_vg(job, options, config, vg_path, vg_id, phase):
 
             # todo: do we want to add the minigraph prefix to keep stubs from minigraph? but I don't think it makes stubs....
             cmd.append(stub_cmd)
+
+    # enforce chopping
+    if phase == 'full' and options.chop:
+        cmd.append(['vg', 'mod', '-X', str(options.chop), '-'])
 
     # and we sort by id on the first go-around
     if phase == 'full':


### PR DESCRIPTION
This option will chop all nodes to 1024bp very early on.  This way, all output graphs will be in consistent id space. 

By default (if this option is not used), then the graphs are left unchopped, but gbz constructiont will do its own chopping, meaning that there are two node spaces: one for gbz and everything derived from it, and one for everything else.  Which can make debugging maddening (the translation is kept in the GBZ and automatically used by some vg tools, but this sadly usually only adds confusions). 