### PR TITLE
prep release 2.6.4

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,10 @@
+# Release 2.6.4 2023-07-02
+
+This is another minor patch release to fix support for multiple values to `--reference`.
+
+- Don't fail if a given reference contig contains no sequences from the 2nd reference. This issue prevented completing of HPRC graphs with `--reference GRCh38 CHM13` because CHM13 wasn't present in the non-chromosome components.
+- Fix `--dupeMode consensus` to output MAF with rows sorted (and, importantly, leaving the first row as reference). 
+
 # Release 2.6.3 2023-06-29
 
 This release contains a single, minor patch that only applies when passing multiple values to `--reference`.  

--- a/doc/progressive.md
+++ b/doc/progressive.md
@@ -169,12 +169,12 @@ Conservation scores can be computed using [phast](http://compgen.cshl.edu/phast/
 The Cactus Docker image contains everything you need to run Cactus (python environment, all binaries, system dependencies). For example, to run the test data:
 
 ```
-docker run -v $(pwd):/data --rm -it quay.io/comparative-genomics-toolkit/cactus:v2.6.3 cactus /data/jobStore /data/evolverMammals.txt /data/evolverMammals.hal
+docker run -v $(pwd):/data --rm -it quay.io/comparative-genomics-toolkit/cactus:v2.6.4 cactus /data/jobStore /data/evolverMammals.txt /data/evolverMammals.hal
 ```
 
 Or you can proceed interactively by running
 ```
-docker run -v $(pwd):/data --rm -it quay.io/comparative-genomics-toolkit/cactus:v2.6.3 bash
+docker run -v $(pwd):/data --rm -it quay.io/comparative-genomics-toolkit/cactus:v2.6.4 bash
 cactus /data/jobStore /data/evolverMammals.txt /data/evolverMammals.hal
 
 ```
@@ -210,7 +210,7 @@ You cannot run `cactus --batchSystem slurm` from *inside* the Cactus docker cont
 To run Progressive Cactus with CPU (default) lastz, you should increase the chunk size.  This will divide the input assemblies into fewer pieces, resulting in fewer jobs on the cluster.
 
 ```
-cp cactus-bin-v2.6.3/src/cactus/cactus_progressive_config.xml ./config-slurm.xml
+cp cactus-bin-v2.6.4/src/cactus/cactus_progressive_config.xml ./config-slurm.xml
 sed -i config-slurm.xml -e 's/blast chunkSize="30000000"/blast chunkSize="90000000"/g'
 sed -i config-slurm.xml -e 's/dechunkBatchSize="1000"/dechunkBatchSize="200"/g'
 ```

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ class PostInstallCommand(install):
 
 setup(
     name = "Cactus",
-    version = "2.6.3",
+    version = "2.6.4",
     author = "Benedict Paten",
     package_dir = {'': 'src'},
     packages = find_packages(where='src'),

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -305,7 +305,7 @@ def getDockerImage():
 
 def getDockerRelease(gpu=False):
     """Get the most recent docker release."""
-    r = "quay.io/comparative-genomics-toolkit/cactus:v2.6.3"
+    r = "quay.io/comparative-genomics-toolkit/cactus:v2.6.4"
     if gpu:
         r += "-gpu"
     return r


### PR DESCRIPTION
Another tiny release, in an attempt to get something to pin a (GRCh38-based) hprc graph to. 