### PR TITLE
Fix awk arithmatic issue due to large contig sizes

### DIFF
--- a/src/cactus/refmap/cactus_graphmap_split.py
+++ b/src/cactus/refmap/cactus_graphmap_split.py
@@ -506,10 +506,10 @@ def split_fa_into_contigs(job, event, fa_id, fa_name, split_id_map, strip_prefix
             cactus_call(parameters=cmd, outfile=contig_fasta_path)
 
             # now get the total sequence size
-            size_cmd = [['cat', contig_fasta_path], ['grep', '-v', '>'], ['wc'], ['awk', '{print $3-$1}']]
+            size_cmd = [['cat', contig_fasta_path], ['grep', '-v', '>'], ['wc'], ['awk', '{printf \"%f\", $3-$1}']]
             if is_gz:
                 size_cmd[0] = ['bgzip', '-dc', contig_fasta_path, '--threads', str(job.cores)]
-            num_bases = int(cactus_call(parameters=size_cmd, check_output=True).strip())
+            num_bases = int(float(cactus_call(parameters=size_cmd, check_output=True).strip()))
         else:
             # TODO: review how cases like this are handled
             with open(contig_fasta_path, 'w') as empty_file:


### PR DESCRIPTION
`cactus-graphmap-split` uses `awk` at some point to [make a contig size table](https://github.com/ComparativeGenomicsToolkit/cactus/blob/022e7fbbf73f717f85586c97ceedb64beb0119f5/src/cactus/refmap/cactus_graphmap_split.py#L508-L512).

The problem is that some versions of `awk`, including the one in the cactus docker image (`mawk`) return scientific notation for numbers > 2Gb (32bits), and this trips up Cactus which casts it to int.  

This PR is a little patch that specifies float output, which seems consistent across `awk` flavours and number sizes and returns output readable by the existing code. 

In no way does this mean that `cactus-pangenome` will now work well on giant genomes... it's just this one particular crash that should be fixed. 

Resolves #1125