### PR TITLE
move 'will not be attached' message to debug

### DIFF
--- a/setup/impl/setup.c
+++ b/setup/impl/setup.c
@@ -43,18 +43,18 @@ bool getCompleteStatus(const char *fileName) {
     if (i >= 9) {
         const char *cA = fileName + i - 9;
         if (strcmp(cA, ".complete") == 0) {
-            st_logInfo("The file %s is specified complete, the sequences will be attached\n", fileName);
+            st_logDebug("The file %s is specified complete, the sequences will be attached\n", fileName);
             return 1;
         }
     }
     if (i >= 12) {
         const char *cA = fileName + i - 12;
         if (strcmp(cA, ".complete.fa") == 0) {
-            st_logInfo("The file %s is specified complete, the sequences will be attached\n", fileName);
+            st_logDebug("The file %s is specified complete, the sequences will be attached\n", fileName);
             return 1;
         }
     }
-    st_logInfo("The file %s is specified incomplete, the sequences will not be attached\n", fileName);
+    st_logDebug("The file %s is specified incomplete, the sequences will not be attached\n", fileName);
     return 0;
 }
 


### PR DESCRIPTION
Gets rid of messages like 
```
cactus_consolidated(chr2): The file /data/tmp/9eeeec3d467250f1999ba98b3759d207/6b90/9563/tmp4b8_vsdf/CHM13.fa is specified incomplete, the sequences will not be attached
```
(probably should just deprecate the whole function at some point?)