### PR TITLE
add maf_stream consensus duplication filter, and recommend it for phast

### DIFF
--- a/build-tools/downloadMafTools
+++ b/build-tools/downloadMafTools
@@ -21,6 +21,17 @@ rm -rf ${mafBuildDir}
 mkdir -p ${mafBuildDir}
 mkdir -p ${binDir}
 
+# maf_stream
+cd ${mafBuildDir}
+wget -q https://github.com/ComparativeGenomicsToolkit/maf_stream/releases/download/v0.1/maf_stream
+chmod +x maf_stream
+if [[ $STATIC_CHECK -ne 1 || $(ldd maf_stream | grep so | wc -l) -eq 0 ]]
+then
+	 mv maf_stream ${binDir}
+else
+	 exit 1
+fi
+
 # taffy
 cd ${mafBuildDir}
 wget -q https://github.com/samtools/samtools/releases/download/1.11/samtools-1.11.tar.bz2

--- a/doc/progressive.md
+++ b/doc/progressive.md
@@ -112,6 +112,8 @@ The various batching options can be used to tune distributed runs on very large 
 --chunkSize 1000000 --batchCount 4 --batchCores 32 --batchParallelTaf 8 --batchSystem mesos --provisioner aws --defaultPreemptable --nodeStorage 2000 --maxNodes 4 --nodeTypes r5.8xlarge 
 ```
 
+**Important** Even with the default normalization, `hal2maf` will still often create alignemnts with too many blocks.  It is therefore highly recommended to add the `--filterGapCausingDupes` option to `cactus-hal2maf` (regardless of the `--dupeMode` selection below).  This option will greedily remove duplicate row entries that would break a block apart. In practice, it has a negligible effect on coverage, but a very large effect on the number of blocks. 
+
 Depending on the application, you may want to handle duplication events differently when creating the MAF. Four different modes are available via the `--dupeMode` option.
 
 * "single" : Uses greedy heuristics to pick the copy for each species that results in fewest mutations and block breaks.

--- a/doc/progressive.md
+++ b/doc/progressive.md
@@ -112,9 +112,10 @@ The various batching options can be used to tune distributed runs on very large 
 --chunkSize 1000000 --batchCount 4 --batchCores 32 --batchParallelTaf 8 --batchSystem mesos --provisioner aws --defaultPreemptable --nodeStorage 2000 --maxNodes 4 --nodeTypes r5.8xlarge 
 ```
 
-Depending on the application, you may want to handle duplication events differently when creating the MAF. Three different modes are available via the `--dupeMode` option.
+Depending on the application, you may want to handle duplication events differently when creating the MAF. Four different modes are available via the `--dupeMode` option.
 
-* "single" : Uses greedy heuristics to pick the copy for each species that results in fewest mutations and block breaks. Recommended when visualizing via BigMaf (see below)
+* "single" : Uses greedy heuristics to pick the copy for each species that results in fewest mutations and block breaks.
+* "consensus" : Uses [maf_stream merge_dups consensus](https://github.com/ComparativeGenomicsToolkit/maf_stream#resolving-duplicated-entries) to make a single "consensus" row for all duplicate rows. This row won't actually reflect a real sequence in the fasta, but the individual columns will be more sensitive to the true coverage than when using "single".  Recommended when only looking at columns and duplications are not supported (ex with Phast and the UCSC Genome Browser). 
 * "ancestral" : Restricts the duplication relationships shown to only those orthologous to the reference genome according to the HAL tree. There may be multiple orthologs per genome. This relies on the dating of the duplication in the hal tree (ie in which genome it is explicitly self-aligned) and is still a work in progress. For example, in a tree with `((human,chimp),gorilla)`, if a duplication in human is collapsed (ie a single copy) in the human-chimp ancestor, then it would not show up on the human-referenced MAF using this option. But if the duplication is not collapsed in this ancestor (presumably because each copy has an ortholog in chimp and gorilla), then it will be in the MAF because the duplication event was higher in the tree.
 * "all" : (default) All duplications are written, including ancestral events (orthologs) and paralogs in the reference. 
 

--- a/src/cactus/maf/cactus_hal2maf.py
+++ b/src/cactus/maf/cactus_hal2maf.py
@@ -52,8 +52,8 @@ def main():
     parser.add_argument("--raw", action="store_true", help = "Do not run taf-based normalization on the MAF")
 
     # new dupe-handler option
-    parser.add_argument("--dupeMode", type=str, choices=["single", "ancestral", "all"],
-                        help="Toggle how to handle duplications: None: heuristically choose single, most similar homolog; Ancestral: keep only duplications that are also separate in ancestor; All: keep all duplications, including paralogies (self-alignments) in given genome [default=All]",
+    parser.add_argument("--dupeMode", type=str, choices=["single", "consensus", "ancestral", "all"],
+                        help="Toggle how to handle duplications: single: heuristically choose single, most similar homolog; consensus: squish all duplicate rows into a single conensus row; Ancestral: keep only duplications that are also separate in ancestor; All: keep all duplications, including paralogies (self-alignments) in given genome [default=all]",
                         default="all")
 
     # pass through a subset of hal2maf options
@@ -336,6 +336,8 @@ def taf_cmd(hal_path, chunk, chunk_num, options):
     cmd += ' | mafFilter -m - -l 2'
     if options.dupeMode == 'single':
         cmd += ' | mafDuplicateFilter -m - -k'
+    elif options.dupeMode == 'consensus':
+        cmd += ' | maf_stream merge_dups consensus'
     if chunk[1] != 0:
         cmd += ' | grep -v ^#'
     if options.outputMAF.endswith('.gz'):


### PR DESCRIPTION
As discussed in #1063, there's an existing tool, `maf_stream` that can squish together duplication rows in the MAF, without losing any coverage.  

This was an issue that just came up for me when looking at another alignment : multiple copies not allowed, but filtering them out visibly tanks coverage.  

The solution here kind of cheats in that the rows in the consensus MAF don't actually correspond the the fasta.  But PhastCons only considers the columns, so that should be okay. 

The interface for this is `cactus-hal2maf --dupeMode consensus`. 

Resolves #1063