### PR TITLE
fix cactus-update-prepare replace to print halRemoveGenome instead of…

### DIFF
--- a/doc/cactus-update-prepare.md
+++ b/doc/cactus-update-prepare.md
@@ -1,6 +1,8 @@
 # Updating Cactus alignments
 This document provides examples of how to use `cactus-update-prepare`, a wrapper tool of `cactus-prepare` yielding a list of command-lines to update cactus alignments in a step-by-step fashion. 
 
+**Important: back up your alignment file before attempting any of these operations. If something goes wrong, the file may be completely unrecoverable.**
+
 ## EvolverPrimates Example
 Before show examples of updating an alignment, let's create an alignment first using the evolverMammals [example](https://raw.githubusercontent.com/ComparativeGenomicsToolkit/cactus/master/examples/evolverMammals.txt) as follows:
 
@@ -161,6 +163,7 @@ cactus-blast ./jobstore/2 ./steps/seq_file.out ./steps/Anc1.cigar --root Anc1 --
 cactus-align ./jobstore/3 ./steps/seq_file.out ./steps/Anc1.cigar ./steps/Anc1.hal --root Anc1 --realTimeLogging --logInfo --retryCount 0 --maxCores 2 --includeRoot 
 
 ## Alignment update
+halRemoveGenome  ./steps/Anc1.hal simHuman_chr6
 halReplaceGenome --bottomAlignmentFile ./steps/Anc1.hal --topAlignmentFile ./evolverMammals.hal ./evolverMammals.hal Anc1 --hdf5InMemory 
 
 ## Alignment validation

--- a/src/cactus/update/cactus_update_prepare.py
+++ b/src/cactus/update/cactus_update_prepare.py
@@ -407,6 +407,7 @@ def get_plan_adding2node(
     jobStore,
     outSeqFile,
     cactus_prepare_options="",
+    remove_genome=None
 ):
     """
     A function that automatises the instructions at
@@ -478,6 +479,8 @@ def get_plan_adding2node(
             f"{halOptions} "
         )
     ]
+    if remove_genome:
+        update_cmds.insert(0, f"halRemoveGenome {out_hal} {remove_genome}")
 
     # adding HAL-file validating instructions
     validation_cmds = [f"halValidate --genome {genome} {in_hal} {halOptions}"]
@@ -692,6 +695,7 @@ def cactus_alignment_update(options):
     # A genome can be replaced (for example to update an assembly version) by
     # removing it and then following the "add-to-node" procedure to add the
     # new version back as a child of its parent.
+    remove_genome = None
     if "replace" == options.action:
 
         # grab parent_genome info before genome removal
@@ -718,10 +722,7 @@ def cactus_alignment_update(options):
         )
 
         # remove the genome for replacement
-        cactus_call(
-            check_output=False,
-            parameters=["halRemoveGenome", options.in_hal, options.genome],
-        )
+        remove_genome = options.genome
 
         # following the "add-to-node" procedure below to add it again
         options.action = "add"
@@ -741,6 +742,7 @@ def cactus_alignment_update(options):
                     options.jobStore,
                     options.outSeqFile,
                     options.cactus_prepare_options,
+                    remove_genome=remove_genome
                 )
             )
 


### PR DESCRIPTION
Noticed this debugging https://github.com/ComparativeGenomicsToolkit/cactus/issues/1033

In order to replace a genome, you need to run `halRemoveGenome` then `halReplaceGenome`.  

`cactus-update-prepare replace` silently runs `halRemoveGenome` editing the input file, while printing `halReplaceGenome` into the output recipe.  This mix of printing and running is confusing, and a bit dangerous as I don't think the user expects their input hal file to be modified while generating the prepare recipe. 

This PR just changes it to print `halRemoveGenome` in the recipe instead. 