### PR TITLE
keep sample haps together in event of mash ties

### DIFF
--- a/src/cactus/refmap/cactus_minigraph.py
+++ b/src/cactus/refmap/cactus_minigraph.py
@@ -241,6 +241,9 @@ def mash_dist(job, query_seqs, ref_seq, seq_id_map, ref_sketch_id):
         catFiles(query_paths, cat_path)
         cat_mash_output = cactus_call(parameters=['mash', 'dist', cat_path, ref_sketch_path], check_output=True)
         cat_mash_dist = parse_mash_output(cat_mash_output)
+        # we want samples to stay together in the event of ties (which happen).  So add a a little bit to make unique
+        cat_mash_dist += float(sorted(seq_id_map.keys()).index(query_seqs[0])) * sys.float_info.epsilon
+        assert False
 
     # make the individual distance
     for query_seq, query_path in zip(query_seqs, query_paths):


### PR DESCRIPTION
samples are sent into minigraph in mash distance to reference order by default.  There's logic in there to keep different haplotypes of the same sample together.  But this logic breaks down in the event that the mash distance of two different samples is the same.  Even though it's 9 decimal places, this happens
```
HG00673.2 (size = 3053585067) to reference GRCh38 = 0.00075568 sample distance = 0.000805673
HG00733.2 (size = 3026533161) to reference GRCh38 = 0.00075568 sample distance = 0.000805673
```
which leads to `HG00673.2.fa HG00733.2.fa HG00733.1.fa HG00673.1.fa` which is what it's supposed to avoid. 
This PR will fall back to lexicographical order in case of sample distance tie. 