### PR TITLE
remove os.remove before deleteGlobalFile

### DIFF
--- a/src/cactus/paf/local_alignment.py
+++ b/src/cactus/paf/local_alignment.py
@@ -138,7 +138,6 @@ def merge_combined_chunks(job, combined_chunks):
             chunk_path = job.fileStore.readGlobalFile(chunk, mutable=True)
             with open(chunk_path, 'r') as chunk_file:
                 shutil.copyfileobj(chunk_file, output_file)
-            os.remove(chunk_path)
             job.fileStore.deleteGlobalFile(chunk)
     return job.fileStore.writeGlobalFile(output_path)
 


### PR DESCRIPTION
This will hopefully fix the double-delete error described in https://github.com/DataBiosphere/toil/issues/4671 (which, for whatever it's worth, I can't seem to reproduce on aws, slurm, or single machine)

