### PR TITLE
run full hal tests in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,6 +29,7 @@ test-job:
     - export ASAN_OPTIONS="detect_leaks=0"
     - CGL_DEBUG=ultra make -j 8
     - CACTUS_BINARIES_MODE=local SON_TRACE_DATASETS=$(pwd)/cactusTestData CACTUS_TEST_CHOICE=normal make test
+    - pip install -U newick    
     - make -j 8 hal_test
     # rebuild without all the debug flags
     - make clean

--- a/Makefile
+++ b/Makefile
@@ -92,24 +92,6 @@ unitTests = \
 
 #paffyTests \ # This is removed for now
 
-# these are slow, but added to CI here since hal no longer has its own
-halTests = \
-	hal4dExtractTest \
-	halAlignmentTreesTest \
-	halBottomSegmentTest \
-	halColumnIteratorTest \
-	halGappedSegmentIteratorTest \
-	halGenomeTest \
-	halHdf5Tests \
-	halLiftoverTests \
-	halMafTests \
-	halMappedSegmentTest \
-	halMetaDataTest \
-	halRearrangementTest \
-	halSequenceTest \
-	halTopSegmentTest \
-	halValidateTest
-
 # if running travis or gitlab, we want output to go to stdout/stderr so it can
 # be seen in the log file, as opposed to individual files, which are much
 # easier to read when running tests in parallel.
@@ -133,7 +115,8 @@ testLogDir = ${testOutDir}/logs
 test: ${testModules:%=%_runtest} ${unitTests:%=%_run_unit_test}
 test_blast: ${testModules:%=%_runtest_blast}
 test_nonblast: ${testModules:%=%_runtest_nonblast}
-hal_test: ${halTests:%=%_run_unit_test}
+hal_test:
+	cd ${CWD}/submodules/hal && make test
 
 # run one test and save output
 %_runtest: ${versionPy}


### PR DESCRIPTION
https://github.com/ComparativeGenomicsToolkit/hal/issues/286 points out that the HAL tests are broken.  If fixed them in https://github.com/ComparativeGenomicsToolkit/hal/issues/287 but the root issue seems to be that they don't all get run in Cactu's CI (where HAL's automated testing as moved).  I imagine the fact that Cactus was only running a subset probably traces back to Travis time limitations back in the day.  

Anyway, this PR changes `make hal_test` in Cactus to just run `make test` in HAL, rather than picking and choosing a subset. It also updates HAL to a version that passes all tests. 