### PR TITLE
rGFA support (experimental)

### DIFF
--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -279,7 +279,7 @@ fi
 # vg
 cd ${pangenomeBuildDir}
 #wget -q https://github.com/vgteam/vg/releases/download/v1.51.0/vg
-wget -q http://public.gi.ucsc.edu/~hickey/vg-patch/vg.e65bfb2f9ee098c2bd65a854d7d8597048e7c529 -O vg
+wget -q http://public.gi.ucsc.edu/~hickey/vg-patch/vg.c162ee345210d18e5eb6f3a129da857184e952be -O vg
 chmod +x vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd vg | grep so | wc -l) -eq 0 ]]
 then

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -278,7 +278,8 @@ fi
 
 # vg
 cd ${pangenomeBuildDir}
-wget -q https://github.com/vgteam/vg/releases/download/v1.51.0/vg
+#wget -q https://github.com/vgteam/vg/releases/download/v1.51.0/vg
+wget -q http://public.gi.ucsc.edu/~hickey/vg-patch/vg.30ac0c77e91fbeff06b6e7bc9a7f172607ff84ba -O vg
 chmod +x vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd vg | grep so | wc -l) -eq 0 ]]
 then

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -215,7 +215,7 @@ fi
 
 # hal2vg
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.5/hal2vg
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.4/hal2vg
 chmod +x hal2vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd hal2vg | grep so | wc -l) -eq 0 ]]
 then
@@ -225,7 +225,7 @@ else
 fi
 # clip-vg
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.5/clip-vg
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.4/clip-vg
 chmod +x clip-vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd clip-vg | grep so | wc -l) -eq 0 ]]
 then
@@ -235,7 +235,7 @@ else
 fi
 # halRemoveDupes
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.5/halRemoveDupes
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.4/halRemoveDupes
 chmod +x halRemoveDupes
 if [[ $STATIC_CHECK -ne 1 || $(ldd halRemoveDupes | grep so | wc -l) -eq 0 ]]
 then
@@ -245,7 +245,7 @@ else
 fi
 # halMergeChroms
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.5/halMergeChroms
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.4/halMergeChroms
 chmod +x halMergeChroms
 if [[ $STATIC_CHECK -ne 1 || $(ldd halMergeChroms | grep so | wc -l) -eq 0 ]]
 then
@@ -256,7 +256,7 @@ fi
 
 # halUnclip
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.5/halUnclip
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.4/halUnclip
 chmod +x halUnclip
 if [[ $STATIC_CHECK -ne 1 || $(ldd halUnclip | grep so | wc -l) -eq 0 ]]
 then
@@ -267,7 +267,7 @@ fi
 
 # filter-paf-deletions
 cd ${pangenomeBuildDir}
-wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.5/filter-paf-deletions
+wget -q https://github.com/ComparativeGenomicsToolkit/hal2vg/releases/download/v1.1.4/filter-paf-deletions
 chmod +x filter-paf-deletions
 if [[ $STATIC_CHECK -ne 1 || $(ldd filter-paf-deletions | grep so | wc -l) -eq 0 ]]
 then
@@ -279,7 +279,7 @@ fi
 # vg
 cd ${pangenomeBuildDir}
 #wget -q https://github.com/vgteam/vg/releases/download/v1.51.0/vg
-wget -q http://public.gi.ucsc.edu/~hickey/vg-patch/vg.c162ee345210d18e5eb6f3a129da857184e952be -O vg
+wget -q http://public.gi.ucsc.edu/~hickey/vg-patch/vg.9df2a056197cafd817cf48c76cf662dd775d265d -O vg
 chmod +x vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd vg | grep so | wc -l) -eq 0 ]]
 then

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -279,7 +279,7 @@ fi
 # vg
 cd ${pangenomeBuildDir}
 #wget -q https://github.com/vgteam/vg/releases/download/v1.51.0/vg
-wget -q http://public.gi.ucsc.edu/~hickey/vg-patch/vg.30ac0c77e91fbeff06b6e7bc9a7f172607ff84ba -O vg
+wget -q http://public.gi.ucsc.edu/~hickey/vg-patch/vg.aadda02a8056c8120c5fa655b04fbe927f3b8586 -O vg
 chmod +x vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd vg | grep so | wc -l) -eq 0 ]]
 then

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -279,7 +279,7 @@ fi
 # vg
 cd ${pangenomeBuildDir}
 #wget -q https://github.com/vgteam/vg/releases/download/v1.51.0/vg
-wget -q http://public.gi.ucsc.edu/~hickey/vg-patch/vg.aadda02a8056c8120c5fa655b04fbe927f3b8586 -O vg
+wget -q http://public.gi.ucsc.edu/~hickey/vg-patch/vg.e65bfb2f9ee098c2bd65a854d7d8597048e7c529 -O vg
 chmod +x vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd vg | grep so | wc -l) -eq 0 ]]
 then

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -380,6 +380,7 @@
 	<!-- odgiDrawOptions: options to odgi draw, used for 2d viz -->
 	<!-- rindexOptions: options to vg gbwt -r (r-index construction) as used to make haplotype sampling index -->
 	<!-- haplOptions: options to vg haplotypes as used to make haplotype sampling index -->
+	<!-- minRGFAFragment: smallest rGFA (rank > 0) cover path to write -->
 	<graphmap_join
 		 gfaffix="1"
 		 clipNonMinigraph="1"		 
@@ -392,6 +393,7 @@
 		 odgiDrawOptions="-H 1000"
 		 rindexOptions="-p"
 		 haplOptions="-v 2"
+		 minRGFAFragment="50"
 		 />
 	<!-- hal2vg options -->
 	<!-- includeMinigraph: include minigraph node sequences as paths in output (note that cactus-graphmap-join will still remove them by default) -->

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -381,6 +381,7 @@
 	<!-- rindexOptions: options to vg gbwt -r (r-index construction) as used to make haplotype sampling index -->
 	<!-- haplOptions: options to vg haplotypes as used to make haplotype sampling index -->
 	<!-- minRGFAFragment: smallest rGFA (rank > 0) cover path to write -->
+	<!-- keepRGFAFragmentsInChromGraphs: toggle whether rGFA fragments end up in chromosome graphs (by default only in gbz/rgfa) -->	
 	<graphmap_join
 		 gfaffix="1"
 		 clipNonMinigraph="1"		 
@@ -394,6 +395,7 @@
 		 rindexOptions="-p"
 		 haplOptions="-v 2"
 		 minRGFAFragment="50"
+		 keepRGFAFragmentsInChromGraphs="0"
 		 />
 	<!-- hal2vg options -->
 	<!-- includeMinigraph: include minigraph node sequences as paths in output (note that cactus-graphmap-join will still remove them by default) -->

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -663,7 +663,7 @@ def clip_vg(job, options, config, vg_path, vg_id, phase):
         if phase in options.rgfa:
             # do the rgfa cover
             min_rgfa_fragment = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_join"), "minRGFAFragment", typeFn=int, default=1)
-            rgfa_cover_cmd = ['vg', 'paths', '-v', '-', '-R', str(min_rgfa_fragment),
+            rgfa_cover_cmd = ['vg', 'paths', '-v', '-', '-f', str(min_rgfa_fragment),
                               '-Q', options.reference[0], '-t', str(job.cores)]
             cmd.append(rgfa_cover_cmd)
 
@@ -796,7 +796,7 @@ def drop_rgfa_path_fragments(job, vg_path, vg_id):
     out_vg_path = os.path.join(work_dir, os.path.splitext(os.path.basename(vg_path))[0]) + 'norgfa.vg'
     job.fileStore.readGlobalFile(vg_id, vg_path)
 
-    cactus_call(parameters=['vg', 'paths', '-d', '-S', rgfa_sample_name, '-v', vg_path], outfile=out_vg_path)
+    cactus_call(parameters=['vg', 'paths', '-d', '--rgfa-paths', '-v', vg_path], outfile=out_vg_path)
     return job.fileStore.writeGlobalFile(out_vg_path)    
     
 def vg_to_gfa(job, options, config, vg_path, vg_id, rgfa=False):

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -542,7 +542,7 @@ def graphmap_join_workflow(job, options, config, vg_ids, hal_ids):
                                                             memory=index_mem)
                 out_dicts.append(deconstruct_job.rv())                
 
-                if do_rgfa and vcf_ref == options.vcfReference[0]:
+                if do_rgfa and vcf_ref == options.reference[0]:
                     rgfa_deconstruct_job = prev_job.addFollowOnJobFn(make_vcf, config, options.outName, vcf_ref, current_out_dict,
                                                                      max_ref_allele=options.vcfbub,
                                                                      tag=vcftag + '.', ref_tag = workflow_phase + '.',


### PR DESCRIPTION
This adds the `--rgfa` option to `cactus-pangenome`.  It will get you

* `graph.rgfa.gz`: Like the usual GFA file, but no paths -- only rGFA tags.  These tags will cover off-reference sequence as determined by greedy cover.  By default, only intervals >= 50bp are included. (`graph.gfa.gz` changed to no longer have rank-0 tags)
* `graph.rgfa.gbz`: This is the usual GBZ, but with the full rGFA cover added as reference path fragments (that have special sample name `_rGFA`)
* `graph.rgfa.vcf.gz`: This VCF contains nested calls inside insertions by means of the rGFA cover. It does not go through `vcfbub` like usual.   

It'd be nice to not have different GBZ/VCF outputs, but keeping them separate will make it easier to benchmark.  There's also still some work needed regarding VCF tags...