### PR TITLE
fix --refContigs in cactus-graphmap-split

### DIFF
--- a/src/cactus/refmap/cactus_pangenome.py
+++ b/src/cactus/refmap/cactus_pangenome.py
@@ -332,7 +332,7 @@ def pangenome_end_to_end_workflow(job, options, config_wrapper, seq_id_map, seq_
 
     # cactus_graphmap_split
     split_job = update_seqfile_job.addFollowOnJobFn(graphmap_split_workflow, options, config_wrapper, seq_id_map, seq_name_map, sv_gfa_id,
-                                                    sv_gfa_path, paf_id, paf_path, options.refContigs, options.otherContig, sanitize=False)
+                                                    sv_gfa_path, paf_id, paf_path, sanitize=False)
 
     wf_output = split_job.rv()
     split_out_path = os.path.join(options.outDir, 'chrom-subproblems')    


### PR DESCRIPTION
The `--refContigs` option is shared by `cactus-pangenome` and `cactus-graphmap-split`.  But during a recent refactor, it apparently stopped working in the latter, which is under a bit lest testing.  No matter what you gave to `cactus-graphmap-split --refContigs`, it would assume the option was empty and determine its own reference contigs.  The same option in `cactus-pangenome` worked fine, however.

Anyway, this PR should fix this issue.  And is probably worth a patch release once it passes its tests. 

Resolves #1078