### PR TITLE
Clean out jobstore cruft in preprocessor

### DIFF
--- a/src/cactus/progressive/cactus_progressive.py
+++ b/src/cactus/progressive/cactus_progressive.py
@@ -68,7 +68,7 @@ def preprocess_all(job, options, config_node, input_seq_id_map):
         pp_seq_ids[event] = preprocessor_job.rv(i)
 
     # do the logging and checkpointing
-    root_job.addFollowOnJobFn(save_preprocessed_files, options, config_node, input_seq_id_map)
+    root_job.addFollowOnJobFn(save_preprocessed_files, options, config_node, pp_seq_ids)
     
     return pp_seq_ids
 

--- a/src/cactus/refmap/cactus_graphmap.py
+++ b/src/cactus/refmap/cactus_graphmap.py
@@ -233,7 +233,7 @@ def minigraph_workflow(job, options, config, seq_id_map, gfa_id, graph_event, sa
 
     if zipped_gfa:
         # gaf2paf needs unzipped gfa, so we take care of that upfront
-        gfa_unzip_job = root_job.addChildJobFn(unzip_gz, options.minigraphGFA, gfa_id, disk=5*gfa_id.size)
+        gfa_unzip_job = root_job.addChildJobFn(unzip_gz, options.minigraphGFA, gfa_id, delete_original=False, disk=5*gfa_id.size)
         gfa_id = gfa_unzip_job.rv()
         gfa_id_size *= 10
         options.minigraphGFA = options.minigraphGFA[:-3]
@@ -270,7 +270,8 @@ def minigraph_workflow(job, options, config, seq_id_map, gfa_id, graph_event, sa
                                                    del_size_threshold,
                                                    disk=8*gfa_id_size, cores=mg_cores,
                                                    memory=cactus_clamp_memory(16*gfa_id_size))
-        unfiltered_paf_id = prev_job.addFollowOnJobFn(zip_gz, 'mg.paf.unfiltered', out_paf_id, disk=gfa_id_size).rv()
+        unfiltered_paf_id = prev_job.addFollowOnJobFn(zip_gz, 'mg.paf.unfiltered', out_paf_id, delete_original=False,
+                                                      disk=gfa_id_size).rv()
         out_paf_id = del_filter_job.rv(0)
         filtered_paf_log = del_filter_job.rv(1)
         paf_was_filtered = del_filter_job.rv(2)

--- a/src/cactus/refmap/cactus_graphmap_split.py
+++ b/src/cactus/refmap/cactus_graphmap_split.py
@@ -218,10 +218,10 @@ def graphmap_split_workflow(job, options, config, seq_id_map, seq_name_map, gfa_
     
     # use file extension to sniff out compressed input
     if gfa_path.endswith(".gz"):
-        gfa_id = root_job.addChildJobFn(unzip_gz, gfa_path, gfa_id, disk=gfa_id.size * 10).rv()
+        gfa_id = root_job.addChildJobFn(unzip_gz, gfa_path, gfa_id, delete_original=False, disk=gfa_id.size * 10).rv()
         gfa_size *= 10
     if paf_path.endswith(".gz"):
-        paf_id = root_job.addChildJobFn(unzip_gz, paf_path, paf_id, disk=paf_id.size * 10).rv()
+        paf_id = root_job.addChildJobFn(unzip_gz, paf_path, paf_id, delete_original=False, disk=paf_id.size * 10).rv()
         paf_size *= 10
 
     # do some basic paf filtering


### PR DESCRIPTION
Looks like the preprocessor, which may run 4-5 steps on the input sequence, along with unzip them, will keep aorund every intermediate copy in the jobstore.  This PR, along the lines #1295, explicitly deletes the previous iteration once the new version is computed. 