### PR TITLE
Disable support for multi-way splits

### DIFF
--- a/build-tools/downloadMafTools
+++ b/build-tools/downloadMafTools
@@ -51,7 +51,7 @@ export HTSLIB_LIBS="$(pwd)/libhts.a -lbz2 -ldeflate -lm -lpthread -lz -llzma -pt
 cd ${mafBuildDir}
 git clone https://github.com/ComparativeGenomicsToolkit/taffy.git
 cd taffy
-git checkout 78ab3191092459c6e148209fff5526c871372359
+git checkout 48e4dc6a5119e082d5e039d629184e46955acb0f
 git submodule update --init --recursive
 export HALDIR=${CWD}/submodules/hal
 make -j ${numcpu}

--- a/doc/progressive.md
+++ b/doc/progressive.md
@@ -73,7 +73,7 @@ cactus <jobStorePath> <seqFile> <outputHal>
 
 The `jobStorePath` is where intermediate files, as well as job metadata, [will be kept by Toil](https://toil.readthedocs.io/en/latest/running/introduction.html#job-store). **It must be accessible to all worker systems.** 
 
-The `seqFile` is a text file containing the locations of the input sequences as well as their phylogenetic tree. The tree will be used to progressively decompose the alignment by iteratively aligning sibling genomes to estimate their parents in a bottom-up fashion. Polytomies in the tree are allowed, though the amount of computation required for a sub-alignment rises quadratically with the degree of the polytomy.  Cactus uses the predicted branch lengths from the tree to determine appropriate pairwise alignment parameters, allowing closely related species to be aligned more quickly with no loss in accuracy. The file is formatted as follows:
+The `seqFile` is a text file containing the locations of the input sequences as well as their phylogenetic tree. The tree will be used to progressively decompose the alignment by iteratively aligning sibling genomes to estimate their parents in a bottom-up fashion. Polytomies in the tree are *no longer* allowed, as changes to chaining have caused them to lead to drops in coverage. Cactus uses the predicted branch lengths from the tree to determine appropriate pairwise alignment parameters, allowing closely related species to be aligned more quickly with no loss in accuracy. The file is formatted as follows:
 
     NEWICK tree
     name1 path1

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -425,10 +425,12 @@
 		<!-- default_internal_node_prefix: internal nodes of the tree are labeled with this prefix then a BFS order number -->
 		<!-- default_branch_len: use this branch length if information is missing from the input tree -->
 		<!-- default_branch_len_pangenome: use this branch length (for implicit star tree) in pangenome mode -->
+		<!-- allow_multifurcations: added in v2.7.2 and defaulted to 0, since multifurcations (ancestors with > 2 children) have been shown to reduce coverage. -->
 	 	<decomposition
 	 		default_internal_node_prefix="Anc"
 			default_branch_len="1"
 			default_branch_len_pangenome="0.025"
+			allow_multifurcations="0"
 	 	/>
   	</multi_cactus>
 	<consolidated>

--- a/src/cactus/progressive/cactus_progressive.py
+++ b/src/cactus/progressive/cactus_progressive.py
@@ -383,10 +383,8 @@ def main():
         if options.consCores is None:
             if options.maxCores is not None and options.maxCores < 2**20:
                 options.consCores = int(options.maxCores)
-                print("conscores2 is maxcores {}".format(options.consCores))
             else:
                 options.consCores = cactus_cpu_count()
-                print("conscores is cput count {}".format(options.consCores))
         elif options.maxCores is not None and options.maxCores < 2**20 and options.consCores > int(options.maxCores):
             raise RuntimeError('--consCores must be <= --maxCores')
     else:

--- a/src/cactus/progressive/progressive_decomposition.py
+++ b/src/cactus/progressive/progressive_decomposition.py
@@ -46,7 +46,10 @@ def parse_seqfile(seqfile_path, config_wrapper, root_name = None, pangenome = Fa
 
     check_branch_lengths(mc_tree)
 
-    check_degree2_ancestors(mc_tree)    
+    check_degree2_ancestors(mc_tree)
+
+    if not pangenome and not config_wrapper.getAllowMultifurcations():
+        check_multifurcations(mc_tree)
 
     return (mc_tree, seq_file.pathMap, seq_file.outgroups)
 
@@ -272,3 +275,10 @@ def check_degree2_ancestors(mc_tree):
         child_nodes = mc_tree.getChildren(node)
         if len(child_nodes) == 1:
             raise RuntimeError("Error parsing tree \"{}\":\n Node {} (parent of {}) has single descendant: Please remove all such nodes and try again.".format(NXNewick().writeString(mc_tree), mc_tree.getName(node), mc_tree.getName(child_nodes[0])))
+
+def check_multifurcations(mc_tree):
+    for node in mc_tree.postOrderTraversal():
+        child_nodes = mc_tree.getChildren(node)
+        if len(child_nodes) > 2:
+            raise RuntimeError("Error parsing tree \"{}\":\n Node {} has more than two children: {}. Such nodes have been shown to drastically drop coverage in recent versions of Cactus. For best results, binarize your tree and try again. You can override this check by toggling \"allow_multifurcations\" to \"1\" in the configuration XML".format(NXNewick().writeString(mc_tree), mc_tree.getName(node), [mc_tree.getName(child) for child in child_nodes]))
+    

--- a/src/cactus/shared/configWrapper.py
+++ b/src/cactus/shared/configWrapper.py
@@ -123,6 +123,10 @@ class ConfigWrapper:
         else:
             return float(decompElem.attrib["default_branch_len"])
 
+    def getAllowMultifurcations(self):
+        decompElem = self.getDecompositionElem()
+        return getOptionalAttrib(decompElem, attribName="allow_multifurcations", typeFn=bool, default=False)
+        
     def getBuildHal(self):
         halElem = self.xmlRoot.find("hal")
         if halElem is not None and "buildHal" in halElem.attrib:

--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -83,14 +83,26 @@ class TestCase(unittest.TestCase):
                 seq_file.write('{}\t{}\n'.format(genome, genome_path))
             seq_file.write(new_child_line)
 
+        # use the same logic cactus does to get default config
+        config_path = 'src/cactus/cactus_progressive_config.xml' if not configFile else configFile
+
+        xml_root = ET.parse(config_path).getroot()
+        decomp_elem = xml_root.find("multi_cactus").find("decomposition")
+        # force cactus to accept multifurcation in tree
+        decomp_elem.attrib["allow_multifurcations"] = "1"
+
+        mc_config_path = os.path.join(self.tempDir, "config.mc.xml")
+        with open(mc_config_path, 'w') as mc_config_file:
+            xmlString = ET.tostring(xml_root, encoding='unicode')
+            xmlString = minidom.parseString(xmlString).toprettyxml()
+            mc_config_file.write(xmlString)
+            
         # run the alignment
         out_hal = os.path.join(self.tempDir, '{}.hal'.format(new_root))
         if step_by_step:
             out_paf = os.path.join(self.tempDir, '{}.paf'.format(new_root))
             cmd = ['cactus-blast', self._job_store(binariesMode), seq_file_path, out_paf, '--includeRoot', '--root', new_root,
-                   '--binariesMode', binariesMode, '--logInfo', '--workDir', self.tempDir]
-            if configFile:
-                cmd += ['--configFile', configFile]
+                   '--binariesMode', binariesMode, '--logInfo', '--workDir', self.tempDir, '--configFile', mc_config_path]
             # todo: it'd be nice to have an interface for setting tag to something not latest or commit
             if binariesMode == 'docker':
                 cmd += ['--latest']
@@ -98,9 +110,7 @@ class TestCase(unittest.TestCase):
             subprocess.check_call(cmd)
 
             cmd = ['cactus-align', self._job_store(binariesMode), seq_file_path, out_paf, out_hal, '--includeRoot', '--root', new_root,
-                   '--binariesMode', binariesMode, '--logInfo', '--workDir', self.tempDir]
-            if configFile:
-                cmd += ['--configFile', configFile]
+                   '--binariesMode', binariesMode, '--logInfo', '--workDir', self.tempDir, '--configFile', mc_config_path]
             # todo: it'd be nice to have an interface for setting tag to something not latest or commit
             if binariesMode == 'docker':
                 cmd += ['--latest']
@@ -108,9 +118,7 @@ class TestCase(unittest.TestCase):
             subprocess.check_call(cmd)
         else:
             cmd = ['cactus', self._job_store(binariesMode), seq_file_path, out_hal,
-                   '--binariesMode', binariesMode, '--logInfo', '--workDir', self.tempDir]
-            if configFile:
-                cmd += ['--configFile', configFile]
+                   '--binariesMode', binariesMode, '--logInfo', '--workDir', self.tempDir, '--configFile', mc_config_path]
             # todo: it'd be nice to have an interface for setting tag to something not latest or commit
             if binariesMode == 'docker':
                 cmd += ['--latest']
@@ -310,9 +318,23 @@ class TestCase(unittest.TestCase):
         seq_file_path = os.path.join(self.tempDir, 'primates.txt')
         self._write_primates_seqfile(seq_file_path)
 
+        # use the same logic cactus does to get default config
+        config_path = 'src/cactus/cactus_progressive_config.xml'
+
+        xml_root = ET.parse(config_path).getroot()
+        decomp_elem = xml_root.find("multi_cactus").find("decomposition")
+        # force cactus to accept multifurcation in tree
+        decomp_elem.attrib["allow_multifurcations"] = "1"
+
+        mc_config_path = os.path.join(self.tempDir, "config.mc.xml")
+        with open(mc_config_path, 'w') as mc_config_file:
+            xmlString = ET.tostring(xml_root, encoding='unicode')
+            xmlString = minidom.parseString(xmlString).toprettyxml()
+            mc_config_file.write(xmlString)
+
         # do the mapping
         cigar_path = os.path.join(self.tempDir, 'aln.paf')
-        cactus_opts = ['--binariesMode', binariesMode, '--logInfo', '--workDir', self.tempDir]
+        cactus_opts = ['--binariesMode', binariesMode, '--logInfo', '--workDir', self.tempDir, '--configFile', mc_config_path]
         # todo: it'd be nice to have an interface for setting tag to something not latest or commit
         if binariesMode == 'docker':
             cactus_opts += ['--latest']
@@ -339,6 +361,10 @@ class TestCase(unittest.TestCase):
         bar_elem = xml_root.find("bar")
         bar_elem.attrib["partialOrderAlignment"] = "1"
         bar_elem.attrib["partialOrderAlignmentMaskFilter"] = "1"
+        
+        # force cactus to accept multifurcation in tree
+        decomp_elem = xml_root.find("multi_cactus").find("decomposition")
+        decomp_elem.attrib["allow_multifurcations"] = "1"
 
         poa_config_path = os.path.join(self.tempDir, "config.poa.xml")
         with open(poa_config_path, 'w') as poa_config_file:
@@ -897,6 +923,9 @@ class TestCase(unittest.TestCase):
         xml_root = ET.parse(config_path).getroot()
         bar_elem = xml_root.find("bar")
         bar_elem.attrib["partialOrderAlignment"] = "1"
+        decomp_elem = xml_root.find("multi_cactus").find("decomposition")
+        # force cactus to accept multifurcation in tree
+        decomp_elem.attrib["allow_multifurcations"] = "1"
 
         poa_config_path = os.path.join(self.tempDir, "config.poa.xml")
         with open(poa_config_path, 'w') as poa_config_file:


### PR DESCRIPTION
You used to be able to replace something like `((a,b)(c,d))` with `(a,b,c,d)` in an input tree.  It would lead to more memory usage, but might actually help coverage since two internal ancestors are avoided. 

But sometime over the past year, this seems to have changed. I just noticed that doing this caused a dramatic loss of coverage inside the subtree in question when aligning some apes.  

So now the best practice seems to be to always binarize the input tree, even if the choice of topology may not necessarily be clear.  This PR enforces this.  IF you pass in a tree with a node with `>2` children, it will fail with an error.  This check can be disabled in the configuration XML. Hopefully this will be fixed at some point. 