### PR TITLE
track upstream abpoa directly; update to latest release

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,7 +21,7 @@
 	url = https://github.com/ComparativeGenomicsToolkit/kyoto.git
 [submodule "submodules/abPOA"]
 	path = submodules/abPOA
-	url = https://github.com/ComparativeGenomicsToolkit/abPOA.git
+	url = https://github.com/yangao07/abPOA.git
 [submodule "submodules/lastz"]
 	path = submodules/lastz
 	url = https://github.com/ComparativeGenomicsToolkit/lastz.git


### PR DESCRIPTION
The comparativegenomicstoolkit fork hasn't had anything cactus-specific in it for a while.  So this PR moves the submodule to directly use the upstream abPOA in order to make it easier to keep up with new releases.  Also update to latest release (v.1.4.3)