### PR TITLE
Fix chrom ordering in cactus-pangenome

### DIFF
--- a/src/cactus/refmap/cactus_pangenome.py
+++ b/src/cactus/refmap/cactus_pangenome.py
@@ -274,7 +274,7 @@ def export_align_wrapper(job, options, results_dict, reference_list):
     if not chrom_dir.startswith('s3://') and not os.path.isdir(chrom_dir):
         os.makedirs(chrom_dir)
 
-    for chrom, results in results_dict.items():
+    for chrom, results in sorted(results_dict.items()):
         hal_path = makeURL(os.path.join(chrom_dir, '{}.hal'.format(chrom)))
         vg_path = makeURL(os.path.join(chrom_dir, '{}.vg'.format(chrom)))
         job.fileStore.exportFile(results[0], hal_path)


### PR DESCRIPTION
When running `cactus-pangenome`, the chromosomes are apparently joined together in arbitrary order.  This PR changes it to sort by chromosome name.  This way chr1 will have id 1, and appear first in the GFA file.  (no impact on anything else I can think of apart from id names and gfa line order).  