### PR TITLE
Fix error check that trips up GRCh38 graph with second reference

### DIFF
--- a/src/cactus/refmap/cactus_minigraph.py
+++ b/src/cactus/refmap/cactus_minigraph.py
@@ -132,8 +132,8 @@ def check_sample_names(sample_names, references):
         if type(references) is str:
             references = [references]
         if references[0] not in sample_names:
-                raise RuntimeError("Specified reference, \"{}\" not in seqfile".format(references[0]))
-
+            raise RuntimeError("Specified reference, \"{}\" not in seqfile".format(references[0]))
+        for reference in references:
             # graphmap-join uses reference names as prefixes, so make sure we don't get into trouble with that
             reference_base = os.path.splitext(reference)[0]
             for sample in sample_names:

--- a/src/cactus/refmap/cactus_minigraph.py
+++ b/src/cactus/refmap/cactus_minigraph.py
@@ -131,8 +131,7 @@ def check_sample_names(sample_names, references):
         assert type(references) in [list, str]
         if type(references) is str:
             references = [references]
-        for reference in references:
-            if reference not in sample_names:
+        if references[0] not in sample_names:
                 raise RuntimeError("Specified reference not in seqfile")
 
             # graphmap-join uses reference names as prefixes, so make sure we don't get into trouble with that

--- a/src/cactus/refmap/cactus_minigraph.py
+++ b/src/cactus/refmap/cactus_minigraph.py
@@ -132,7 +132,7 @@ def check_sample_names(sample_names, references):
         if type(references) is str:
             references = [references]
         if references[0] not in sample_names:
-                raise RuntimeError("Specified reference not in seqfile")
+                raise RuntimeError("Specified reference, \"{}\" not in seqfile".format(references[0]))
 
             # graphmap-join uses reference names as prefixes, so make sure we don't get into trouble with that
             reference_base = os.path.splitext(reference)[0]

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -280,9 +280,8 @@ def make_align_job(options, toil, config_wrapper=None, chrom_name=None):
     # check --reference input
     if options.reference:
         leaves = [mc_tree.getName(leaf) for leaf in mc_tree.getLeaves()]
-        for reference in options.reference:
-            if reference not in leaves:
-                raise RuntimeError("Genome specified with --reference, {}, not found in tree leaves".format(options.reference))
+        if options.reference[0] not in leaves:
+            raise RuntimeError("Genome specified with --reference, {}, not found in tree leaves".format(options.reference[0]))
 
     # toggle stable
     paf_to_stable = False


### PR DESCRIPTION
There are components with no CHM13 contig aligned, but that shouldn't be a fatal erro when running with `--reference GRC3h8 CHM13`