### PR TITLE
Interface for making outgroup selection sex-chromosome aware

### DIFF
--- a/doc/progressive.md
+++ b/doc/progressive.md
@@ -96,6 +96,30 @@ Please ensure your genomes are *soft*-masked, ideally with RepeatMasker. We do s
 
 An example seqfile can be found [here](../examples/evolverMammals.txt).
 
+### Sex Chromosomes and Diploid Assemblies
+
+The number of genome assemblies for any given species is increasing.  To align several genomes of the same species, you are probably best to use the [Pangenome pipeline](./pangenome.md), but there are cases such as for diploid assemblies where you may want to include multiple genomes from one species in a progressive alignment. An example of such a dataset is the [T2T Primates](https://www.ncbi.nlm.nih.gov/datasets/genome/?taxon=9443&assembly_level=2:3&release_year=2024:2024) from NHGRI. These assemblies are all diploid, in that for each species, two haploid genomes are provided. For species (bonobo and gorilla) for which parental sequencing data was available, the haplotypes could be labeled as maternal or paternal, while for the other species the assignment into haplotypes is based on assembly quality.  The nomenclature for this data is as follows
+
+* primary assembly: most complete version of each autosome plus chrX and chrY
+* alternate assembly: other version of each autosome (no sex chromosomes)
+* maternal assembly: maternal autosomes (assigned with trio data) plus chrX
+* paternal assembly: paternal autosomes (assigned with trio data) plus chrY
+
+Note that all the samples were male. In other projects it's quite possible that the primary assembly does not include a chrY. Also, the same principle applies to other types of chromosomes, such as chrW and chrZ.
+
+In all cases, we want progressive cactus, where possible, to correctly reconstruct sex chromosomes in the ancestors. To do this, each of these chromosomes should be present in at least two genomes in each alignment. The `--chromInfo` option can be used to guide the outgroup selection process to ensure that this is the case. This option specifies a two-column text file mapping input genomes to lists of the sex chromosomes they contain. For example, it may contain something like
+
+```
+chimp_primary chrX,chrY
+hg38 chrX,chrY
+gorilla_maternal chrX
+gorilla_paternal chrY
+```
+
+Note that genomes with no chromosomes to specify (`chimp_alt` in this example) can be left out of the file (or included in a single column).
+
+Normally, cactus greedily chooses the N (default=2, override with `cactus --maxOutgroups` or in the configuration XML) nearest genomes to the ancestor in question to be outgroups.  When `--chromFile` is specified, it will choose (greedily, by distance) as many extra outgroups are needed to cover the set of specified chromosomes in the ingroups. 
+
 ## Using the HAL Output
 
 The `outputHal` file represents the multiple alignment, including all input and inferred ancestral sequences.  It is stored in HAL format, and can be accessed with [HAL tools](https://github.com/ComparativeGenomicsToolkit/Hal), which are all included in Cactus either as static binaries for the binary release, or within the Docker image for the Docker release.

--- a/src/cactus/blast/cactus_blast.py
+++ b/src/cactus/blast/cactus_blast.py
@@ -65,7 +65,11 @@ def main():
     parser.add_argument("--lastzMemory", type=human2bytesN,
                         help="Memory in bytes for each lastz/segalign job (defaults to an estimate based on the input data size). "
                         "Standard suffixes like K, Ki, M, Mi, G or Gi are supported (default=bytes))", default=None)
-        
+    parser.add_argument("--chromInfo",
+                        help="Two-column file mapping genome (col 1) to comma-separated list of sex chromosomes. This information "
+                        "will be used to guide outgroup selection so that, where possible, all chromosomes are present in"
+                        " at least one outgroup.")    
+    
     options = parser.parse_args()
 
     setupBinaries(options)
@@ -103,7 +107,7 @@ def runCactusBlastOnly(options):
             # apply gpu override
             config_wrapper.initGPU(options)
             mc_tree, input_seq_map, og_candidates = parse_seqfile(options.seqFile, config_wrapper)
-            og_map = compute_outgroups(mc_tree, config_wrapper, set(og_candidates))
+            og_map = compute_outgroups(mc_tree, config_wrapper, set(og_candidates), chrom_info_file = options.chromInfo))
             event_set = get_event_set(mc_tree, config_wrapper, og_map, options.root)
             if options.includeRoot:
                 event_set.add(options.root)

--- a/src/cactus/blast/cactus_blast.py
+++ b/src/cactus/blast/cactus_blast.py
@@ -107,7 +107,7 @@ def runCactusBlastOnly(options):
             # apply gpu override
             config_wrapper.initGPU(options)
             mc_tree, input_seq_map, og_candidates = parse_seqfile(options.seqFile, config_wrapper)
-            og_map = compute_outgroups(mc_tree, config_wrapper, set(og_candidates), chrom_info_file = options.chromInfo))
+            og_map = compute_outgroups(mc_tree, config_wrapper, set(og_candidates), chrom_info_file = options.chromInfo)
             event_set = get_event_set(mc_tree, config_wrapper, og_map, options.root)
             if options.includeRoot:
                 event_set.add(options.root)

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -412,12 +412,14 @@
 	        <!-- stategy: outgroup selection algorithm, can be one of greedy, greedyLeaves or greedyPreference -->
 		<!-- threshold: depth increases by at most k per outgroup -->
 		<!-- ancestor_quality_fraction: min fraction of children of ancestor in candidateSet in order for the ancestor to be an outgroup candidate -->
-		<!-- max_num_outgroups: maximum number of outgroups per alignment job-->	  
+		<!-- max_num_outgroups: maximum number of outgroups per alignment job-->
+		<!-- extra_chrom_outgroups: if max_num_outgroups is not sufficent to satisfy sex chromosome requirements of an ancestor while still using nearest species, allow up to this many extra (when -1 set to the number of unique sex chromosomes for the ancestor).  -->
 		<outgroup
 			strategy="greedyPreference"
 			threshold="0"
 			ancestor_quality_fraction="0.75"
 			max_num_outgroups="2"
+			extra_chrom_outgroups="-1"
 			/>
 
 		<!-- default_internal_node_prefix: internal nodes of the tree are labeled with this prefix then a BFS order number -->

--- a/src/cactus/progressive/outgroup.py
+++ b/src/cactus/progressive/outgroup.py
@@ -166,15 +166,15 @@ class GreedyOutgroup(object):
                 toks = line.rstrip().split()
                 if len(toks) <= 2:
                     genome_name = toks[0]
-                    if len(toks) > 1:
-                        chroms = toks[1]
-                    else:
-                        chroms = []
                     if genome_name in self.chrom_map:
                         RuntimeError('Duplicate genome, {}, found in chromInfo file {}'.format(genome, chrom_info_name))
                     if nodes_in_tree and genome_name not in nodes_in_tree:
                         RuntimeError('Genome name, {}, from chromInfo file {}, not found in tree'.format(genome, chrom_info_name))
-                    self.chrom_map[genome_name] = chroms.split(',')
+                    if len(toks) > 1:
+                        chroms = toks[1].split(',')
+                    else:
+                        chroms = []
+                    self.chrom_map[genome_name] = chroms
                 elif len(toks):
                     raise RuntimeError('Unable to parse line in {}, expecting 2 columns: {}'.format(chrom_info_name, line))
                     

--- a/src/cactus/progressive/outgroup.py
+++ b/src/cactus/progressive/outgroup.py
@@ -15,8 +15,10 @@ import math
 import copy
 import itertools
 import networkx as NX
+import xml.etree.ElementTree as ET
 from collections import defaultdict, namedtuple
 from optparse import OptionParser
+from sonLib.nxnewick import NXNewick
 from cactus.shared.common import cactusRootPath
 from cactus.shared.configWrapper import ConfigWrapper
 from cactus.progressive.multiCactusTree import MultiCactusTree
@@ -240,11 +242,12 @@ def main():
                       default = None, help="greedy threshold")
     parser.add_option("--numOutgroups", dest="maxNumOutgroups",
                       help="Maximum number of outgroups to provide", type=int)
-    parser.add_argument("--configFile", dest="configFile",
-                        help="Specify cactus configuration file",
-                        default=os.path.join(cactusRootPath(), "cactus_progressive_config.xml"))    
+    parser.add_option("--configFile", dest="configFile",
+                      help="Specify cactus configuration file",
+                      default=os.path.join(cactusRootPath(), "cactus_progressive_config.xml"))    
     options, args = parser.parse_args()
 
+    options.binariesMode = 'local'
     if len(args) != 2:
         parser.print_help()
         raise RuntimeError("Wrong number of arguments")
@@ -275,6 +278,7 @@ def main():
     except Exception as e:
         print(("NetworkX failed: %s" % str(e)))
         print("Writing ogMap in non-graphviz format")
+        print("Tree %s" % NXNewick().writeString(mc_tree))
         with open(args[1], "w") as f:
             for node, ogs in list(outgroup.ogMap.items()):
                 f.write("%s -> %s\n" % (node, str(ogs)))

--- a/src/cactus/progressive/outgroup.py
+++ b/src/cactus/progressive/outgroup.py
@@ -11,6 +11,7 @@ leaves as outgroups
 """
 
 import os
+import sys
 import math
 import copy
 import itertools
@@ -24,6 +25,7 @@ from cactus.shared.configWrapper import ConfigWrapper
 from cactus.progressive.multiCactusTree import MultiCactusTree
 from cactus.progressive.seqFile import SeqFile
 from cactus.shared.common import cactus_call
+from toil.statsAndLogging import logger
 
 class GreedyOutgroup(object):
     def __init__(self):
@@ -33,20 +35,30 @@ class GreedyOutgroup(object):
         self.root = None
         self.ogMap = None
         self.mcTree = None
+        self.chrom_map = None
 
     # add edges from sonlib tree to self.dag
     # compute self.dm: an undirected distance matrix
     def importTree(self, mcTree, rootId = None):
+        # input tree
         self.mcTree = mcTree
+        # initialize digraph with input tree
         self.dag = mcTree.nxDg.copy()
+        # root of input tree
         self.root = mcTree.rootId
+        # remove nodes that aren't events (probably unused in practice)
         self.stripNonEvents(self.root, mcTree.subtreeRoots)
+        # distance matrix of tree (directed)
         self.dmDirected = dict(NX.algorithms.shortest_paths.weighted.\
         all_pairs_dijkstra_path_length(self.dag))
+        # nodes that are outside scope and should just be ignored
         self.invalidSet = self.getInvalid(rootId)
+        # undirected graph
         graph = NX.Graph(self.dag)
+        # undirected distance matrix
         self.dm = dict(NX.algorithms.shortest_paths.weighted.\
         all_pairs_dijkstra_path_length(graph))
+        # the results: map tree events to otugroups
         self.ogMap = defaultdict(list)
 
     # return set of ancestral nodes that aren't below alignment root
@@ -108,7 +120,7 @@ class GreedyOutgroup(object):
                 htable[node] = max([htable[i] for i in children]) + 1
         rec(self.root)
         return htable
-
+    
     # check the candidate using the set and and fraction
     def inCandidateSet(self, node, candidateChildFrac):
         if self.candidateMap is None or len(self.candidateMap) == 0:
@@ -134,6 +146,103 @@ class GreedyOutgroup(object):
         self.candidateMap[self.mcTree.getName(node)] = False
         return False
 
+    def loadChromInfo(self, chrom_info_name):
+        """
+        load the chrom info.  it's like a seqfile, but maps genome names
+        to lists of chromosomes.  not all genomes need to be in it
+        """
+        self.chrom_map = {}
+        
+        if not os.path.isfile(chrom_info_name):
+            raise RuntimeError('Unable to open chromosome info file {}'.format(chrom_info_name))
+
+        with open(chrom_info_name, 'r') as chrom_info_file:
+            for line in chrom_info_file:
+                toks = line.rstrip().split()
+                if len(toks) == 2:
+                    genome_name = toks[0]
+                    chroms = toks[1]
+                    self.chrom_map[genome_name] = chroms.split(',')
+                elif len(toks):
+                    raise RuntimeError('Unable to parse line in {}, expecting 2 columns: {}'.format(chrom_info_name, line))
+                    
+    def check_chrom_satisfied(self, node_id, id_to_chroms):
+        """
+        see if the current outgroup selection for the given node has at least
+        one copy of every chromosome in/under that node.  this check is only
+        relevant if input chroms have been specified...
+
+        these chromosomes are strings like "X", "Y" etc.  that can
+        be used to denote the sex of certain leaf assemblies.  This
+        will then be used to guide outgroup selection, where outgroups
+        are chosen so that at least two copies of each chromosome
+        are present in the ingroup+outgroup set.  
+
+        """
+        node_chrom_set = id_to_chroms[node_id]
+        if not node_chrom_set:
+            return True
+        outgroup_names = self.ogMap[self.mcTree.getName(node_id)]
+        og_ids = [self.mcTree.getNodeId(og_name[0]) for og_name in outgroup_names]
+        og_chroms = set()
+        for og_id in og_ids:
+            for og_chrom in id_to_chroms[og_id]:
+                og_chroms.add(og_chrom)
+        return node_chrom_set.issubset(og_chroms)
+
+    def refine_og_chroms(self, node_chroms, max_outgroups):
+        """
+        go over the outgroup assignment and try to refine the selections to
+        best represent the chromosome specificaitons
+        """
+        for source_name, og_names_dists in self.ogMap.items():
+            source_id = self.mcTree.getNodeId(source_name)
+            source_chroms = node_chroms[source_id]            
+            # only need to do anything if we have chromosomes
+            if source_chroms:
+                chrom_set = set()
+                essential_ogs = []
+                for og_name, og_dist in og_names_dists:
+                    og_id = self.mcTree.getNodeId(og_name)
+                    og_chroms = node_chroms[og_id]
+                    is_essential = False
+                    for og_chrom in og_chroms:
+                        if og_chrom in source_chroms and og_chrom not in chrom_set:
+                            # this outgroup brings with it a needed chromosome we haven't seen yet,
+                            # so we mark it as "essential"
+                            is_essential = True
+                            chrom_set.add(og_chrom)
+                    if is_essential:
+                        essential_ogs.append((og_name, og_dist))
+
+                # todo: we can/should use some kind of threshold to make sure we
+                # don't take rediculously distance outgroups just because they
+                # have the right chromosomes
+                if len(essential_ogs) > max_outgroups:
+                    logger.warning("Warning: Limiting outgroups for {} to {}, which means leaving out {}".format(
+                        source_name, max_outgroups, ",".join([dog[0] for dog in essential_ogs[max_outgroups:]])))
+                    # todo: rank by how many chromosomes they have!
+                    essential_ogs = essential_ogs[:max_outgroups]
+                
+                if len(chrom_set) < len(source_chroms):
+                    logger.warning("Warning: Unable to fulfull chromosome requirements when selecting outgroups for {}".format(source_name) +
+                                   ". In particular, these chromosomes could not be found: {}".format(",".join(source_chroms - chrom_set)))
+                # if we have room for outgroups that aren't listed "essential" for their chromosome content,
+                # then pad by distance
+                if len(essential_ogs) < max_outgroups:
+                    padded_ogs = []
+                    padding = max_outgroups - len(essential_ogs)
+                    for og_name, og_dist in og_names_dists:
+                        is_essential = (og_name, og_dist) in essential_ogs
+                        if is_essential or padding > 0:
+                            padded_ogs.append((og_name, og_dist))
+                            if not is_essential:
+                                padding -= 1
+                    essential_ogs = padded_ogs
+
+                # update the outgroupss
+                self.ogMap[source_name] = essential_ogs                    
+
     # greedily assign closest possible valid outgroups
     # If some outgroups are already assigned, keep the existing
     # assignments but attempt to add more, if possible.
@@ -150,8 +259,13 @@ class GreedyOutgroup(object):
     # if > 1, then only members of the candidate set and none of their
     # ancestors are chosen
     # maxNumOutgroups : max number of outgroups to put in each entry of self.ogMap
+    # maxNumChromOutgroups : max number of outgroups when trying to make chromosome assignment
+    # should be bigger than maxNumOutgroups so that the genomes with rare chromosomes can
+    # get the extra help they need.
     def greedy(self, threshold = None, candidateSet = None,
-               candidateChildFrac = 2., maxNumOutgroups = 1):
+               candidateChildFrac = 2., maxNumOutgroups = 1,
+               maxNumChromOutgroups = 1):
+        # sort the (undirected) distance map
         orderedPairs = []
         for source, sinks in list(self.dm.items()):
             for sink, dist in list(sinks.items()):
@@ -167,62 +281,104 @@ class GreedyOutgroup(object):
 
         htable = self.heightTable()
 
+        # convert the input (leaf) chroms to id-space
+        node_chroms = defaultdict(set)
+        if self.chrom_map:
+            for node_name, chr_list in self.chrom_map.items():
+                node_chroms[self.mcTree.getNodeId(node_name)] = set(chr_list)
+                
+        # fill in the chromosomes of the ancestors, where they are (maybe naively)
+        # just the union of all chroms below
+        # these are the chroms that outgroups will need to have if possible.
+        for node, chr_list in list(node_chroms.items()):
+            parent = node
+            while (self.mcTree.hasParent(parent)):
+                parent = self.mcTree.getParent(parent)
+                prev_len = len(node_chroms[parent])
+                node_chroms[parent] = node_chroms[parent].union(chr_list)
+                if len(node_chroms[parent]) == prev_len:
+                    # no sense continuing traveral upwards if we're not adding anything
+                    break
+
+        # fast check to see if chromosomes of a given source are satisfied
+        source_satisfied = {}
+        for node in self.mcTree.postOrderTraversal():
+            if node in node_chroms and len(node_chroms[node]) > 0 and not self.mcTree.isLeaf(node):
+                # ancestral nodes with descendant chromosome specificaitons need to be satisfied
+                source_satisfied[node] = False
+            else:
+                source_satisfied[node] = True
+
+        # sort the orderedPairs by source
+        ordered_pairs_by_source = defaultdict(list)
         for candidate in orderedPairs:
+            # source is the ancestor we're trying to find outgroups for
             source = candidate[1][0]
-            sink = candidate[1][1]
-            sourceName = self.mcTree.getName(source)
-            sinkName = self.mcTree.getName(sink)
-            dist = candidate[0]
+            ordered_pairs_by_source[source].append(candidate)
 
-            # skip leaves (as sources)
-            if len(self.dag.out_edges(source)) == 0:
-                finished.add(source)
+        # visit the tree bottom up
+        for node in self.mcTree.postOrderTraversal():
+            # visit the candidates in order of increasing distance
+            orderedPairs = ordered_pairs_by_source[node]
+            for candidate in orderedPairs:
+                # source is the ancestor we're trying to find outgroups for
+                source = candidate[1][0]
+                # sink it the candidate outgroup
+                sink = candidate[1][1]
+                sourceName = self.mcTree.getName(source)
+                sinkName = self.mcTree.getName(sink)
+                dist = candidate[0]
 
-            # skip nodes that were already finished in a previous run
-            if sourceName in self.ogMap and len(self.ogMap[sourceName]) >= maxNumOutgroups:
-                finished.add(source)
+                # skip leaves (as sources)
+                if len(self.dag.out_edges(source)) == 0:
+                    finished.add(source)
 
-            # skip invalid outgroups
-            if sink in self.invalidSet:
-                continue
+                # skip nodes that were already finished in a previous run
+                if sourceName in self.ogMap and source_satisfied[source] and len(self.ogMap[sourceName]) >= maxNumOutgroups:
+                    finished.add(source)
 
-            # skip nodes that aren't in the candidate set (if specified)
-            # or don't have enough candidate children
-            if not self.inCandidateSet(sink, candidateChildFrac):
-                continue
+                # skip invalid outgroups
+                if sink in self.invalidSet:
+                    continue
 
-            # candidate (ancestral) sink is too high up the tree compared to the source, so we skip
-            if (threshold is not None and
-                not self.mcTree.isLeaf(sink) and
-                # "+ 1" because we want a threshold of 0 to indicate we
-                # probably won't have to wait for the outgroup (it will
-                # already have been finished, assuming all subproblems
-                # proceed at the same rate)
-                htable[sink] - htable[source] + 1 > threshold):
-                continue
+                # skip nodes that aren't in the candidate set (if specified)
+                # or don't have enough candidate children
+                if not self.inCandidateSet(sink, candidateChildFrac):
+                    continue
 
-            # Don't use any outgroups that are a child of another node
-            # already in the outgroup set
-            if any([self.onSamePath(x, sink) for x in self.dag.successors(source)]):
-                continue
+                # candidate (ancestral) sink is too high up the tree compared to the source, so we skip
+                if (threshold is not None and
+                    not self.mcTree.isLeaf(sink) and
+                    # "+ 1" because we want a threshold of 0 to indicate we
+                    # probably won't have to wait for the outgroup (it will
+                    # already have been finished, assuming all subproblems
+                    # proceed at the same rate)
+                    htable[sink] - htable[source] + 1 > threshold):
+                    continue
 
-            if source not in finished and \
-            not self.onSamePath(source, sink):
-                self.dag.add_edge(source, sink, weight=dist, info='outgroup')
-                if NX.is_directed_acyclic_graph(self.dag):
-                    htable[source] = max(htable[source], htable[sink] + 1)
-                    existingOutgroups = [i[0] for i in self.ogMap[sourceName]]
-                    if sinkName in existingOutgroups:
-                        # This outgroup was already assigned to this source in a previous run
-                        # Sanity check that the distance is equal
-                        existingOutgroupDist = dict(self.ogMap[sourceName])
-                        assert existingOutgroupDist[sinkName] == dist
-                        continue
-                    self.ogMap[sourceName].append((sinkName, dist))
-                    if len(self.ogMap[sourceName]) >= maxNumOutgroups:
-                        finished.add(source)
-                else:
-                    self.dag.remove_edge(source, sink)
+                # Don't use any outgroups that are a child of another node
+                # already in the outgroup set
+                if any([self.onSamePath(x, sink) for x in self.dag.successors(source)]):
+                    continue
+
+                if source not in finished and \
+                not self.onSamePath(source, sink):
+                    self.dag.add_edge(source, sink, weight=dist, info='outgroup')
+                    if NX.is_directed_acyclic_graph(self.dag):
+                        htable[source] = max(htable[source], htable[sink] + 1)
+                        existingOutgroups = [i[0] for i in self.ogMap[sourceName]]
+                        if sinkName in existingOutgroups:
+                            # This outgroup was already assigned to this source in a previous run
+                            # Sanity check that the distance is equal
+                            existingOutgroupDist = dict(self.ogMap[sourceName])
+                            assert existingOutgroupDist[sinkName] == dist
+                            continue
+                        self.ogMap[sourceName].append((sinkName, dist))
+                        source_satisfied[source] = self.check_chrom_satisfied(source, node_chroms)
+                        if len(self.ogMap[sourceName]) >= maxNumOutgroups and source_satisfied[source]:
+                            finished.add(source)
+                    else:
+                        self.dag.remove_edge(source, sink)
 
         # Since we could be adding to the ogMap instead of creating
         # it, sort the outgroups by distance again. Sorting the
@@ -230,6 +386,11 @@ class GreedyOutgroup(object):
         # work well.
         for node, outgroups in list(self.ogMap.items()):
             self.ogMap[node] = sorted(outgroups, key=lambda x: x[1])
+
+        # the chromosome specification logic trumps the maximum number of outgroups
+        # so we do a second pass to reconcile them (greedily) as best as possible
+        if node_chroms:
+            self.refine_og_chroms(node_chroms, max(maxNumOutgroups, maxNumChromOutgroups))
 
 
 def main():
@@ -242,6 +403,8 @@ def main():
                       default = None, help="greedy threshold")
     parser.add_option("--numOutgroups", dest="maxNumOutgroups",
                       help="Maximum number of outgroups to provide", type=int)
+    parser.add_option("--chromInfo", dest="chromInfo",
+                      help="File mapping genomes to sex chromosome lists")
     parser.add_option("--configFile", dest="configFile",
                       help="Specify cactus configuration file",
                       default=os.path.join(cactusRootPath(), "cactus_progressive_config.xml"))    
@@ -264,6 +427,8 @@ def main():
 
     outgroup = GreedyOutgroup()
     outgroup.importTree(mc_tree)
+    if options.chromInfo:
+        outgroup.loadChromInfo(options.chromInfo)
     if options.justLeaves:
         candidates = set([mc_tree.getName(x)
                         for x in mc_tree.getLeaves()])

--- a/src/cactus/progressive/outgroupTest.py
+++ b/src/cactus/progressive/outgroupTest.py
@@ -330,7 +330,7 @@ class TestCase(unittest.TestCase):
         og = GreedyOutgroup()
         og.importTree(tree)
         og.loadChromInfo(self.dipApesChromInfo)
-        og.greedy(maxNumOutgroups=1)
+        og.greedy(maxNumOutgroups=1, extraChromOutgroups=0)
         chrom_map = {}
         for source_name, ogs_dists in og.ogMap.items():
             chrom_map[source_name] = [o[0] for o in ogs_dists]
@@ -353,6 +353,35 @@ class TestCase(unittest.TestCase):
                 self.assertEqual([og[0].replace('.2', '.1')], chrom_map[source])
             else:
                 self.assertEqual(og, chrom_map[source])
+
+        # give an extra outgroup if needed to satisfy chromosomes (default behaviour now)
+        og = GreedyOutgroup()
+        og.importTree(tree)
+        og.loadChromInfo(self.dipApesChromInfo)
+        og.greedy(maxNumOutgroups=1)
+        chrom_map_extra = {}
+        for source_name, ogs_dists in og.ogMap.items():
+            chrom_map_extra[source_name] = [o[0] for o in ogs_dists]
+
+        self.assertEqual(len(chrom_map_extra), len(default_map))
+        self.assertEqual(sorted(chrom_map_extra.keys()), sorted(default_map.keys()))
+        for source, og in default_map.items():
+            assert source in chrom_map_extra
+            # there are three cases where either an extra outgroup is needed to satisfy both x,y
+            # or the closest outgroup can be added on becaue it wasn't in the solution that satisfied x,y
+            self.assertEqual(len(og), 1)
+            if og[0].startswith('chimp') or og[0].startswith('ponabe') or og[0].startswith('gor'):
+                self.assertEqual(len(chrom_map_extra[source]), 2)
+                self.assertTrue(chrom_map_extra[source][0] != chrom_map_extra[source][1])
+                self.assertEqual(chrom_map_extra[source][0].replace('.1', '').replace('.2', ''),
+                                 chrom_map_extra[source][1].replace('.1', '').replace('.2', ''))
+            else:
+                self.assertEqual(og, chrom_map_extra[source])
+        
+        
+
+        
+        
                             
 def main():
     unittest.main()

--- a/src/cactus/progressive/progressive_decomposition.py
+++ b/src/cactus/progressive/progressive_decomposition.py
@@ -50,7 +50,8 @@ def parse_seqfile(seqfile_path, config_wrapper, root_name = None, pangenome = Fa
 
     return (mc_tree, seq_file.pathMap, seq_file.outgroups)
 
-def compute_outgroups(mc_tree, config_wrapper, outgroup_candidates = set(), root_name = None, include_dists = False):
+def compute_outgroups(mc_tree, config_wrapper, outgroup_candidates = set(), root_name = None, include_dists = False,
+                      chrom_info_file = None):
     """
     computes the outgroups
     returns event->outgroups map
@@ -70,24 +71,28 @@ def compute_outgroups(mc_tree, config_wrapper, outgroup_candidates = set(), root
         outgroup.greedy(threshold=config_wrapper.getOutgroupThreshold(),
                         candidateSet=outgroup_candidates,
                         candidateChildFrac=config_wrapper.getOutgroupAncestorQualityFraction(),
-                        maxNumOutgroups=config_wrapper.getMaxNumOutgroups())
+                        maxNumOutgroups=config_wrapper.getMaxNumOutgroups(),
+                        extraChromOutgroups=config_wrapper.getExtraChromOutgroups())
     elif config_wrapper.getOutgroupStrategy() == 'greedyLeaves':
         # use all leaves as outgroups, unless outgroup candidates are given
         outgroup.greedy(threshold=config_wrapper.getOutgroupThreshold(),
                         candidateSet=outgroup_candidates,
                         candidateChildFrac=2.0,
-                        maxNumOutgroups=config_wrapper.getMaxNumOutgroups())
+                        maxNumOutgroups=config_wrapper.getMaxNumOutgroups(),
+                        extraChromOutgroups=config_wrapper.getExtraChromOutgroups())
     elif config_wrapper.getOutgroupStrategy() == 'greedyPreference':
         # prefer the provided outgroup candidates, if any, but use
         # other nodes as "filler" if we can't find enough.
         outgroup.greedy(threshold=config_wrapper.getOutgroupThreshold(),
                         candidateSet=outgroup_candidates,
                         candidateChildFrac=config_wrapper.getOutgroupAncestorQualityFraction(),
-                        maxNumOutgroups=config_wrapper.getMaxNumOutgroups())
+                        maxNumOutgroups=config_wrapper.getMaxNumOutgroups(),
+                        extraChromOutgroups=config_wrapper.getExtraChromOutgroups())
         outgroup.greedy(threshold=config_wrapper.getOutgroupThreshold(),
                         candidateSet=None,
                         candidateChildFrac=config_wrapper.getOutgroupAncestorQualityFraction(),
-                        maxNumOutgroups=config_wrapper.getMaxNumOutgroups())
+                        maxNumOutgroups=config_wrapper.getMaxNumOutgroups(),
+                        extraChromOutgroups=config_wrapper.getExtraChromOutgroups())                        
     elif config_wrapper.getOutgroupStrategy() != 'none':
         raise RuntimeError('Outgroup strategy "{}" not supported. Must be one of [greedy, greedyLeaves, greedyPreference, none]'.format(config_wrapper.getOutgroupStrategy))
 

--- a/src/cactus/refmap/cactus_pangenome.py
+++ b/src/cactus/refmap/cactus_pangenome.py
@@ -117,6 +117,7 @@ def main():
     options.outVG = True
     options.outGFA = False
     options.minIdentity = None
+    options.chromInfo = None
     
     setupBinaries(options)
     set_logging_from_options(options)

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -96,7 +96,11 @@ def main():
                         help="Number of cores for each cactus_consolidated job (defaults to all available / maxCores on single_machine)", default=None)
     parser.add_argument("--consMemory", type=human2bytesN,
                         help="Memory in bytes for each cactus_consolidated job (defaults to an estimate based on the input data size). "
-                        "Standard suffixes like K, Ki, M, Mi, G or Gi are supported (default=bytes))", default=None)   
+                        "Standard suffixes like K, Ki, M, Mi, G or Gi are supported (default=bytes))", default=None)
+    parser.add_argument("--chromInfo",
+                        help="Two-column file mapping genome (col 1) to comma-separated list of sex chromosomes. This information "
+                        "will be used to guide outgroup selection so that, where possible, all chromosomes are present in"
+                        " at least one outgroup.")        
 
     options = parser.parse_args()
 
@@ -254,7 +258,7 @@ def make_align_job(options, toil, config_wrapper=None, chrom_name=None):
     
     mc_tree, input_seq_map, og_candidates = parse_seqfile(options.seqFile, config_wrapper,
                                                           pangenome=options.pangenome)
-    og_map = compute_outgroups(mc_tree, config_wrapper, set(og_candidates))
+    og_map = compute_outgroups(mc_tree, config_wrapper, set(og_candidates), chrom_info_file = options.chromInfo)
     event_set = get_event_set(mc_tree, config_wrapper, og_map, options.root if options.root else mc_tree.getRootName())
     if options.includeRoot:
         if options.root not in input_seq_map:

--- a/src/cactus/shared/configWrapper.py
+++ b/src/cactus/shared/configWrapper.py
@@ -92,6 +92,21 @@ class ConfigWrapper:
             maxNumOutgroups = int(ogElem.attrib["max_num_outgroups"])
         return maxNumOutgroups
 
+    def setMaxNumOutgroups(self, maxOutgroups):
+        ogElem = self.getOutgroupElem()
+        maxNumOutgroups = self.defaultMaxNumOutgroups
+        assert ogElem is not None
+        ogElem.attrib["max_num_outgroups"] = str(maxOutgroups)
+    
+    def getExtraChromOutgroups(self):
+        ogElem = self.getOutgroupElem()
+        extraChromOutgroups = -1
+        if (ogElem is not None and\
+            "strategy" in ogElem.attrib and\
+            "extra_chrom_outgroups" in ogElem.attrib):
+            extraChromOutgroups = int(ogElem.attrib["extra_chrom_outgroups"])
+        return extraChromOutgroups
+
     def getDefaultInternalNodePrefix(self):
         decompElem = self.getDecompositionElem()
         prefix = self.defaultInternalNodePrefix

--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -28,13 +28,19 @@ class TestCase(unittest.TestCase):
     def _out_hal(self, binariesMode):
         return os.path.join(self.tempDir, 'evolver-{}.hal'.format(binariesMode))
 
-    def _run_evolver(self, binariesMode, configFile = None, seqFile = './examples/evolverMammals.txt'):
+    def _run_evolver(self, binariesMode, configFile = None, seqFile = './examples/evolverMammals.txt', chromInfoDict={}):
         """ Run the full evolver test, putting the jobstore and output in tempDir
         """
         cmd = ['cactus', self._job_store(binariesMode), seqFile, self._out_hal(binariesMode),
                         '--binariesMode', binariesMode, '--logInfo', '--workDir', self.tempDir]
         if configFile:
             cmd += ['--configFile', configFile]
+        if chromInfoDict:
+            chromInfoName = os.path.join(self.tempDir, 'chromInfo.txt')
+            with open(chromInfoName, 'w') as chromInfoFile:
+                for source, ogs in chromInfoDict.items():
+                    chromInfoFile.write('{}\t{}\n'.format(source, ogs))
+            cmd += ['--chromInfo', chromInfoName]
 
         # todo: it'd be nice to have an interface for setting tag to something not latest or commit
         if binariesMode == 'docker':
@@ -760,7 +766,7 @@ class TestCase(unittest.TestCase):
         """
         # run cactus directly, the old school way
         name = "local"
-        self._run_evolver(name)
+        self._run_evolver(name, chromInfoDict = {'simChow' : 'X,Y',  'simDog' : 'X', 'simRat' : 'Y', 'simHuman' : 'X,Y,Z'})
 
         # check the output
         #self._check_stats(self._out_hal(name), delta_pct=0.25)


### PR DESCRIPTION
This PR adds the `--chromInfo` option which allows the user to pass a map of genomes to sex chromosomes.  This information is used to choose outgroups that best cover the set of sex chromosomes in the ingroups, and will (by default) allow extra outgroups be selected as necessary to do this.  The idea is to prevent cases where, when aligning a male (XY) and female sample (X) chooses two female outgroups, which could result in a loss of Y in the reconstructed ancestor.  

It also adds a `--maxOutgroups` option that lets the user set the number of outgroups (default to 2) without editing the XML (so `--maxOutputs` if defined overrides `<outgroup max_num_outgroups>` in the config.  

I think at some point I'd like to try implementing a more dynamic outgroup count (ie use more outgroups if they are available near by, and fewer if candidates are all far in the tree).  