### PR TITLE
fix typo problem in gaf export

### DIFF
--- a/doc/mc-pangenomes/10-chicken-pg-2023-06-27-commands.md
+++ b/doc/mc-pangenomes/10-chicken-pg-2023-06-27-commands.md
@@ -8,7 +8,7 @@ Note: `--consMemory 256Gi` is very conservative and could be lowered by at least
 cactus-pangenome ./js ./10-chicken-pg-2022-09-23-seqfile.txt --outName 10-chicken-pg-2023-06-7 --outDir 10-chicken-pg-2023-06-27 --reference galGal6 --batchSystem slurm --indexCores 64 --consCores 64 --mgCores 64 --mapCores 8 --logFile 10-chicken-pg-2023-06-27.log --maxLocalJobs 1000 --gbz --gfa --vcf --giraffe --chrom-og --chrom-vg --viz --consMemory 256Gi
 ```
 
-Oops! (export of debug file broken in this release)
+Oops! (gaf file extension not added due to bug in this release)
 ```
-mv 10-chicken-pg-2023-06-27/10-chicken-pg-2023-06-27 10-chicken-pg-2023-06-27/10-chicken-pg-2023-06-27.paf.unfiltered.gz
+mv 10-chicken-pg-2023-06-27/10-chicken-pg-2023-06-27 10-chicken-pg-2023-06-27/10-chicken-pg-2023-06-27.gaf.gz
 ```

--- a/doc/mc-pangenomes/9-dog-pg-2023-06-27-commands.md
+++ b/doc/mc-pangenomes/9-dog-pg-2023-06-27-commands.md
@@ -8,8 +8,8 @@ Note: `--consMemory 256Gi` probably very conservative and could be lowered (see 
 cactus-pangenome ./js ./9-dog-pg-2023-06-27-seqfile.txt --outName 9-dog-pg-2023-06-27 --outDir 9-dog-pg-2023-06-27 --reference canFam4 --batchSystem slurm --indexCores 64 --consCores 64 --mgCores 64 --mapCores 8 --logFile 9-dog-pg-2023-06-27.log --gbz --gfa --vcf --giraffe --chrom-og --chrom-vg --viz --consMemory 256Gi
 ```
 
-Oops! (export of debug file broken in this release)
+Oops! (gaf file extension not added due to bug in this release)
 ```
-mv 9-dog-pg-2023-06-27/9-dog-pg-2023-06-27 9-dog-pg-2023-06-27/9-dog-pg-2023-06-27.paf.unfiltered.gz
+mv 9-dog-pg-2023-06-27/9-dog-pg-2023-06-27 9-dog-pg-2023-06-27/9-dog-pg-2023-06-27.gaf.gz
 ```
 

--- a/src/cactus/refmap/cactus_pangenome.py
+++ b/src/cactus/refmap/cactus_pangenome.py
@@ -226,11 +226,12 @@ def export_graphmap_wrapper(job, options, paf_id, paf_path, gaf_id, unfiltered_p
     paf_path = os.path.join(options.outDir, os.path.basename(paf_path))
     job.fileStore.exportFile(paf_id, makeURL(paf_path))
     if gaf_id:
-        gaf_name = os.path.splitext(os.path.basename(paf_path))[0]
+        gaf_name = os.path.splitext(os.path.basename(paf_path))[0] + '.gaf.gz'
         job.fileStore.exportFile(gaf_id, makeURL(os.path.join(options.outDir, gaf_name)))
     if unfiltered_paf_id:
-        job.fileStore.exportFile(paf_id, makeURL(paf_path + '.unfiltered.gz'))
+        job.fileStore.exportFile(unfiltered_paf_id, makeURL(paf_path + '.unfiltered.gz'))
         job.fileStore.exportFile(paf_filter_log, makeURL(paf_path + '.filter.log'))
+        
 
 def update_seqfile(job, options, seq_id_map, seq_path_map, seq_order, gfa_fa_id, gfa_fa_path, graph_event):
     """ put the minigraph gfa.fa file into the seqfile and export both """


### PR DESCRIPTION
This affects `cactus-pangenome` but not `cactus-graphmap`.  `name.unfiltered.paf.gz` was being overwritten with `name.paf` and `name.gaf.gz` was being saved as `name`.  This PR fixes both issues (these files only ever needed for debugging).  