### PR TITLE
rescue tiny reference contigs from paf filter

### DIFF
--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -156,7 +156,7 @@ fi
 cd ${pangenomeBuildDir}
 git clone https://github.com/ComparativeGenomicsToolkit/cactus-gfa-tools.git
 cd cactus-gfa-tools
-git checkout 9b26caa961d6e72ad3747e5c2ce81cdf1e9b63c3
+git checkout 0c17bc4ae9a7cf174fa40805cde7f8f1f6de8225
 make -j ${numcpu}
 if [[ $STATIC_CHECK -ne 1 || $(ldd paf2lastz | grep so | wc -l) -eq 0 ]]
 then

--- a/src/cactus/refmap/cactus_graphmap.py
+++ b/src/cactus/refmap/cactus_graphmap.py
@@ -429,7 +429,7 @@ def extract_paf_from_gfa(job, gfa_id, gfa_path, ref_event, graph_event, ignore_p
     cactus_call(parameters=cmd, outfile=paf_path)
     return job.fileStore.writeGlobalFile(paf_path)
 
-def filter_paf(job, paf_id, config):
+def filter_paf(job, paf_id, config, reference=None):
     """ run basic paf-filtering.  these are quick filters that are best to do on-the-fly when reading the paf and 
         as such, they are called by cactus-graphmap-split and cactus-align, not here """
     work_dir = job.fileStore.getLocalTempDir()
@@ -444,6 +444,7 @@ def filter_paf(job, paf_id, config):
     with open(paf_path, 'r') as paf_file, open(filter_paf_path, 'w') as filter_paf_file:
         for line in paf_file:
             toks = line.split('\t')
+            is_ref = reference and toks[0].startswith('id={}|'.format(reference))
             mapq = int(toks[11])
             query_len = int(toks[1])
             ident = float(toks[9]) / (float(toks[10]) + 0.00000001)
@@ -456,7 +457,7 @@ def filter_paf(job, paf_id, config):
                 # we can also get the identity of the parent gaf block 
                 if tok.startswith('gi:i:'):
                     ident = min(ident, float(toks[5:]))
-            if mapq >= min_mapq and (bl is None or query_len <= min_block or bl >= min_block) and ident >= min_ident:
+            if is_ref or (mapq >= min_mapq and (bl is None or query_len <= min_block or bl >= min_block) and ident >= min_ident):
                 filter_paf_file.write(line)
 
     overlap_ratio = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap"), "PAFOverlapFilterRatio", typeFn=float, default=0)

--- a/src/cactus/refmap/cactus_graphmap_split.py
+++ b/src/cactus/refmap/cactus_graphmap_split.py
@@ -225,7 +225,8 @@ def graphmap_split_workflow(job, options, config, seq_id_map, seq_name_map, gfa_
 
     # do some basic paf filtering
     paf_filter_mem = max(paf_id.size * 10, 2**32)
-    paf_filter_job = root_job.addFollowOnJobFn(filter_paf, paf_id, config, disk = paf_id.size * 10, memory=paf_filter_mem)
+    paf_filter_job = root_job.addFollowOnJobFn(filter_paf, paf_id, config, reference=options.reference,
+                                               disk = paf_id.size * 10, memory=paf_filter_mem)
     paf_id = paf_filter_job.rv()
     root_job = paf_filter_job
 


### PR DESCRIPTION
Just noticed a regression as of a result of a refactor a few versions back. 

The issue is that some tiny reference contigs (such as found in the unplaced / random GRCh38 stuff) do not map back to the graph in the minigraph mapping stage.  For contigs that don't map at all, `cactus-graphmap` is able to detect then fill them in. 

But for contigs that map poorly enough to get filtered out by, say the MAPQ filter, those are now left in after `cactus-graphmap` (the refactor pushed the filter downstream to make playing with it easier with respect to not having to rerun the mapping).  The problem is that if a downstream filter removes all their mappings, they can end up excluded from the graph.  

This PR changes `cactus-graphmap-split` to make sure that reference contigs always get put into their own reference chromosome, no matter how poor their mappings are.

As an aside: I suspect the unplaced GRCh38 contigs are **not** in any way helpful to the graph and should probably excluded altogether -- but need to run some tests to confirm before advertising that as best practices.   

