### PR TITLE
ignore numeric and duplicate ancestor labels

### DIFF
--- a/src/cactus/progressive/multiCactusTree.py
+++ b/src/cactus/progressive/multiCactusTree.py
@@ -50,7 +50,7 @@ class MultiCactusTree(NXTree):
             width = int(math.log10(numInternal)) + 1
         for node in self.breadthFirstTraversal():
             if not self.isLeaf(node):
-                while not self.hasName(node):
+                while not self.hasName(node) or not self.getName(node):
                     new_name = "%s%s" % (prefix, str(count).zfill(width))
                     if new_name not in existing_labels:
                         self.setName(node, new_name)

--- a/src/cactus/progressive/seqFile.py
+++ b/src/cactus/progressive/seqFile.py
@@ -121,6 +121,7 @@ class SeqFile:
         if len([i for i in self.tree.postOrderTraversal()]) <= 2:
             raise RuntimeError("At least two valid leaf genomes required in"
                                " input tree")
+        ancNameSet = set()
         for node in self.tree.postOrderTraversal():
             if self.tree.isLeaf(node):
                 name = self.tree.getName(node)
@@ -131,6 +132,16 @@ class SeqFile:
                     #if not os.path.exists(path):
                     #    raise RuntimeError("Sequence path not found: %s" % path)
                     #self.sanityCheckSequence(path)
+            elif self.tree.hasName(node):
+                name = self.tree.getName(node)
+                if name.isnumeric():
+                    sys.stderr.write("WARNING: ignoring numeric ancestor name {} in input tree\n".format(name))
+                    self.tree.setName(node, None)
+                elif name in ancNameSet or name in self.pathMap:
+                    sys.stderr.write("WARNING: ignoring duplicate ancestor name {} in input tree\n".format(name))
+                    self.tree.setName(node, None)
+                else:
+                    ancNameSet.add(name)
 
     def sanityCheckSequence(self, path):
         """Warns the user about common problems with the input sequences."""

--- a/src/cactus/progressive/seqFile.py
+++ b/src/cactus/progressive/seqFile.py
@@ -121,7 +121,7 @@ class SeqFile:
         if len([i for i in self.tree.postOrderTraversal()]) <= 2:
             raise RuntimeError("At least two valid leaf genomes required in"
                                " input tree")
-        ancNameSet = set()
+        nameSet = set()
         for node in self.tree.postOrderTraversal():
             if self.tree.isLeaf(node):
                 name = self.tree.getName(node)
@@ -132,16 +132,17 @@ class SeqFile:
                     #if not os.path.exists(path):
                     #    raise RuntimeError("Sequence path not found: %s" % path)
                     #self.sanityCheckSequence(path)
+                nameSet.add(name)
             elif self.tree.hasName(node):
                 name = self.tree.getName(node)
                 if name.isnumeric():
                     sys.stderr.write("WARNING: ignoring numeric ancestor name {} in input tree\n".format(name))
                     self.tree.setName(node, None)
-                elif name in ancNameSet or name in self.pathMap:
+                elif name in nameSet:
                     sys.stderr.write("WARNING: ignoring duplicate ancestor name {} in input tree\n".format(name))
                     self.tree.setName(node, None)
                 else:
-                    ancNameSet.add(name)
+                    nameSet.add(name)
 
     def sanityCheckSequence(self, path):
         """Warns the user about common problems with the input sequences."""


### PR DESCRIPTION
It's come up a few times that weird ancestor names in the input tree lead to very cryptic crashes late in the pipeline.  This PR adds a check to clean out any numeric names (which tend to be bootstrap or other kinds of confidence scores from phylogeny progreams) or duplicate names with a warning. 

Resolves #1107