### PR TITLE
Boost memory requirements to make docker binaries with slurm more stable

### DIFF
--- a/src/cactus/blast/cactus_blast.py
+++ b/src/cactus/blast/cactus_blast.py
@@ -95,7 +95,7 @@ def runCactusBlastOnly(options):
             # load up the seqfile and figure out the outgroups and schedule
             config_node = ET.parse(options.configFile).getroot()
             config_wrapper = ConfigWrapper(config_node)
-            config_wrapper.substituteAllPredefinedConstantsWithLiterals()
+            config_wrapper.substituteAllPredefinedConstantsWithLiterals(options)
             # apply gpu override
             config_wrapper.initGPU(options)
             mc_tree, input_seq_map, og_candidates = parse_seqfile(options.seqFile, config_wrapper)

--- a/src/cactus/maf/cactus_hal2chains.py
+++ b/src/cactus/maf/cactus_hal2chains.py
@@ -102,7 +102,7 @@ def main():
             #load cactus config
             configNode = ET.parse(options.configFile).getroot()
             config = ConfigWrapper(configNode)
-            config.substituteAllPredefinedConstantsWithLiterals()
+            config.substituteAllPredefinedConstantsWithLiterals(options)
             
             logger.info("Importing {}".format(options.halFile))
             hal_id = toil.importFile(options.halFile)            

--- a/src/cactus/maf/cactus_hal2maf.py
+++ b/src/cactus/maf/cactus_hal2maf.py
@@ -179,7 +179,7 @@ def main():
             #load cactus config
             configNode = ET.parse(options.configFile).getroot()
             config = ConfigWrapper(configNode)
-            config.substituteAllPredefinedConstantsWithLiterals()
+            config.substituteAllPredefinedConstantsWithLiterals(options)
             
             logger.info("Importing {}".format(options.halFile))
             hal_id = toil.importFile(options.halFile)

--- a/src/cactus/maf/cactus_maf2bigmaf.py
+++ b/src/cactus/maf/cactus_maf2bigmaf.py
@@ -84,7 +84,7 @@ def main():
             #load cactus config
             configNode = ET.parse(options.configFile).getroot()
             config = ConfigWrapper(configNode)
-            config.substituteAllPredefinedConstantsWithLiterals()
+            config.substituteAllPredefinedConstantsWithLiterals(options)
             
             logger.info("Importing {}".format(options.mafFile))
             maf_id = toil.importFile(options.mafFile)

--- a/src/cactus/preprocessor/cactus_preprocessor.py
+++ b/src/cactus/preprocessor/cactus_preprocessor.py
@@ -352,7 +352,7 @@ def stageWorkflow(outputSequenceDir, configNode, inputSequences, toil, restart=F
     loadDnaBrnnModel(toil, configNode, maskAlpha = maskMode == 'brnn')
         
     if configNode.find("constants") != None:
-        ConfigWrapper(configNode).substituteAllPredefinedConstantsWithLiterals()
+        ConfigWrapper(configNode).substituteAllPredefinedConstantsWithLiterals(options)
     if maskMode:
         lastz = maskMode == 'lastz'
         brnn = maskMode == 'brnn'

--- a/src/cactus/preprocessor/cactus_preprocessor.py
+++ b/src/cactus/preprocessor/cactus_preprocessor.py
@@ -341,7 +341,7 @@ class CactusPreprocessor2(RoundedJob):
 def stageWorkflow(outputSequenceDir, configNode, inputSequences, toil, restart=False,
                   outputSequences = [], maskMode=None, maskAction=None,
                   maskFile=None, minLength=None, inputEventNames=None, brnnCores=None,
-                  gpu_override=False):
+                  gpu_override=False, options=None):
     #Replace any constants
     if not outputSequences:
         outputSequences = CactusPreprocessor.getOutputSequenceFiles(inputSequences, outputSequenceDir)
@@ -406,7 +406,7 @@ def runCactusPreprocessor(outputSequenceDir, configFile, inputSequences, toilDir
     toilOptions.logLevel = "INFO"
     toilOptions.disableCaching = True
     with Toil(toilOptions) as toil:
-        stageWorkflow(outputSequenceDir, ET.parse(options.configFile).getroot(), inputSequences, toil)
+        stageWorkflow(outputSequenceDir, ET.parse(options.configFile).getroot(), inputSequences, toil, options=toilOptions)
 
 def main():
     parser = ArgumentParser()
@@ -552,7 +552,8 @@ def main():
                       maskAction=options.maskAction,
                       minLength=options.minLength,
                       inputEventNames=inNames,
-                      brnnCores=options.brnnCores)
+                      brnnCores=options.brnnCores,
+                      options=options)
 
 if __name__ == '__main__':
     main()

--- a/src/cactus/preprocessor/lastzRepeatMasking/cactus_lastzRepeatMask.py
+++ b/src/cactus/preprocessor/lastzRepeatMasking/cactus_lastzRepeatMask.py
@@ -48,7 +48,10 @@ class RepeatMaskOptions:
 class LastzRepeatMaskJob(RoundedJob):
     def __init__(self, repeatMaskOptions, queryID, targetIDs):
         targetsSize = sum(targetID.size for targetID in targetIDs)
-        memory = 4*1024*1024*1024
+        if repeatMaskOptions.gpu:
+            memory = min(25 * targetsSize, 512e9)
+        else:
+            memory = 4*1024*1024*1024
         disk = 4*(queryID.size + targetsSize)
         cores = repeatMaskOptions.cpu
         accelerators = ['cuda:{}'.format(repeatMaskOptions.gpu)] if repeatMaskOptions.gpu else None            

--- a/src/cactus/progressive/cactus_progressive.py
+++ b/src/cactus/progressive/cactus_progressive.py
@@ -398,7 +398,7 @@ def main():
             # load up the seqfile and figure out the outgroups and schedule
             config_node = ET.parse(options.configFile).getroot()
             config_wrapper = ConfigWrapper(config_node)
-            config_wrapper.substituteAllPredefinedConstantsWithLiterals()            
+            config_wrapper.substituteAllPredefinedConstantsWithLiterals(options)
             config_wrapper.setSystemMemory(options)
 
             # apply gpu override

--- a/src/cactus/progressive/outgroup.py
+++ b/src/cactus/progressive/outgroup.py
@@ -253,7 +253,7 @@ def main():
     # can't use progressive_decomposition.py for circular deps...
     config_node = ET.parse(options.configFile).getroot()
     config_wrapper = ConfigWrapper(config_node)
-    config_wrapper.substituteAllPredefinedConstantsWithLiterals()
+    config_wrapper.substituteAllPredefinedConstantsWithLiterals(options)
     seq_file = SeqFile(args[0])
     mc_tree = MultiCactusTree(seq_file.tree)
     mc_tree.nameUnlabeledInternalNodes(config_wrapper.getDefaultInternalNodePrefix())

--- a/src/cactus/refmap/cactus_graphmap.py
+++ b/src/cactus/refmap/cactus_graphmap.py
@@ -111,7 +111,7 @@ def graph_map(options):
             paf_id, gfa_fa_id, gaf_id, unfiltered_paf_id, paf_filter_log = toil.restart()            
         else:
             # load up the seqfile and figure out the outgroups and schedule
-            config_wrapper.substituteAllPredefinedConstantsWithLiterals()
+            config_wrapper.substituteAllPredefinedConstantsWithLiterals(options)
             mc_tree, input_seq_map, og_candidates = parse_seqfile(options.seqFile, config_wrapper, pangenome=True)
             og_map = compute_outgroups(mc_tree, config_wrapper, set(og_candidates))
             event_set = get_event_set(mc_tree, config_wrapper, og_map, mc_tree.getRootName())

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -305,7 +305,7 @@ def graphmap_join(options):
             #load cactus config
             configNode = ET.parse(options.configFile).getroot()
             config = ConfigWrapper(configNode)
-            config.substituteAllPredefinedConstantsWithLiterals()
+            config.substituteAllPredefinedConstantsWithLiterals(options)
                 
             # load up the vgs
             vg_ids = []

--- a/src/cactus/refmap/cactus_graphmap_split.py
+++ b/src/cactus/refmap/cactus_graphmap_split.py
@@ -100,7 +100,7 @@ def cactus_graphmap_split(options):
         #load cactus config
         config_node = ET.parse(options.configFile).getroot()
         config = ConfigWrapper(config_node)
-        config.substituteAllPredefinedConstantsWithLiterals()
+        config.substituteAllPredefinedConstantsWithLiterals(options)
 
         #Run the workflow
         if options.restart:

--- a/src/cactus/refmap/cactus_minigraph.py
+++ b/src/cactus/refmap/cactus_minigraph.py
@@ -79,7 +79,7 @@ def main():
             # load up the seqfile
             config_node = ET.parse(options.configFile).getroot()
             config_wrapper = ConfigWrapper(config_node)
-            config_wrapper.substituteAllPredefinedConstantsWithLiterals()
+            config_wrapper.substituteAllPredefinedConstantsWithLiterals(options)
             graph_event = getOptionalAttrib(findRequiredNode(config_node, "graphmap"), "assemblyName", default="_MINIGRAPH_")
 
             # load the seqfile

--- a/src/cactus/refmap/cactus_pangenome.py
+++ b/src/cactus/refmap/cactus_pangenome.py
@@ -167,7 +167,7 @@ def main():
             # load up the seqfile
             config_node = ET.parse(options.configFile).getroot()
             config_wrapper = ConfigWrapper(config_node)
-            config_wrapper.substituteAllPredefinedConstantsWithLiterals()
+            config_wrapper.substituteAllPredefinedConstantsWithLiterals(options)
             graph_event = getOptionalAttrib(findRequiredNode(config_node, "graphmap"), "assemblyName", default="_MINIGRAPH_")
 
             # load the seqfile

--- a/src/cactus/refmap/cactus_refmap.py
+++ b/src/cactus/refmap/cactus_refmap.py
@@ -295,7 +295,7 @@ def main():
         # load up the seqfile and figure out the outgroups and schedule
         config_node = ET.parse(options.configFile).getroot()
         config_wrapper = ConfigWrapper(config_node)
-        config_wrapper.substituteAllPredefinedConstantsWithLiterals()
+        config_wrapper.substituteAllPredefinedConstantsWithLiterals(options)
         mc_tree, input_seq_map, og_candidates = parse_seqfile(options.seqFile, config_wrapper)
         og_map = compute_outgroups(mc_tree, config_wrapper, set(og_candidates))
         event_set = get_event_set(mc_tree, config_wrapper, og_map, mc_tree.getRootName())

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -248,7 +248,7 @@ def make_align_job(options, toil, config_wrapper=None, chrom_name=None):
     else:
         config_node = ET.parse(options.configFile).getroot()
         config_wrapper = ConfigWrapper(config_node)
-        config_wrapper.substituteAllPredefinedConstantsWithLiterals()
+        config_wrapper.substituteAllPredefinedConstantsWithLiterals(options)
         config_wrapper.initGPU(options)
     config_wrapper.setSystemMemory(options)
     

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -40,7 +40,7 @@ from toil.lib.bioio import getLogLevelString
 from toil.common import Toil
 from toil.job import Job
 from toil.realtimeLogger import RealtimeLogger
-from toil.lib.humanize import bytes2human
+from toil.lib.humanize import bytes2human, human2bytes
 from toil.lib.threading import cpu_count
 from sonLib.bioio import popenCatch
 from sonLib.bioio import getTempDirectory
@@ -83,7 +83,10 @@ def cactus_override_toil_options(options):
         # slurm when using non-local binaries. to date, the solution has been
         # to boost memory. this override is to help apply this globally to all
         # the little jobs
-        options.defaultMemory = int(max(options.defaultMemory if options.defaultMemory else 0, 2**32))
+        opt_default_mem = options.defaultMemory if options.defaultMemory else 0
+        if isinstance(opt_default_mem, str):
+            opt_default_mem = human2bytes(opt_default_mem)
+        options.defaultMemory = int(max(opt_default_mem, 2**32))
     
     if not options.realTimeLogging:
         # Too much valuable debugging information to pass up

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -77,6 +77,13 @@ def cactus_override_toil_options(options):
         # lead to weird toil errors?
         # https://github.com/DataBiosphere/toil/issues/4218
         options.disableCaching = True
+
+    if options.binariesMode in ['docker', 'singularity']:
+        # jobs, even when seemingly not using docker, sometimes disappear on
+        # slurm when using non-local binaries. to date, the solution has been
+        # to boost memory. this override is to help apply this globally to all
+        # the little jobs
+        options.defaultMemory = int(max(options.defaultMemory if options.defaultMemory else 0, 2**32))
     
     if not options.realTimeLogging:
         # Too much valuable debugging information to pass up

--- a/src/cactus/shared/configWrapper.py
+++ b/src/cactus/shared/configWrapper.py
@@ -150,9 +150,19 @@ class ConfigWrapper:
         constantsElem = self.xmlRoot.find("constants")
         return int(constantsElem.attrib["defaultMemory"])
 
-    def substituteAllPredefinedConstantsWithLiterals(self):
+    def substituteAllPredefinedConstantsWithLiterals(self, options):
         constants = findRequiredNode(self.xmlRoot, "constants")
         defines = constants.find("defines")
+        if options.binariesMode in ['docker', 'singularity']:
+            # hack to boost default memory to 4 Gigs when using docker            
+            for attrib in defines.attrib:
+                if attrib.endswith('Memory'):
+                    try:
+                        mem_val = int(defines[attrib])
+                        mem_val = max(mem_val, options.defaultMemory if options.defaultMemory else 2**32)
+                        defines[attrib] = str(mem_val)
+                    except:
+                        pass
         def replaceAllConstants(node, defines):
             for attrib in node.attrib:
                 if node.attrib[attrib] in defines.attrib:


### PR DESCRIPTION
This PR fixes a bug where `run_segalign_repeatmasker` was only getting 4G, which is a show stopper on slurm for anything but tiny genomes.

It also adds a hack so that `--defaultMemory` gets boosted to `4Gi` by default if docker/singularity binaries are specified.  Likewise, the `littleMemory`, `mediumMemory` etc values in the config.xml get increased to `4Gi` for docker/singularity.  This will hopefully address issues where tiny jobs just quietly disappear at random without anything helpful in the log (because, in part, I think, they don't trip a cactus_call exception)

What this PR **Does Not Do** (at least as I write this) is boost the memory of jobs that request their own memory on the input data sizes.  That means that running evolverMammals on the cluster will still work badly, because many jobs will request a few hundred Mi and fail totally.  Fixing this is really tedious but probably necessary at some point: each memory request should be clamped to a minimum value (or just None to let the Toil default take over) if it's too small.  Ideally this clamping only comes into play with Docker binaries.  
 