### PR TITLE
Force single_machine inside cactus docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,6 +87,9 @@ RUN chmod 777 /opt/cactus/wrapper.sh
 # log the memory usage (with --realTimeLogging) for local commands
 ENV CACTUS_LOG_MEMORY 1
 
+# remember we're in a docker to help with error handling
+ENV CACTUS_INSIDE_CONTAINER 1
+
 # UCSC convention is to work in /data
 RUN mkdir -p /data
 WORKDIR /data

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -78,6 +78,13 @@ def cactus_override_toil_options(options):
         # https://github.com/DataBiosphere/toil/issues/4218
         options.disableCaching = True
 
+    # some people get confused when trying to use their cluster from inside the cactus
+    # docker. it doesn't work (without tons of hackery) since slurm isnt in the image
+    if options.batchSystem.lower() not in ['single_machine', 'singleMachine'] and \
+       'CACTUS_INSIDE_CONTAINER' in os.environ and str(os.environ['CACTUS_INSIDE_CONTAINER']) == '1':
+        e = RuntimeError('"--batchSystem {}" is not supported from inside the Cactus Docker container. In order to use this batch system, you must run directly from a Python virutalenv on your head node. You can use --binariesMode docker to execute the various binaries using docker, but the cactus command itself must be run directly on your system where it will have access to your cluster environment (ex: sbatch).'.format(options.batchSystem))
+        raise e
+
     if options.binariesMode in ['docker', 'singularity']:
         # jobs, even when seemingly not using docker, sometimes disappear on
         # slurm when using non-local binaries. to date, the solution has been


### PR DESCRIPTION
This will hopefully avoid confusion ([example](https://github.com/ComparativeGenomicsToolkit/cactus/issues/1198#issuecomment-1778962992)) where people try to use their cluster from inside a Container and get errors because the cluster environment is not accessible in the container. 

Now running anything but single-machine from inside the container will print out a (hopefully) very clear error message right away.  

The very tiny minority of users who are able to hack things so that they somehow can use their cluster from inside a container will have to just add an `CACTUS_INSIDE_DOCKER=0` to their command to override this behaviour.  

