### PR TITLE
auto-scale blast chunk size on slurm

### DIFF
--- a/src/cactus/blast/cactus_blast.py
+++ b/src/cactus/blast/cactus_blast.py
@@ -104,6 +104,7 @@ def runCactusBlastOnly(options):
             config_node = ET.parse(options.configFile).getroot()
             config_wrapper = ConfigWrapper(config_node)
             config_wrapper.substituteAllPredefinedConstantsWithLiterals(options)
+            config_wrapper.applySlurmChunkScaling(options)
             # apply gpu override
             config_wrapper.initGPU(options)
             mc_tree, input_seq_map, og_candidates = parse_seqfile(options.seqFile, config_wrapper)

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -60,6 +60,7 @@
 	<!-- pickIngroupPrimaryAlignmentsSeparatelyToOutgroups Separately make ingroups pick their primary alignment to
 	     other ingroups without outgroups, then get the outgroups to pick their primary alignment to the ingroups. If 0
 	     get every sequence to pick its primary alignment without regard to if the other sequence is an ingroup or outgroup -->
+	<!-- slurmChunkScale Multiply chunkSize and divide dechunkBatchSize by this value when running slurm in order to decrease job count -->
 	<blast chunkSize="30000000"
 		   overlapSize="10000"
 		   mapper="lastz"
@@ -85,6 +86,7 @@
 		   outputSecondaryAlignments="0"
 		   dechunkBatchSize="1000"
 		   pickIngroupPrimaryAlignmentsSeparatelyToOutgroups="1"
+		   slurmChunkScale="3"
 		   >
 
 		<!-- The following are parametrised to produce the same results as the default settings,

--- a/src/cactus/progressive/cactus_progressive.py
+++ b/src/cactus/progressive/cactus_progressive.py
@@ -415,6 +415,7 @@ def main():
             config_wrapper = ConfigWrapper(config_node)
             config_wrapper.substituteAllPredefinedConstantsWithLiterals(options)
             config_wrapper.setSystemMemory(options)
+            config_wrapper.applySlurmChunkScaling(options)
             if options.maxOutgroups:
                 config_wrapper.setMaxNumOutgroups(options.maxOutgroups)
 


### PR DESCRIPTION
Right now there's a crucial bit in the README about manually increasing the blast chunk size for cpu jobs:

>cp cactus-bin-v2.7.2/src/cactus/cactus_progressive_config.xml ./config-slurm.xml
>sed -i config-slurm.xml -e 's/blast chunkSize="30000000"/blast chunkSize="90000000"/g'
>sed -i config-slurm.xml -e 's/dechunkBatchSize="1000"/dechunkBatchSize="200"/g'

This brings down the number of jobs by a factor of 9, which helps to not spam the cluster with too many jobs (ie reduces from 100s of thousands to 10s of thousands).  I think slurm itself can handle big queues, but I was seeing some issues in early tests that may be related to the jobstore pushing the network filesystem with so many jobs.  

Anyway, this PR changes cactus so that is applied automatically, and controlled by `slurmChunkScale` in the config XML.  