### PR TITLE
use --maxMemory to clamp memory requirements of bigger jobs

### DIFF
--- a/src/cactus/maf/cactus_hal2maf.py
+++ b/src/cactus/maf/cactus_hal2maf.py
@@ -33,6 +33,7 @@ from toil.realtimeLogger import RealtimeLogger
 from cactus.shared.common import cactus_cpu_count
 from toil.lib.humanize import bytes2human
 from sonLib.bioio import getTempDirectory
+from cactus.shared.common import cactus_clamp_memory
 
 def main():
     parser = ArgumentParser()
@@ -274,7 +275,7 @@ def hal2maf_all(job, hal_id, chunks, genome_list_id, options, config):
     else:
         maf_mem = math.ceil(hal_id.size / 200)
         taf_mem = math.ceil(hal_id.size / 33)
-        batch_memory = max(maf_mem * options.batchParallelHal2maf, taf_mem * options.batchParallelTaf)
+        batch_memory = cactus_clamp_memory(max(maf_mem * options.batchParallelHal2maf, taf_mem * options.batchParallelTaf))
         
     chunks_left = len(chunks)
     batch_results = []        

--- a/src/cactus/pipeline/cactus_workflow.py
+++ b/src/cactus/pipeline/cactus_workflow.py
@@ -19,6 +19,7 @@ from cactus.shared.common import makeURL
 from cactus.shared.common import cactus_call
 from cactus.shared.configWrapper import ConfigWrapper
 from cactus.shared.common import findRequiredNode, getOptionalAttrib
+from cactus.shared.common import cactus_clamp_memory
 
 ############################################################
 ############################################################
@@ -84,7 +85,7 @@ def cactus_cons_with_resources(job, tree, ancestor_event, config_node, seq_id_ma
 
     cons_job = job.addChildJobFn(cactus_cons, tree, ancestor_event, config_node, seq_id_map, og_map, paf_id,
                                  intermediate_results_url=intermediate_results_url, chrom_name=chrom_name, cores = cons_cores,
-                                 memory=mem, disk=disk)
+                                 memory=cactus_clamp_memory(mem), disk=disk)
     return cons_job.rv()
 
 def cactus_cons(job, tree, ancestor_event, config_node, seq_id_map, og_map, paf_id,

--- a/src/cactus/progressive/cactus_progressive.py
+++ b/src/cactus/progressive/cactus_progressive.py
@@ -35,6 +35,7 @@ from cactus.shared.common import cactusRootPath
 from cactus.shared.common import enableDumpStack
 from cactus.shared.common import cactus_override_toil_options
 from cactus.shared.common import write_s3
+from cactus.shared.common import cactus_clamp_memory
 
 from cactus.pipeline.cactus_workflow import cactus_cons_with_resources
 from cactus.progressive.progressive_decomposition import compute_outgroups, parse_seqfile, get_subtree, get_spanning_subtree, get_event_set
@@ -181,7 +182,7 @@ def progressive_step(job, options, config_node, seq_id_map, tree, og_map, event)
         trim_sequences = paf_job.addChildJobFn(trim_unaligned_sequences,
                                                [subtree_eventmap[i] for i in outgroups], paf_job.rv(), config_node,
                                                disk=sum(8*[subtree_eventmap[i].size for i in outgroups]),
-                                               memory=sum(8*[subtree_eventmap[i].size for i in outgroups]))
+                                               memory=cactus_clamp_memory(sum(8*[subtree_eventmap[i].size for i in outgroups])))
         return paf_job.addFollowOnJobFn(progressive_step_2, trim_sequences.rv(), options, config_node, subtree_eventmap,
                                         spanning_tree, og_map, event).rv()
 
@@ -266,7 +267,7 @@ def export_hal(job, mc_tree, config_node, seq_id_map, og_map, results, event=Non
 
     if not has_resources:
         disk = 3 * sum([file_id.size for file_id in fa_file_ids + c2h_file_ids])
-        mem = 5 * (max([file_id.size for file_id in fa_file_ids]) + max([file_id.size for file_id in c2h_file_ids]))
+        mem = cactus_clamp_memory(5 * (max([file_id.size for file_id in fa_file_ids]) + max([file_id.size for file_id in c2h_file_ids])))
         # allows pass-through of memory override from --consMemory
         if memory_override:
             mem = memory_override

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -41,6 +41,7 @@ from cactus.shared.common import cactus_override_toil_options
 from cactus.shared.common import cactus_call
 from cactus.shared.common import getOptionalAttrib, findRequiredNode
 from cactus.shared.common import unzip_gz, write_s3
+from cactus.shared.common import cactus_clamp_memory
 from cactus.shared.version import cactus_commit
 from cactus.preprocessor.fileMasking import get_mask_bed_from_fasta
 from toil.job import Job
@@ -361,6 +362,8 @@ def graphmap_join_workflow(job, options, config, vg_ids, hal_ids):
 
     # use --indexMemory to cap memory on some jobs
     max_mem = options.indexMemory if options.indexMemory else sys.maxsize
+    if not options.indexMemory:
+        max_mem = cactus_clamp_memory(max_mem)
     
     # keep og ids in separate structure indexed on chromosome
     og_chrom_ids = {'full' : defaultdict(list), 'clip' : defaultdict(list), 'filter' : defaultdict(list)}

--- a/src/cactus/refmap/cactus_minigraph.py
+++ b/src/cactus/refmap/cactus_minigraph.py
@@ -33,6 +33,7 @@ from toil.statsAndLogging import set_logging_from_options
 from toil.realtimeLogger import RealtimeLogger
 from toil.lib.conversions import bytes2human
 from cactus.shared.common import cactus_cpu_count
+from cactus.shared.common import cactus_clamp_memory
 from cactus.progressive.multiCactusTree import MultiCactusTree
 from sonLib.bioio import getTempDirectory
 
@@ -300,8 +301,7 @@ def minigraph_construct(job, options, config_node, seq_id_map, seq_order, gfa_pa
         max_size = max([x.size for x in seq_id_map.values()])
         total_size = sum([x.size for x in seq_id_map.values()])
         disk = total_size * 2
-        mem = 60 * max_size + int(total_size / 4)
-        mem = max(mem, 2**31)
+        mem = cactus_clamp_memory(60 * max_size + int(total_size / 4))
         if options.mgMemory is not None:
             RealtimeLogger.info('Overriding minigraph_construct memory estimate of {} with {} value {} from --mgMemory'.format(bytes2human(mem), 'greater' if options.mgMemory > mem else 'lesser', bytes2human(options.mgMemory)))     
             mem = options.mgMemory

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -27,6 +27,7 @@ from cactus.shared.common import getOptionalAttrib
 from cactus.shared.common import cactus_call
 from cactus.shared.common import write_s3, has_s3, get_aws_region, unzip_gzs
 from cactus.shared.common import cactusRootPath
+from cactus.shared.common import cactus_clamp_memory
 from cactus.shared.version import cactus_commit
 from cactus.shared.configWrapper import ConfigWrapper
 from cactus.refmap.cactus_graphmap import filter_paf
@@ -415,7 +416,7 @@ def export_vg(job, hal_id, config_wrapper, doVG, doGFA, referenceEvents, checkpo
                                  resource_spec = True,
                                  disk=hal_id.size * 3,
                                  # allow override with cons_memory
-                                 memory=hal_id.size * 60 if not memory_override else memory_override).rv()
+                                 memory=cactus_clamp_memory(hal_id.size * 60) if not memory_override else memory_override).rv()
         
     work_dir = job.fileStore.getLocalTempDir()
     hal_path = os.path.join(work_dir, "out.hal")

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -66,7 +66,7 @@ def cactus_cpu_count():
     return num_cpus
 
 def cactus_override_toil_options(options):
-    """  Mess with some toil options to create useful defaults. """
+    """  Mess with some toil options to create useful defaults. """    
     if options.retryCount is None and options.batchSystem.lower() not in ['single_machine', 'singleMachine']:
         # If the user didn't specify a retryCount value, make it 5
         # instead of Toil's default (1).
@@ -104,6 +104,14 @@ def cactus_override_toil_options(options):
         # Too much valuable debugging information to pass up
         logger.info('Enabling realtime logging in Toil')
         options.realTimeLogging = True
+
+    # store toil memory limits here so we can get at them without carrying options around
+    os.environ['CACTUS_MAX_MEMORY'] = str(options.maxMemory)
+    os.environ['CACTUS_DEFAULT_MEMORY'] = str(options.defaultMemory)
+
+def cactus_clamp_memory(memory_bytes):
+    """ use the environment variables from --maxMemory and --defaultMemory to clamp a given memory value """
+    return max(min(int(os.environ['CACTUS_MAX_MEMORY']), memory_bytes), int(os.environ['CACTUS_DEFAULT_MEMORY']))
 
 def makeURL(path_or_url):
     if urlparse(path_or_url).scheme == '':


### PR DESCRIPTION
It's frustrating when cactus calculates the memory required for a job, issues it, then that memory is too large for the batch system to run it, because it's a non-recoverable error.  And it could be that the estimate was a bit too conservative and the job could have been run after all (it's also possible that the estimate was fine and the job would end up crashing).  

This comes up in pangenome indexing (where `--indexMemory` already works like a type of global override), but also when dealing with very repetitive pariwise alignments.  

This PR introduces some logic to clamp memory estimates with a value from `--maxMemory`.   So if you are running on a cluster with at most 1TB available, you can run `--maxMemory 1TB` and cactus will never ask for anymore memory no matter what.  

Since this needs to be implemented job-by-job, and I didn't apply it to every single job, it's possible there are cases that still aren't handled.  But if/when they are discovered they can be fixed by using `cactus_clamp_memory()`.  