### PR TITLE
Enforce exactly 2 tips per component

### DIFF
--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -278,7 +278,8 @@ fi
 
 # vg
 cd ${pangenomeBuildDir}
-wget -q https://github.com/vgteam/vg/releases/download/v1.50.1/vg
+#wget -q https://github.com/vgteam/vg/releases/download/v1.51.0/vg
+wget -q http://public.gi.ucsc.edu/~hickey/vg-patch/vg.035c20a1a530d2b04ad30fe0f6cc1ae1a9432727 -O vg
 chmod +x vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd vg | grep so | wc -l) -eq 0 ]]
 then

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -594,7 +594,7 @@ def clip_vg(job, options, config, vg_path, vg_id, phase):
         cmd.append(clip_cmd)
         if phase == 'clip' and getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_join"), "removeStubs", typeFn=bool, default=True):
             # todo: could save a little time by making vg clip smart enough to do two things at once
-            stub_cmd = ['vg', 'clip', '-s', '-', '-P', options.reference[0]]
+            stub_cmd = ['vg', 'clip', '-sS', '-', '-P', options.reference[0]]
 
             # todo: do we want to add the minigraph prefix to keep stubs from minigraph? but I don't think it makes stubs....
             cmd.append(stub_cmd)
@@ -679,7 +679,7 @@ def vg_clip_vg(job , options, config, vg_path, vg_id):
 
     if getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_join"), "removeStubs", typeFn=bool, default=True):
         # this command can also leave fragments smaller than min-fragment
-        stub_cmd = ['vg', 'clip', '-s', '-']
+        stub_cmd = ['vg', 'clip', '-sS', '-']
         if options.reference:
             stub_cmd += ['-P', options.reference[0]]
         if min_fragment:


### PR DESCRIPTION
Stub clipping (which is on by default) makes sure there are at most 2 tips per component.  But there's nothing stopping from there being *fewer* than 2 tips.  

A case recently came up in a fly graph (see https://github.com/vgteam/vg/issues/4060 and https://github.com/vgteam/vg/issues/4061) where a big tangle at the end of `chr4` had an edge coming off the end of the reference path.  This one-tipped graph leads to a more complicated snarl decomposition (4 top level chains) which isn't supported by haplotype sampling.

Anyway, this PR activates a new option in `vg clip` (`-S`) which makes sure that the first and last steps of reference paths are stubs, which should guarantee each graph component has exactly two ends (which should translate to a single top-level chain and a happy `vg haplotypes`)