### PR TITLE
remove assert False

### DIFF
--- a/src/cactus/refmap/cactus_minigraph.py
+++ b/src/cactus/refmap/cactus_minigraph.py
@@ -243,7 +243,6 @@ def mash_dist(job, query_seqs, ref_seq, seq_id_map, ref_sketch_id):
         cat_mash_dist = parse_mash_output(cat_mash_output)
         # we want samples to stay together in the event of ties (which happen).  So add a a little bit to make unique
         cat_mash_dist += float(sorted(seq_id_map.keys()).index(query_seqs[0])) * sys.float_info.epsilon
-        assert False
 
     # make the individual distance
     for query_seq, query_path in zip(query_seqs, query_paths):


### PR DESCRIPTION
#1208 merged in a debug assertion that completely breaks support for diploid samples in pangenomes, and is a sign that we need a CI test for this.. 