### PR TITLE
Fix maf row order with --dupeMode consensus

### DIFF
--- a/build-tools/downloadMafTools
+++ b/build-tools/downloadMafTools
@@ -66,7 +66,7 @@ fi
 cd ${mafBuildDir}
 git clone https://github.com/ComparativeGenomicsToolkit/mafTools.git
 cd mafTools
-git checkout f66cafb395f96773454895b4a1f6592a6850bfbc
+git checkout 837b8f27c7bf781c7cbee3972b94e91aa6a77790
 find . -name "*.mk" | xargs sed -ie "s/-Werror//g"
 find . -name "Makefile*" | xargs sed -ie "s/-Werror//g"
 # hack in flags support

--- a/build-tools/downloadMafTools
+++ b/build-tools/downloadMafTools
@@ -66,7 +66,7 @@ fi
 cd ${mafBuildDir}
 git clone https://github.com/ComparativeGenomicsToolkit/mafTools.git
 cd mafTools
-git checkout 0d2a253a528749bad2c6c0179bd15edd8d56adf6
+git checkout f66cafb395f96773454895b4a1f6592a6850bfbc
 find . -name "*.mk" | xargs sed -ie "s/-Werror//g"
 find . -name "Makefile*" | xargs sed -ie "s/-Werror//g"
 # hack in flags support

--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -703,6 +703,11 @@ class TestCase(unittest.TestCase):
         # run mafComparator on the evolver output
         subprocess.check_call(['cactus-hal2maf', self._job_store('h2m'), halPath,  halPath + '.maf', '--chunkSize', '10000', '--batchCount', '2',
                                '--refGenome', 'Anc0'], shell=False)
+
+        # run it with --dupeMode consensus just to make sure it doesn't crash
+        subprocess.check_call(['cactus-hal2maf', self._job_store('h2m'), halPath,  halPath + '.consensus.maf.gz', '--chunkSize', '10000', '--batchCount', '2',
+                               '--refGenome', 'Anc0', '--dupeMode', 'consensus'], shell=False)
+        
         # cactus-hal2maf doesnt support --onlySequenceNames because the genome names are needed by taf_add_gap_bases
         # so we manually filter here
         for genome in subprocess.check_output(['halStats', halPath, '--genomes']).strip().decode('utf-8').split():


### PR DESCRIPTION
I didn't realize it, but `maf_stream` re-orders the rows in the maf blocks.  This is bad news for, say, `taffy index`, which assumes the reference is the first row.  

this PR uses `mafRowOrderer` to re-sort the output of `maf_stream`. 