### PR TITLE
fix off-by-1 error in sample name extraction

### DIFF
--- a/src/cactus/refmap/cactus_minigraph.py
+++ b/src/cactus/refmap/cactus_minigraph.py
@@ -195,7 +195,8 @@ def sort_minigraph_input_with_mash(job, options, seq_id_map, seq_order):
     # will be determined jointly (by just concatenating them).
     seq_by_sample = defaultdict(list)
     for seq_name in seq_order[len(options.reference):]:
-        seq_by_sample[seq_name[:seq_name.rfind('.')]].append(seq_name)
+        sample_name = seq_name[:seq_name.rfind('.')] if '.' in seq_name else seq_name
+        seq_by_sample[sample_name].append(seq_name)
 
     # list of dictionary (promises) that map genome name to mash distance output
     dist_maps = []


### PR DESCRIPTION
Noticed this when seeing counterintuitive minigraph ordering for flys.  What happened is that genomes named `A1, A2, A3` etc were being lumped together in the same sample while computing the mash distance, which skewed the final order.  This traced back to a python bug where the last character was getting dropped from comparison, which is fixed here. 

This bug only affects minigraph construction ordering when sample names have no '.' characters and more than one sample has the same name when the last character is dropped. 