### PR TITLE
default to latest release in --binariesMode docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ python3 -m pip install -U -r ./toil-requirement.txt
 
 If you have Docker installed, you can now run Cactus.  All binaries, such as `lastz` and `cactus-consolidated` will be run via Docker.  Singularity binaries can be used in place of docker binaries with the `--binariesMode singularity` flag.  Note, you must use Singularity 2.3 - 2.6 or Singularity 3.1.0+. Singularity 3 versions below 3.1.0 are incompatible with cactus (see [issue #55](https://github.com/ComparativeGenomicsToolkit/cactus/issues/55) and [issue #60](https://github.com/ComparativeGenomicsToolkit/cactus/issues/60)).
 
-By default, cactus will use the image, `quay.io/comparative-genomics-toolkit/cactus:<CACTUS_COMMIT>` when running binaries. This is usually okay, but can be overridden with the `CACTUS_DOCKER_ORG` and `CACTUS_DOCKER_TAG` environment variables.  For example, to use GPU release 2.4.4, run `export CACTUS_DOCKER_TAG=v2.4.4-gpu` before running cactus.
+By default, cactus will use the image corresponding to the latest release when running docker binaries. This is usually okay, but can be overridden with the `CACTUS_DOCKER_ORG` and `CACTUS_DOCKER_TAG` environment variables.  For example, to use GPU release 2.4.4, run `export CACTUS_DOCKER_TAG=v2.4.4-gpu` before running cactus.
 
 ### Compiling Binaries Locally
 In order to compile the binaries locally and not use a Docker image, you need some dependencies installed.  On Ubuntu (we've tested on 20.04 and 22.04), you can look at the [Cactus Dockerfile](./Dockerfile) for guidance. To obtain the `apt-get` command:

--- a/build-tools/makeCpuDockerRelease
+++ b/build-tools/makeCpuDockerRelease
@@ -24,6 +24,7 @@ git checkout "${REL_TAG}"
 git submodule update --init --recursive
 
 docker build . -f Dockerfile -t ${dockname}:${REL_TAG}
+docker tag ${dockname}:${REL_TAG} ${dockname}:latest
 
 read -p "Are you sure you want to push ${dockname}:${REL_TAG} to quay?" yn
 case $yn in

--- a/doc/progressive.md
+++ b/doc/progressive.md
@@ -342,7 +342,9 @@ Please [cite SegAlign](https://doi.ieeecomputersociety.org/10.1109/SC41405.2020.
 
 ### Using GPU Acceleration on a Cluster
 
-Since `SegAlign` is only released in the GPU-enabled docker image, that's the easiest way to run it. When running on a cluster, this usually means the best way to use it is with `--binariesMode docker --gpu <N>`.  This way cactus is installed locally on your virtual environment and can run slurm commands like `sbatch` (that aren't available in the Cactus container), but SegAlign itself will be run from inside Docker. 
+Since `SegAlign` is only released in the GPU-enabled docker image, that's the easiest way to run it. When running on a cluster, this usually means the best way to use it is with `--binariesMode docker --gpu <N>`.  This way cactus is installed locally on your virtual environment and can run slurm commands like `sbatch` (that aren't available in the Cactus container), but SegAlign itself will be run from inside Docker.
+
+**Important**: Consider using `--lastzMemory` when using GPU acceleration on a cluster. Like `--consMemory`, it lets you override the amount of memory Toil requests which can help with errors if Cactus's automatic estimate is either too low (cluster evicts the job) or too high (cluster cannot schedule the job).  
 
 ## Pre-Alignment Checklist
 

--- a/doc/progressive.md
+++ b/doc/progressive.md
@@ -340,6 +340,9 @@ We've tested SegAlign on Nvidia V100 and A10G GPUs. See the Terra example above 
 
 Please [cite SegAlign](https://doi.ieeecomputersociety.org/10.1109/SC41405.2020.00043).
 
+### Using GPU Acceleration on a Cluster
+
+Since `SegAlign` is only released in the GPU-enabled docker image, that's the easiest way to run it. When running on a cluster, this usually means the best way to use it is with `--binariesMode docker --gpu <N>`.  This way cactus is installed locally on your virtual environment and can run slurm commands like `sbatch` (that aren't available in the Cactus container), but SegAlign itself will be run from inside Docker. 
 
 ## Pre-Alignment Checklist
 

--- a/src/cactus/progressive/cactus_prepare.py
+++ b/src/cactus/progressive/cactus_prepare.py
@@ -25,7 +25,7 @@ from cactus.progressive.multiCactusTree import MultiCactusTree
 from cactus.progressive.progressive_decomposition import compute_outgroups, get_subtree, check_branch_lengths
 from cactus.shared.common import cactusRootPath
 from cactus.shared.common import enableDumpStack, setupBinaries
-from cactus.shared.common import getDockerImage, getDockerRelease
+from cactus.shared.common import getDockerImage
 from cactus.shared.configWrapper import ConfigWrapper
 from cactus.shared.version import cactus_commit
 from cactus.shared.common import findRequiredNode
@@ -746,7 +746,7 @@ def wdl_task_preprocess(options):
         s += '        gpuCount: {}\n'.format(options.gpu)
         s += '        bootDiskSizeGb: 20\n'
         s += '        nvidiaDriverVersion: \"{}\"\n'.format(options.nvidiaDriver)
-        s += '        docker: \"{}\"\n'.format(getDockerRelease(gpu=True))
+        s += '        docker: \"{}\"\n'.format(getDockerImage(gpu=True))
         s += '        zones: \"{}\"\n'.format(options.gpuZone)
     else:
         s += '        docker: \"{}\"\n'.format(options.dockerImage)
@@ -828,7 +828,7 @@ def wdl_task_blast(options):
         s += '        gpuCount: {}\n'.format(options.gpu)
         s += '        bootDiskSizeGb: 20\n'
         s += '        nvidiaDriverVersion: \"{}\"\n'.format(options.nvidiaDriver)
-        s += '        docker: \"{}\"\n'.format(getDockerRelease(gpu=True))
+        s += '        docker: \"{}\"\n'.format(getDockerImage(gpu=True))
         s += '        zones: \"{}\"\n'.format(options.gpuZone)
     else:
         s += '        docker: \"{}\"\n'.format(options.dockerImage)

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -278,20 +278,6 @@ def runGetChunks(sequenceFiles, chunksDir, chunkSize, overlapSize, work_dir=None
                                      "--dir", chunksDir] + sequenceFiles)
     return [chunk for chunk in chunks.split("\n") if chunk != ""]
 
-def pullCactusImage():
-    """Ensure that the cactus Docker image is pulled."""
-    if os.environ.get('CACTUS_DOCKER_MODE') == "0":
-        return
-    if os.environ.get('CACTUS_USE_LOCAL_IMAGE', 0) == "1":
-        return
-    image = getDockerImage()
-    call = ["docker", "pull", image]
-    process = subprocess.Popen(call, stdout=subprocess.PIPE,
-                                 stderr=sys.stderr, bufsize=-1)
-    output, _ = process.communicate()
-    if process.returncode != 0:
-        raise RuntimeError("Command %s failed with output: %s" % (call, output))
-
 def getDockerOrg():
     """Get where we should find the cactus containers."""
     if "CACTUS_DOCKER_ORG" in os.environ:
@@ -299,26 +285,21 @@ def getDockerOrg():
     else:
         return "quay.io/comparative-genomics-toolkit"
 
-def getDockerTag():
+def getDockerTag(gpu=False):
     """Get what docker tag we should use for the cactus image
-    (either forced to be latest or the current cactus commit)."""
+    Default: latest release (which is all there is on quay these days)
+    otherwise, either forced to be latest or the current cactus commit."""
     if 'CACTUS_DOCKER_TAG' in os.environ:
         return os.environ['CACTUS_DOCKER_TAG']
     elif 'CACTUS_USE_LATEST' in os.environ:
         return "latest"    
     else:
-        return cactus_commit
+        # must be manually kept current with each release        
+        return 'v2.6.8' + ('-gpu' if gpu else '')
 
-def getDockerImage():
+def getDockerImage(gpu=False):
     """Get fully specified Docker image name."""
     return "%s/cactus:%s" % (getDockerOrg(), getDockerTag())
-
-def getDockerRelease(gpu=False):
-    """Get the most recent docker release."""
-    r = "quay.io/comparative-genomics-toolkit/cactus:v2.6.8"
-    if gpu:
-        r += "-gpu"
-    return r
 
 def maxMemUsageOfContainer(containerInfo):
     """Return the max RSS usage (in bytes) of a container, or None if something failed."""
@@ -445,13 +426,14 @@ def importSingularityImage(options):
             oldCWD = os.getcwd()
             os.chdir(os.path.dirname(imgPath))
             # --size is deprecated starting in 2.4, but is needed for 2.3 support. Keeping it in for now.
+            gpu = bool(options.gpu) if gpu in options else False
             try:
                 subprocess.check_call(["singularity", "pull", "--size", "2000", "--name", os.path.basename(imgPath),
-                                       "docker://" + getDockerImage()], stderr=subprocess.PIPE)
+                                       "docker://" + getDockerImage(gpu=gpu)], stderr=subprocess.PIPE)
             except subprocess.CalledProcessError:
                 # Call failed, try without --size, required for singularity 3+
                 subprocess.check_call(["singularity", "pull", "--name", os.path.basename(imgPath),
-                                       "docker://" + getDockerImage()])
+                                       "docker://" + getDockerImage(gpu=gpu)])
             os.chdir(oldCWD)
         else:
             logger.info("Using pre-built singularity image: '{}'".format(imgPath))
@@ -508,7 +490,7 @@ def singularityCommand(tool=None,
 
         # hack to transform back to docker image
         if tool == 'cactus':
-            tool = getDockerImage()
+            tool = getDockerImage(gpu = bool(gpus))
         # not a url or local file? try it as a Docker specifier
         if not tool.startswith('/') and '://' not in tool:
             tool = 'docker://' + tool
@@ -610,7 +592,7 @@ def dockerCommand(tool=None,
     if rm:
         base_docker_call.append('--rm')
 
-    docker_tag = getDockerTag()
+    docker_tag = getDockerTag(gpu=bool(gpus))
     tool = "%s/%s:%s" % (dockstore, tool, docker_tag)
     call = base_docker_call + [tool] + parameters
     return call, containerInfo

--- a/src/cactus/shared/configWrapper.py
+++ b/src/cactus/shared/configWrapper.py
@@ -242,7 +242,9 @@ class ConfigWrapper:
             findRequiredNode(self.xmlRoot, "blast").attrib["gpu"] = str(options.gpu)
             for node in self.xmlRoot.findall("preprocessor"):
                 if getOptionalAttrib(node, "preprocessJob") == "lastzRepeatMask":
-                    node.attrib["gpu"] = str(options.gpu)        
+                    node.attrib["gpu"] = str(options.gpu)
+            if 'latest' in options and options.latest:
+                raise RuntimeError('--latest cannot be used with --gpu')
             
         # we need to make sure that gpu is set to an integer (replacing 'all' with a count)
         def get_gpu_count():


### PR DESCRIPTION
When switching CI recently, I stopped it from spamming quay.io with a Cactus image for every single commit.   This means that `--binariesMode docker` will no longer work by default, since it will look for a commit-tagged image that isn't there.  

This PR switches `--binariesMode` to default to the current release (which has been manually tracked in `common.py` for some time).  This is how prepare has worked on Terra.  

It also fixes `--binariesMode` to automatically switch to the GPU release as needed. 

The usual environment variables, `CACTUS_DOCKER_ORG`, `CACTUS_DOCKER_TAG`, can still be used to override the image.  The `--latest` option will still work, only it will point to the latest release rather than the latest commit.  

If someone really wants to test a non-released commit with docker binaries, they will need to tag it themselves and use the environment variables. 