### PR TITLE
Add Red prefilter

### DIFF
--- a/preprocessor/Makefile
+++ b/preprocessor/Makefile
@@ -6,7 +6,7 @@ CFLAGS += ${hiredisIncl}
 all: all_libs all_progs
 all_libs: 
 all_progs: all_libs
-	${MAKE} ${BINDIR}/cactus_analyseAssembly ${BINDIR}/cactus_makeAlphaNumericHeaders.py ${BINDIR}/cactus_filterSmallFastaSequences.py ${BINDIR}/cactus_softmask2hardmask ${BINDIR}/cactus_sanitizeFastaHeaders ${BINDIR}/cactus_filterRedBreakingSequences
+	${MAKE} ${BINDIR}/cactus_analyseAssembly ${BINDIR}/cactus_makeAlphaNumericHeaders.py ${BINDIR}/cactus_filterSmallFastaSequences.py ${BINDIR}/cactus_softmask2hardmask ${BINDIR}/cactus_sanitizeFastaHeaders ${BINDIR}/cactus_redPrefilter
 	cd lastzRepeatMasking && ${MAKE} all
 
 ${BINDIR}/cactus_filterSmallFastaSequences.py : cactus_filterSmallFastaSequences.py
@@ -26,8 +26,8 @@ ${BINDIR}/cactus_softmask2hardmask : cactus_softmask2hardmask.c ${LIBDEPENDS} ${
 ${BINDIR}/cactus_sanitizeFastaHeaders : cactus_sanitizeFastaHeaders.c ${LIBDEPENDS} ${LIBDIR}/cactusLib.a
 	${CC} ${CPPFLAGS} ${CFLAGS} ${LDFLAGS} -o ${BINDIR}/cactus_sanitizeFastaHeaders cactus_sanitizeFastaHeaders.c ${LIBDIR}/cactusLib.a ${LDLIBS}
 
-${BINDIR}/cactus_filterRedBreakingSequences : cactus_filterRedBreakingSequences.c ${LIBDEPENDS} ${LIBDIR}/cactusLib.a
-	${CC} ${CPPFLAGS} ${CFLAGS} ${LDFLAGS} -o ${BINDIR}/cactus_filterRedBreakingSequences cactus_filterRedBreakingSequences.c ${LIBDIR}/cactusLib.a ${LDLIBS}
+${BINDIR}/cactus_redPrefilter : cactus_redPrefilter.c ${LIBDEPENDS} ${LIBDIR}/cactusLib.a
+	${CC} ${CPPFLAGS} ${CFLAGS} ${LDFLAGS} -o ${BINDIR}/cactus_redPrefilter cactus_redPrefilter.c ${LIBDIR}/cactusLib.a ${LDLIBS}
 
 
 clean : 

--- a/preprocessor/Makefile
+++ b/preprocessor/Makefile
@@ -6,7 +6,7 @@ CFLAGS += ${hiredisIncl}
 all: all_libs all_progs
 all_libs: 
 all_progs: all_libs
-	${MAKE} ${BINDIR}/cactus_analyseAssembly ${BINDIR}/cactus_makeAlphaNumericHeaders.py ${BINDIR}/cactus_filterSmallFastaSequences.py ${BINDIR}/cactus_softmask2hardmask ${BINDIR}/cactus_sanitizeFastaHeaders
+	${MAKE} ${BINDIR}/cactus_analyseAssembly ${BINDIR}/cactus_makeAlphaNumericHeaders.py ${BINDIR}/cactus_filterSmallFastaSequences.py ${BINDIR}/cactus_softmask2hardmask ${BINDIR}/cactus_sanitizeFastaHeaders ${BINDIR}/cactus_filterRedBreakingSequences
 	cd lastzRepeatMasking && ${MAKE} all
 
 ${BINDIR}/cactus_filterSmallFastaSequences.py : cactus_filterSmallFastaSequences.py
@@ -25,6 +25,10 @@ ${BINDIR}/cactus_softmask2hardmask : cactus_softmask2hardmask.c ${LIBDEPENDS} ${
 
 ${BINDIR}/cactus_sanitizeFastaHeaders : cactus_sanitizeFastaHeaders.c ${LIBDEPENDS} ${LIBDIR}/cactusLib.a
 	${CC} ${CPPFLAGS} ${CFLAGS} ${LDFLAGS} -o ${BINDIR}/cactus_sanitizeFastaHeaders cactus_sanitizeFastaHeaders.c ${LIBDIR}/cactusLib.a ${LDLIBS}
+
+${BINDIR}/cactus_filterRedBreakingSequences : cactus_filterRedBreakingSequences.c ${LIBDEPENDS} ${LIBDIR}/cactusLib.a
+	${CC} ${CPPFLAGS} ${CFLAGS} ${LDFLAGS} -o ${BINDIR}/cactus_filterRedBreakingSequences cactus_filterRedBreakingSequences.c ${LIBDIR}/cactusLib.a ${LDLIBS}
+
 
 clean : 
 	rm -f *.o

--- a/preprocessor/cactus_filterRedBreakingSequences.c
+++ b/preprocessor/cactus_filterRedBreakingSequences.c
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2009-2011 by Benedict Paten (benedictpaten@gmail.com)
+ *
+ * Released under the MIT license, see LICENSE.txt
+ *
+ * REpeat Detector (Red) doesn't handle some input edge cases very well. These include
+ * - tiny contigs
+ * - contigs that are very low information -- ie nearly all the same base
+ * 
+ * This program can be used to filter them out before running Red then add them back in (-x) after
+ */
+
+#include <assert.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <time.h>
+#include <getopt.h>
+#include <inttypes.h>
+#include <sys/types.h>
+#include <sys/param.h>
+#include <sys/stat.h>
+#include <dirent.h>
+#include <math.h>
+#include <ctype.h>
+
+#include "bioioC.h"
+#include "cactus.h"
+
+void usage() {
+    fprintf(stderr, "cactus_filterRedBreakingSequences [fastaFile]\n");
+    fprintf(stderr, "-m --minLength N: Filter contigs < Nbp. DEFAULT=20000\n");
+    fprintf(stderr, "-b --maxBaseFrac F:  Filter contigs with proportion of the same base >= F. DEFAULT=0.98\n");    
+    fprintf(stderr, "-x --extract:     Extract (instead of remove) filtered sequences\n");
+}
+
+static bool extract = false;
+static double max_base_frac = 0.98;
+
+static void redfilter(void* min_length_p, const char* name, const char* seq, int64_t length) {
+    int64_t min_length = *(int64_t*)min_length_p;
+    char* uc_seq = (char*)seq;
+
+    bool too_short = length < min_length;
+    // this is a quick hack to filter out really low-entropy sequence
+    // todo: would be better to get Red to handle without crashing,
+    //       but I don't think they're bound to happen much in real assemblies
+    int64_t base_hist[256] = {0};
+    for (int64_t i = 0; i < length; ++i) {
+        int64_t c = (int64_t)toupper(seq[i]);
+        ++base_hist[c];
+    }
+    bool is_monomer = length == 0;
+    for (int64_t i = 0; i < 256 && !is_monomer; ++i) {
+        if ((double)base_hist[i] / (double)length > max_base_frac) {
+            is_monomer = true;
+        }
+    }
+
+    if (is_monomer && extract) {
+        // softmask the monomer
+        for (int64_t i = 0; i < length; ++i) {
+            uc_seq[i] = tolower(uc_seq[i]);               
+        }
+    }
+
+    if ((!extract && !too_short && !is_monomer) || (extract && (too_short || is_monomer))) {
+        fastaWrite(uc_seq, (char*)name, stdout);
+    }
+}
+
+int main(int argc, char *argv[]) {
+
+    int64_t min_length = 20000;
+    
+    while (1) {
+        static struct option long_options[] = { { "minLength", required_argument, 0, 'm' },
+                                                { "maxBaseFrac", required_argument, 0, 'b' },            
+                                                { "extract", no_argument, 0, 'x' },
+                                                { 0, 0, 0, 0 } };
+
+        int option_index = 0;
+
+        int key = getopt_long(argc, argv, "m:b:xs", long_options, &option_index);
+        int i = 0;
+
+        if (key == -1) {
+            break;
+        }
+
+        switch (key) {
+        case 'm':
+            i = sscanf(optarg, "%" PRIi64 "", &min_length);
+            assert(i == 1);
+            break;
+        case 'b':
+            i = sscanf(optarg, "%lf", &max_base_frac);
+            assert(i == 1);
+            break;            
+        case 'x':
+            extract = true;
+            break;
+        default:
+            usage();
+            return 1;
+        }
+    }
+
+    if(argc == 1) {
+        usage();
+        return 0;
+    }
+
+    for (int64_t j = optind; j < argc; j++) {
+        FILE *fileHandle;
+        if (strcmp(argv[j], "-") == 0) {
+            fileHandle = stdin;
+        } else {
+            fileHandle = fopen(argv[j], "r");
+            if (fileHandle == NULL) {
+                st_errnoAbort("Could not open input file %s", argv[j]);
+            }
+        }
+        fastaReadToFunction(fileHandle, &min_length, redfilter);
+    }
+
+    return 0;
+}

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -21,7 +21,8 @@
 	<!-- Use RED (Repeat DEtector) to masks repetitive sequence. -->
 	<!-- unmask: discard any previous masking on the input fasta, only masking from Red is kept -->
 	<!-- redOpts: any command line options can be passed to Red here -->
-	<preprocessor unmask="0" memory="mediumMemory" preprocessJob="red" redOpts='' active="1"/>	
+	<!-- redPrefilterOpts: run red prefilter with these options.  -m 20000 -b 0.98 means exclude contigs with length < 20000 and/or a single base comprising 98 pct of the sequence from Red masking, as Red can crash on very small / low-information contigs -->
+	<preprocessor unmask="0" memory="mediumMemory" preprocessJob="red" redOpts="" redPrefilterOpts="-m 20000 -b 0.98" active="1"/>	
 	<!-- The preprocessor for cactus_lastzRepeatMask masks every seed that is part of more than XX other alignments, this stops a combinatorial explosion in pairwise alignments. gpu sets the number of gpus (if >0, use segalign in stead of lastz. can be set to 'all' for all available GPUs) -->
 	<preprocessor unmask="0" chunkSize="10000000" proportionToSample="0.2" memory="littleMemory" preprocessJob="lastzRepeatMask" minPeriod="50" lastzOpts='--step=3 --ambiguous=iupac,100,100 --ungapped --queryhsplimit=keep,nowarn:1500' gpu="0" active="0"/>
 	<!-- Softmask alpha-satellite using the dna-brnn tool -->

--- a/src/cactus/preprocessor/cactus_preprocessor.py
+++ b/src/cactus/preprocessor/cactus_preprocessor.py
@@ -50,7 +50,7 @@ class PreprocessorOptions:
     def __init__(self, chunkSize, memory, cpu, check, proportionToSample, unmask,
                  preprocessJob, checkAssemblyHub=None, lastzOptions=None, minPeriod=None,
                  gpu=0, lastz_memory=None, dnabrnnOpts=None,
-                 dnabrnnAction=None, redOpts=None, eventName=None, minLength=None,
+                 dnabrnnAction=None, redOpts=None, redPrefilterOpts=None, eventName=None, minLength=None,
                  cutBefore=None, cutBeforeOcc=None, cutAfter=None, inputBedID=None):
         self.chunkSize = chunkSize
         self.memory = memory
@@ -71,6 +71,7 @@ class PreprocessorOptions:
         self.dnabrnnAction = dnabrnnAction
         assert dnabrnnAction in ('softmask', 'hardmask', 'clip')
         self.redOpts = redOpts
+        self.redPrefilterOpts = redPrefilterOpts
         self.eventName = eventName
         self.minLength = minLength        
         self.cutBefore = cutBefore
@@ -168,6 +169,7 @@ class PreprocessSequence(RoundedJob):
         elif self.prepOptions.preprocessJob == "red":
             return RedMaskJob(inChunkID,
                               redOpts=self.prepOptions.redOpts,
+                              redPrefilterOpts=self.prepOptions.redPrefilterOpts,
                               eventName=self.prepOptions.eventName,
                               unmask=self.prepOptions.unmask)  
         elif self.prepOptions.preprocessJob == "cutHeaders":
@@ -272,6 +274,7 @@ class BatchPreprocessor(RoundedJob):
                                               dnabrnnOpts = getOptionalAttrib(prepNode, "dna-brnnOpts", default=""),
                                               dnabrnnAction = getOptionalAttrib(prepNode, "action", typeFn=str, default="softmask"),
                                               redOpts = getOptionalAttrib(prepNode, "redOpts", default=""),
+                                              redPrefilterOpts = getOptionalAttrib(prepNode, "redPrefilterOpts", default=""),
                                               eventName = getOptionalAttrib(prepNode, "eventName", typeFn=str, default=None),
                                               minLength = getOptionalAttrib(prepNode, "minLength", typeFn=int, default=1),
                                               cutBefore = getOptionalAttrib(prepNode, "cutBefore", typeFn=str, default=None),

--- a/src/cactus/preprocessor/redMasking.py
+++ b/src/cactus/preprocessor/redMasking.py
@@ -25,7 +25,7 @@ from toil.realtimeLogger import RealtimeLogger
 class RedMaskJob(RoundedJob):
     def __init__(self, fastaID, redOpts, eventName=None, unmask=False):
         memory = cactus_clamp_memory(6*fastaID.size)
-        disk = 3*(fastaID.size)
+        disk = 5*(fastaID.size)
         RoundedJob.__init__(self, memory=memory, disk=disk, preemptable=True)
         self.fastaID = fastaID
         self.redOpts = redOpts
@@ -45,42 +45,43 @@ class RedMaskJob(RoundedJob):
         os.makedirs(red_out_dir)
         raw_fa_path = os.path.join(work_dir, '{}.fa'.format(self.eventName))
         in_fa_path = os.path.join(red_in_dir, '{}.filter.fa'.format(self.eventName))
-        out_fa_path = os.path.join(red_out_dir, '{}.msk'.format(self.eventName))
+        out_fa_path = os.path.join(red_out_dir, '{}.filter.msk'.format(self.eventName))
         fileStore.readGlobalFile(self.fastaID, raw_fa_path)
-
-        # preserve existing masking
-        pre_mask_size = 0
-        if not self.unmask:
-            bed_path = os.path.join(work_dir, '{}.input.masking.bed'.format(self.eventName))
-            cactus_call(parameters=['cactus_softmask2hardmask', '-b', raw_fa_path], outfile=bed_path)
-            pre_mask_size = int(cactus_call(parameters=['awk', '{sum += $3-$2} END {print sum}', bed_path],
-                                            check_output=True, rt_log_cmd=False).strip())
 
         # get rid of small or single-base contigs that might crash Red
         cactus_call(parameters=['cactus_filterRedBreakingSequences', raw_fa_path], outfile=in_fa_path)
 
-        if os.path.getsize(in_fa_path) > 0:                                       
+        if os.path.getsize(in_fa_path) > 0:
+
+            # preserve existing masking
+            pre_mask_size = 0
+            if not self.unmask:
+                bed_path = os.path.join(work_dir, '{}.input.masking.bed'.format(self.eventName))
+                cactus_call(parameters=['cactus_softmask2hardmask', '-b', in_fa_path], outfile=bed_path)
+                pre_mask_size = int(cactus_call(parameters=['awk', '{sum += $3-$2} END {print sum}', bed_path],
+                                                check_output=True, rt_log_cmd=False).strip())            
             # run red
             red_cmd = ['Red', '-gnm', red_in_dir, '-msk', red_out_dir]
             if self.redOpts:
                 red_cmd += self.redOpts.split()
             cactus_call(parameters=red_cmd)
+
+            # merge the exsiting masking back in
+            if not self.unmask:
+                cactus_call(infile=out_fa_path, outfile=out_fa_path + '.remask',
+                            parameters=['cactus_fasta_softmask_intervals.py', '--origin=zero', bed_path])
+                out_fa_path = out_fa_path + '.remask'
+
+                post_mask_size = int(cactus_call(parameters=[['cactus_softmask2hardmask', '-b', out_fa_path],
+                                                             ['awk', '{sum += $3-$2} END {print sum}']],
+                                                 check_output=True, rt_log_cmd=False).strip())
+                RealtimeLogger.info('Red masked {} bp of {}, increasing masking from {} to {}'.format(
+                    post_mask_size - pre_mask_size, self.eventName, pre_mask_size, post_mask_size))
         else:
             RealtimeLogger.info('Skipping Red for {} because contigs are too small'.format(self.eventName))
 
         # put the filtered contigs back
         cactus_call(parameters=['cactus_filterRedBreakingSequences', '-x', raw_fa_path], outfile=out_fa_path,
                     outappend=True)
-
-        # merge the exsiting masking back in
-        if not self.unmask:
-            cactus_call(infile=out_fa_path, outfile=out_fa_path + '.remask',
-                        parameters=['cactus_fasta_softmask_intervals.py', '--origin=zero', bed_path])
-            out_fa_path = out_fa_path + '.remask'
-
-        post_mask_size = int(cactus_call(parameters=[['cactus_softmask2hardmask', '-b', out_fa_path],
-                                                     ['awk', '{sum += $3-$2} END {print sum}']], check_output=True, rt_log_cmd=False).strip())
-        RealtimeLogger.info('Red masked {} bp of {}, increasing masking from {} to {}'.format(
-            post_mask_size - pre_mask_size, self.eventName, pre_mask_size, post_mask_size))
 
         return fileStore.writeGlobalFile(out_fa_path)


### PR DESCRIPTION
I tried to put a cactus ancestor through Red RepeatMasking via the cactus preprocessor and it crashed right away -- something I haven't seen on any real or test data so far.

After some trial and error, it looks like Red will crash if the input contains a contig that is 
* tiny. not sure the exact limit but 20kb seems to work on tests (though on real data it can mask much smaller sequences at least sometimes)
* or really low-information. for example, a contig that is just `N`'s will crash Red no matter how long it is.  

This PR adds a prefilter to catch these cases (it would eventually be nice to get into Red's code to fix it properly).  Contigs that are smaller than `20kb` or which are more than `98%` a single base are filtered out before `Red` then added back in after.  In the second case, the giant monomer runs in the contig are softmasked before being added back.  

