### PR TITLE
fix gfaffix dont_collapse regex

### DIFF
--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -552,7 +552,7 @@ def clip_vg(job, options, config, vg_path, vg_id, phase):
         cactus_call(parameters=['vg', 'convert', '-W', '-f', vg_path], outfile=gfa_in_path, job_memory=job.memory)
         fix_cmd = ['gfaffix', gfa_in_path, '--output_refined', gfa_out_path, '--check_transformation']
         if options.reference:
-            fix_cmd += ['--dont_collapse', options.reference[0] + '*']
+            fix_cmd += ['--dont_collapse', options.reference[0] + '#[.]*']
         cactus_call(parameters=fix_cmd, job_memory=job.memory)
         # GFAffix strips the header, until this is fixed we need to add it back (for the RS tag)
         gfa_header = cactus_call(parameters=['head', '-1', gfa_in_path], check_output=True).strip()


### PR DESCRIPTION
I have a bad habit of confusing `*`s like in bash with actual regexes.  This lead to a longstanding bug in the `gfaffix` invocation that would potentially select more than the reference paths for `--dont_collapse`.  Since it only ever checks that the reference path didn't get collapsed, this went unnoticed until I publicly humiliated [myself](https://github.com/marschall-lab/GFAffix/issues/14). 

I don't think this bug would have too detrimental of an effect on most graphs -- it would just prevent collapsing of a duplication that otherwise would be zipped in certain very specific circumstances where all characters in the reference sample appear in another path name. 