### PR TITLE
move quay docker build out of ci into release script (as done for gpu)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,16 +40,6 @@ test-job:
     - sed -i Dockerfile -e 's/ENV avx2 1/ENV CACTUS_LEGACY_ARCH 1/g'
     - make docker    
     - make -j 8 evolver_test
-    # only push image to quay if the commit is tagged (and all tests have passed)
-    - export TAG_CMP=$(git describe --tags --exact-match $(git rev-parse --verify HEAD); echo $?)
-    - |
-      if [[ "{TAG_CMP}" == 0 ]] ; then
-        make clean
-        git checkout -- Dockerfile
-        make docker
-        docker login --username $QUAY_USERNAME --password $QUAY_PASSWORD quay.io
-        make push_only
-      fi
 
   artifacts:
     # Let Gitlab see the junit report

--- a/build-tools/makeCpuDockerRelease
+++ b/build-tools/makeCpuDockerRelease
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Make a cpu-enabled docker image and push it to quay
+# Todo: it'd be nice to get travis to do this to be more consistent with normal docker
+# Note: must be run for cactus/ directory
+
+set -x
+set -beEu -o pipefail
+mydir=$(dirname $(which $0))
+source ${mydir}/releaseLib.sh
+
+buildDir=$(realpath -m build)
+binBuildDir="${buildDir}/cpu-docker-tmp"
+
+set -x
+rm -rf ${binBuildDir}
+mkdir -p ${binBuildDir}
+cd ${binBuildDir}
+git clone --recursive https://github.com/ComparativeGenomicsToolkit/cactus.git
+cd cactus
+git fetch --tags origin
+
+REL_TAG=$(getLatestReleaseTag)
+git checkout "${REL_TAG}"
+git submodule update --init --recursive
+
+docker build . -f Dockerfile -t ${dockname}:${REL_TAG}
+
+read -p "Are you sure you want to push ${dockname}:${REL_TAG} to quay?" yn
+case $yn in
+    [Yy]* ) docker push ${dockname}:${REL_TAG}; break;;
+    [Nn]* ) exit;;
+    * ) echo "Please answer yes or no.";;
+esac
+popd


### PR DESCRIPTION
#1176 stopped pushing a quay image for every single CI build.  But its attempt to only push release images was a bit ill thought out, in that it relies on a tag that may not be specified yet before the CI is run. 

I think there's room to fix this up better to get both cpu and gpu release built automatically directly on quay.  In the meantime, this PR moves the quay docker build out of CI entirely, and into a local script that gets manually run when making the release (exactly as has always been done for the gpu images). 
