### PR TITLE
Preprocess :start-end samtools-style path ranges in pangenome input

### DIFF
--- a/doc/pangenome.md
+++ b/doc/pangenome.md
@@ -102,6 +102,25 @@ HG002.2  ./HG002.maternal.fa
 CHM13  ./chm13.fa
 ```
 
+### Contig Names
+
+Ideally, the sequence/contig names in the input FASTA files should be as simple as possible. Ex:
+```
+>chr1
+AAAA....
+>chr2
+CCCC....
+etc
+```
+They do not need to be globally unique: the same contig name can be present in more than one input FASTA file.  But the same name can only appear once per file: you cannot have a genome with two `chr1`s (you will get an error almost right away in this case).  Some other things to know about contig names:
+
+
+* If you have a name of the form `HG002#0#chr1`, then `cactus-pangenome` will automatically ignore everything up to and including the last `#` character (leaving just `chr1`).  The sample name and haplotype will be derived from the Sample Name in the seqfile (as described above). 
+* `vg` can sometimes output paths with names like `HG002#0#chr1#0`.  This will be interpreted as `0` and almost surely lead to trouble.  You must manually correct this type of input before running `cactus-pangenome`.
+* Path subranges denoted by suffixes of the form `:start-end` (1-based, inclusive) are now supported (v2.8.1). The subrange information will be properly handled in the final output (VCF,GFA,GBZ etc). 
+* `:` characters in contig names that are not part of subranges will be automatically replaced with `_` in the output, as they can otherwise confuse the pipeline. 
+* Anything after the first space in a contig name is ignored.
+
 ### Reference Sample
 
 The `--reference` option must be used to select a "reference" sample.  This sample will:

--- a/preprocessor/cactus_sanitizeFastaHeaders.c
+++ b/preprocessor/cactus_sanitizeFastaHeaders.c
@@ -96,6 +96,15 @@ void addUniqueFastaPrefix(void* destination, const char *fastaHeader, const char
                 clipped_header = range_header;
             }
         }
+        if (colonpos != NULL) {
+            // : characters apparently cause crashes in and of themselves
+            int64_t n = strlen(clipped_header);
+            for (int64_t i = 0; i < n; ++i) {
+                if (clipped_header[i] == ':') {
+                    clipped_header[i] = '_';
+                }
+            }
+        }
     }
 
     if (stSet_search(header_set, (void*)clipped_header) != NULL) {


### PR DESCRIPTION
`cactus-pangenome` will crash if any of the input fasta contigs have a suffix like `:10-100` denoting a subpath range (a fairly standard annotation that, ex, `samtools faidx` uses -- note it's 1-based end inclusive).   This seems to be because these types of subranges are already being used in GAF path steps coming out of minigraph, which confuses a parsing step in Cactus.  

Not related, but there is already logic to convert subranges to `_sub_9_100` (0-based exclusive end) going into pangenome HALs because the genome browser can't (couldn't?) handle `:` and/or `-`.  

 This PR just bumps this existing logic forward, paths of the form `chr1:10-100` will get converted right away to `chr1_sub_9_100` in `cactus_sanitizeFastaHeaders` -- the end result being 1) the crash is fixed while 2) the subrange information is correctly preserved through to the output.  

resolves #1287