### PR TITLE
fix hal/vg export --consMemory overrides

### DIFF
--- a/src/cactus/progressive/cactus_progressive.py
+++ b/src/cactus/progressive/cactus_progressive.py
@@ -206,7 +206,7 @@ def progressive_step_2(job, trimmed_outgroups_and_alignments, options, config_no
 
 def export_hal(job, mc_tree, config_node, seq_id_map, og_map, results, event=None, cacheBytes=None,
                cacheMDC=None, cacheRDC=None, cacheW0=None, chunk=None, deflate=None, inMemory=False,
-               checkpointInfo=None, acyclicEvent=None, has_resources=False):
+               checkpointInfo=None, acyclicEvent=None, has_resources=False, memory_override=None):
 
     # todo: going through list nonsense because (i think) it helps with promises, should at least clean up
     work_dir = job.fileStore.getLocalTempDir()
@@ -268,8 +268,8 @@ def export_hal(job, mc_tree, config_node, seq_id_map, og_map, results, event=Non
         disk = 3 * sum([file_id.size for file_id in fa_file_ids + c2h_file_ids])
         mem = 5 * (max([file_id.size for file_id in fa_file_ids]) + max([file_id.size for file_id in c2h_file_ids]))
         # allows pass-through of memory override from --consMemory
-        if job.memory:
-            mem = job.memory
+        if memory_override:
+            mem = memory_override
         return job.addChildJobFn(export_hal, mc_tree, config_node, seq_id_map, og_map, results, event=event,
                                  cacheBytes=cacheBytes, cacheMDC=cacheMDC, cacheRDC=cacheRDC, cacheW0=cacheW0,
                                  chunk=chunk, deflate=deflate, inMemory=inMemory, checkpointInfo=checkpointInfo,
@@ -310,7 +310,7 @@ def progressive_workflow(job, options, config_node, mc_tree, og_map, input_seq_i
 
     # then do the hal export
     hal_export_job = progressive_job.addFollowOnJobFn(export_hal, mc_tree, config_node, seq_id_map, og_map,
-                                                      progressive_job.rv(), event=root_event, memory=options.consMemory)
+                                                      progressive_job.rv(), event=root_event, memory_override=options.consMemory)
 
     return hal_export_job.rv()
 

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -387,12 +387,12 @@ def cactus_align(job, config_wrapper, mc_tree, input_seq_map, input_seq_id_map, 
     # run the hal export
     hal_job = cons_job.addFollowOnJobFn(export_hal, sub_tree, config_wrapper.xmlRoot, new_seq_id_map, og_map, results, event=root_name, inMemory=True,
                                         checkpointInfo=checkpointInfo, acyclicEvent=referenceEvents[0] if referenceEvents else None,
-                                        memory=cons_memory)
+                                        memory_override=cons_memory)
 
     # optionally create the VG
     if doVG or doGFA:
         vg_export_job = hal_job.addFollowOnJobFn(export_vg, hal_job.rv(), config_wrapper, doVG, doGFA, referenceEvents,
-                                                 checkpointInfo=checkpointInfo, memory=cons_memory)
+                                                 checkpointInfo=checkpointInfo, memory_override=cons_memory)
         vg_file_id, gfa_file_id = vg_export_job.rv(0), vg_export_job.rv(1)
     else:
         vg_file_id, gfa_file_id = None, None
@@ -400,7 +400,8 @@ def cactus_align(job, config_wrapper, mc_tree, input_seq_map, input_seq_id_map, 
     return hal_job.rv(), vg_file_id, gfa_file_id
 
 
-def export_vg(job, hal_id, config_wrapper, doVG, doGFA, referenceEvents, checkpointInfo=None, resource_spec = False):
+def export_vg(job, hal_id, config_wrapper, doVG, doGFA, referenceEvents, checkpointInfo=None, resource_spec = False,
+              memory_override=None):
     """ use hal2vg to convert the HAL to vg format """
 
     if not resource_spec:
@@ -410,7 +411,7 @@ def export_vg(job, hal_id, config_wrapper, doVG, doGFA, referenceEvents, checkpo
                                  resource_spec = True,
                                  disk=hal_id.size * 3,
                                  # allow override with cons_memory
-                                 memory=hal_id.size * 60 if not job.memory else job.memory).rv()
+                                 memory=hal_id.size * 60 if not memory_override else memory_override).rv()
         
     work_dir = job.fileStore.getLocalTempDir()
     hal_path = os.path.join(work_dir, "out.hal")


### PR DESCRIPTION
I recently changed `--consMemory` to override the memory specification for `hal2vg` as well as `halAppendCactusSubtree`, in addition to `cactus_consolidated`.  

But it seems that in doing so, I broke the automatic estimation when `--consMemory` isn't used.  The net effect is that these jobs would get the default-memory (`2G`) no matter what if nothing was specified with `--consMemory`.  

This PR should correct this by adding a separate memory override option to these functions.  The initial bug was because toil's `memory` option was being used before, but I was checking it *after* it was getting filled in with its default value.  