### PR TITLE
Explicitly erase some unneeded jobstore files

### DIFF
--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -42,6 +42,7 @@ from cactus.shared.common import cactus_call
 from cactus.shared.common import getOptionalAttrib, findRequiredNode
 from cactus.shared.common import unzip_gz, write_s3
 from cactus.shared.common import cactus_clamp_memory
+from cactus.shared.common import clean_jobstore_files
 from cactus.shared.version import cactus_commit
 from cactus.preprocessor.fileMasking import get_mask_bed_from_fasta
 from toil.job import Job
@@ -456,6 +457,8 @@ def graphmap_join_workflow(job, options, config, vg_ids, hal_ids):
                                           memory=min(max(f.size for f in hal_ids) * 2, max_mem))
         hal_id_dict = hal_merge_job.rv()
         out_dicts.append(hal_id_dict)
+        # delete the chromosome hals
+        hal_merge_job.addFollowOnJobFn(clean_jobstore_files, file_ids=hal_ids)
 
     if options.indexMemory:
         index_mem = options.indexMemory

--- a/src/cactus/refmap/cactus_pangenome.py
+++ b/src/cactus/refmap/cactus_pangenome.py
@@ -29,6 +29,7 @@ from cactus.shared.common import enableDumpStack
 from cactus.shared.common import cactus_override_toil_options
 from cactus.shared.common import cactus_call
 from cactus.shared.common import getOptionalAttrib, findRequiredNode
+from cactus.shared.common import clean_jobstore_files
 from cactus.shared.version import cactus_commit
 from cactus.preprocessor.checkUniqueHeaders import sanitize_fasta_headers
 from toil.job import Job
@@ -361,6 +362,10 @@ def pangenome_end_to_end_workflow(job, options, config_wrapper, seq_id_map, seq_
         split_out_path = os.path.join(options.outDir, 'chrom-subproblems')    
         split_export_job = split_job.addFollowOnJobFn(export_split_wrapper, wf_output, split_out_path, config_wrapper)        
         chromfile_path = os.path.join(split_out_path, 'chromfile.txt')
+
+    # clean out some jobstore files we no longer need
+    clean_jobstore_job = split_export_job.addFollowOnJobFn(clean_jobstore_files, file_id_maps=[seq_id_map] if not options.noSplit else None,
+                                                           file_ids=[sv_gfa_id, paf_id])
 
     # cactus_align        
     align_jobs_make_job = split_export_job.addFollowOnJobFn(make_batch_align_jobs_wrapper, options, chromfile_path, config_wrapper)

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -28,6 +28,7 @@ from cactus.shared.common import cactus_call
 from cactus.shared.common import write_s3, has_s3, get_aws_region, unzip_gzs
 from cactus.shared.common import cactusRootPath
 from cactus.shared.common import cactus_clamp_memory
+from cactus.shared.common import clean_jobstore_files
 from cactus.shared.version import cactus_commit
 from cactus.shared.configWrapper import ConfigWrapper
 from cactus.refmap.cactus_graphmap import filter_paf
@@ -393,6 +394,9 @@ def cactus_align(job, config_wrapper, mc_tree, input_seq_map, input_seq_id_map, 
     hal_job = cons_job.addFollowOnJobFn(export_hal, sub_tree, config_wrapper.xmlRoot, new_seq_id_map, og_map, results, event=root_name, inMemory=True,
                                         checkpointInfo=checkpointInfo, acyclicEvent=referenceEvents[0] if referenceEvents else None,
                                         memory_override=cons_memory)
+
+    # clean out some of the  intermediate jobstore files
+    hal_job.addFollowOnJobFn(clean_jobstore_files, file_id_maps=[new_seq_id_map], file_ids=[paf_id])
 
     # optionally create the VG
     if doVG or doGFA:

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -1167,3 +1167,12 @@ def get_faidx_subpath_rename_cmd():
     """
     return ['sed', '-e', 's/\([^:]*\):\([0-9]*\)-\([0-9]*\)/echo "\\1_sub_$((\\2-1))_\\3"/e']
 
+def clean_jobstore_files(job, file_id_maps=None, file_ids=None):
+    """ clean some intermediate files that are no longer needed out of the jobstore """
+    if file_id_maps:
+        for file_id_map in file_id_maps:
+            for key, file_id in file_id_map.items():
+                job.fileStore.deleteGlobalFile(file_id)
+    if file_ids:
+        for file_id in file_ids:
+            job.fileStore.deleteGlobalFile(file_id)


### PR DESCRIPTION
This is mostly for `cactus-pangenome` which, by chaining together a bunch of workflows, has plenty of opportunity to accumulate jobstore bloat.  This PR adds some following cleanup steps

* erase fasta and paf after consolidated (just paf in progressive mode due to outgroups)
* original fasta and minigraph output after `graphmap-split` 
* chromosome hal_ids after merging together

On the yeast graph, this drops peak usage from `1.1G` to `896G`.  I think it'll have more impact on big human graphs where sequence data accounts for a bigger proportion of disk usuage.   