### PR TITLE
Better refcontigs autodetect

### DIFF
--- a/doc/pangenome.md
+++ b/doc/pangenome.md
@@ -138,7 +138,17 @@ By default, `cactus` attempts to automatically determine the amount of memory to
 
 The application and impact of this option is demonstrated in the explanation of the Yeast pangenome example below.
 
-**Important** The reference genome assembly must be chromosome scale. If your reference assembly also consists of many small fragments (ex GRCh38) then you can use the `--refContigs` option to specify the chromosomes.  Ex for GRCh38 `--refContigs $(for i in `seq 22`; do printf "chr$i "; done ; echo "chrX chrY chrM")`.  If you want to include the remaining reference contig fragments in your graph, add the `--otherContig chrOther` option.  If you do not specify `--refContigs`, they will be determined automatically and small contigs will be included. 
+**Important** The reference genome assembly must be chromosome scale. If your reference assembly also consists of many small fragments (ex GRCh38) then you can use the `--refContigs` option to specify the chromosomes.  Ex for GRCh38 `--refContigs $(for i in `seq 22`; do printf "chr$i "; done ; echo "chrX chrY chrM")`.  If you want to include the remaining reference contig fragments in your graph, add the `--otherContig chrOther` option.  If you do not specify `--refContigs`, they will be determined automatically and all small contigs will be included. For example, if your reference has the following contigs and lengths
+```
+chr1 1000000
+chr2 900000
+chr3 500000
+chrM 1000
+random_1 400000
+random_2 5000
+randome_3 5000 
+```
+Then the pipeline will automatically determine, using the names and sizes (see the <graphmap-split> section of the configuration XML for details) that the reference contigs are `chr1`, `chr2`, `chr3`, `chrM` and `random_1`. It will make a graph file for each of these, and a single `chrOther` graph file for `random_2` and `random_3`.  All contigs will end up in the final whole-genome indexes.  This logic only affects the chromosome-scale output and workload distribution. If you do not want the `random` contigs in the graph, you would need to specify `--refContigs chr1 chr2 chr3 chrM`. By default, refContigs are limited to 128 in number, contigs that are at least 10% as long as the longest contig or contigs whose name begins with `chr` followed by up to 3 characters (any case).
 
 **Also Important** We do not yet automatically support the *alternate* loci from GRCh38, ex the various HLA contigs.  They must be excluded from the input fasta file to get sane results. They can be included in the graph by providing a separate sample / fasta pair in the input for each contig.  Please [here](#grch38-alts-graph) for an example of how to do so.
 

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -355,6 +355,7 @@
 	<!-- remapSplitOptions: extra rgfa-split options to apply when splitting after remapping (use -u 3000000 to enable autoclipping between contigs, add -s to allow within contig)-->
 	<!-- maxRefContigs: The maximum number of auto-detect refContigs -->
 	<!-- refContigDropoff: When detecting refContigs, sort in reverse order by size, and pick refContigs up until contig N is this many times smaller than contig 1 (or maxRefContigs) is reached.  The general idea is to have a refContig for each chromosome then lump all the tiny ones into their own graphs. -->
+	<!-- refContigRegex: If specified, automatically promote any matching contig name into its own graph, regardless of how small it is.  Useful for making sure chrM doesn't get mixed with KI270322.1 etc. By defaulat it's anything beginning with chr (any case) followed by 0-3 chracters. This takes precedence over refContigDropoff -->
   	<graphmap_split
 		 minQueryCoverages="0.75 0.5 0.25"
 		 minQueryCoverageThresholds="100000 1000000"
@@ -363,6 +364,7 @@
 		 remapSplitOptions=""
 		 maxRefContigs="128"
 		 refContigDropoff="10.0"
+		 refContigRegex="[c,C][h,H][r,R].?.?.?"
 		 />
 	<!-- cactus-graphmap-join options -->
 	<!-- gfaffix: toggle gfaffix normalization on/off -->


### PR DESCRIPTION
Having a graph file for each unplaced contig in the reference is annoying.  But specifying the reference contig names you want to keep is also annoying.  The current logic uses a size threshold (anything >10% max contig length gets its own file).  But even on human this doesn't work great because chrM gets lumped in with all the other stuff, whereas it's nice to have a chrM.gfa/vg in the chromosomal output. 

This PR adds a name regex option the the logic, that can be used to override the size parameter.  It defaults to chrXXX, which covers most of the ucsc assemblies I've been using.  It's not going to work everywhere, and people are probably still best taking the time to set it by hand, but will help for a lot of test cases. 