### PR TITLE
--consMemory to override hal2vg as well

### DIFF
--- a/src/cactus/progressive/cactus_progressive.py
+++ b/src/cactus/progressive/cactus_progressive.py
@@ -269,7 +269,7 @@ def export_hal(job, mc_tree, config_node, seq_id_map, og_map, results, event=Non
         mem = 5 * (max([file_id.size for file_id in fa_file_ids]) + max([file_id.size for file_id in c2h_file_ids]))
         # allows pass-through of memory override from --consMemory
         if job.memory:
-            mem = max(job.memory, mem)
+            mem = job.memory
         return job.addChildJobFn(export_hal, mc_tree, config_node, seq_id_map, og_map, results, event=event,
                                  cacheBytes=cacheBytes, cacheMDC=cacheMDC, cacheRDC=cacheRDC, cacheW0=cacheW0,
                                  chunk=chunk, deflate=deflate, inMemory=inMemory, checkpointInfo=checkpointInfo,

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -392,7 +392,7 @@ def cactus_align(job, config_wrapper, mc_tree, input_seq_map, input_seq_id_map, 
     # optionally create the VG
     if doVG or doGFA:
         vg_export_job = hal_job.addFollowOnJobFn(export_vg, hal_job.rv(), config_wrapper, doVG, doGFA, referenceEvents,
-                                                 checkpointInfo=checkpointInfo)
+                                                 checkpointInfo=checkpointInfo, memory=cons_memory)
         vg_file_id, gfa_file_id = vg_export_job.rv(0), vg_export_job.rv(1)
     else:
         vg_file_id, gfa_file_id = None, None
@@ -409,7 +409,8 @@ def export_vg(job, hal_id, config_wrapper, doVG, doGFA, referenceEvents, checkpo
         return job.addChildJobFn(export_vg, hal_id, config_wrapper, doVG, doGFA, referenceEvents, checkpointInfo,
                                  resource_spec = True,
                                  disk=hal_id.size * 3,
-                                 memory=hal_id.size * 60).rv()
+                                 # allow override with cons_memory
+                                 memory=hal_id.size * 60 if not job.memory else job.memory).rv()
         
     work_dir = job.fileStore.getLocalTempDir()
     hal_path = os.path.join(work_dir, "out.hal")


### PR DESCRIPTION
I've got some input that's completely throwing off the usual estimators.  `--consMemory` is a crude but effective work-around. But it currently only applies to `cactus_consolidated` and `halAppendCactusSubtree`.  I've just run into a case where `hal2vg` is asking for `2.2T` RAM, which I don't have.  So this PR applies `--consMemory` to it as well. 