### PR TITLE
cactus-hal2chains makeover

### DIFF
--- a/BIN-INSTALL.md
+++ b/BIN-INSTALL.md
@@ -23,12 +23,12 @@ python3 -m pip install -U -r ./toil-requirement.txt
 ```
 
 Some tools required for `hal2assemblyHub.py`, `cactus-hal2chains` and `cactus-maf2bigmaf` are not included and must be downloaded separately.
-They are `wigToBigWig faToTwoBit bedToBigBed bigBedToBed axtChain pslPosTarget bedSort hgGcPercent mafToBigMaf hgLoadMafSummary`.  More information
+They are `wigToBigWig faToTwoBit bedToBigBed bigBedToBed axtChain pslPosTarget bedSort hgGcPercent mafToBigMaf hgLoadMafSummary hgLoadChain`.  More information
 can be found [here](https://hgdownload.cse.ucsc.edu/admin/exe/).  Note that some may require
 a license for commercial use.  Static binaries are not available, but the following command
 should set them up successfully on many 64 bit Linux systems:
 ```
-cd bin && for i in wigToBigWig faToTwoBit bedToBigBed bigBedToBed axtChain pslPosTarget bedSort hgGcPercent mafToBigMaf hgLoadMafSummary; do wget -q http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/${i}; chmod +x ${i}; done
+cd bin && for i in wigToBigWig faToTwoBit bedToBigBed bigBedToBed axtChain pslPosTarget bedSort hgGcPercent mafToBigMaf hgLoadMafSummary hgLoadChain; do wget -q http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/${i}; chmod +x ${i}; done
 ```
 
 ## Testing

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ENV KENTSRC /home/cactus/submodules/kent/src
 RUN cd /home/cactus && make -j $(nproc)
 
 # download open-licenses kent binaries used by hal for assembly hubs and / or chains
-RUN cd /home/cactus/bin && for i in wigToBigWig faToTwoBit bedToBigBed bigBedToBed axtChain pslPosTarget bedSort hgGcPercent mafToBigMaf hgLoadMafSummary; do wget -q http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/${i}; chmod ugo+x ${i}; done
+RUN cd /home/cactus/bin && for i in wigToBigWig faToTwoBit bedToBigBed bigBedToBed axtChain pslPosTarget bedSort hgGcPercent mafToBigMaf hgLoadMafSummary hgLoadChain; do wget -q http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/${i}; chmod ugo+x ${i}; done
 
 # download tools used for pangenome pipeline
 RUN cd /home/cactus && ./build-tools/downloadPangenomeTools

--- a/doc/progressive.md
+++ b/doc/progressive.md
@@ -245,18 +245,19 @@ The chromosome sizes of the reference genome must be provided as input either di
 
 ### Chains
 
-The [UCSC Chain Format](https://genome.ucsc.edu/goldenPath/help/chain.html) is a concise way to represent pairwise alignments, and is used by the Genome Browser and some of its tools. HAL files can be converted into sets of Chain files using `cactus-hal2chains`.
+The [UCSC Chain Format](https://genome.ucsc.edu/goldenPath/help/chain.html) is a concise way to represent pairwise alignments, and is used by the Genome Browser and some of its tools. HAL files can be converted into sets of Chain files using `cactus-hal2chains`. Use the `--queryGenomes` and `--targetGenomes` flags to specify one or more query and/or target genomes. Chains between all pairs will be computed (so watch out for large alignments!).  If either `--queryGenomes` or `--targetGenomes` is unspecifiefd, then all leaf genomes in the HAL file will be used.
 
 For example
 ```
-cactus-hal2chains ./js ./evolverMammals.hal chains-dir --refGenome simHuman_chr6 
+cactus-hal2chains ./js ./evolverMammals.hal chains-dir --queryGenomes simHuman_chr6 
 ```
 
 will create `./chains-dir` and populate it with a Chain alignment between simHuman and each other leaf genome in evolverMammals.hal.
 
 By default, chains will be created using `halLiftover` [as in CAT](https://github.com/ComparativeGenomicsToolkit/Comparative-Annotation-Toolkit/blob/fc1623da5df1309d2e2f0b9bb0363aaab84708f4/cat/chaining.py#L96-L98). An option `--useHalSynteny` is provided to use that tool instead.
 
-See here for an all-vs-all script to make chains, including BigChain conversion: https://github.com/human-pangenomics/HPRC_Assembly_Hub/blob/main/chains/wdl/snakesonachain.wdl
+In order to view your chains on the UCSC Genome Browser, you need to [convert to bigChain](https://genome.ucsc.edu/goldenPath/help/bigChain.html).  Use the `--bigChain` flag to have `cactus-hal2chains` produce `bigChain.bb` and `bigChain.link.bb` output files in addtion to `chain.gz`.
+
 
 ### CAT
 

--- a/src/cactus/maf/cactus_hal2chains.py
+++ b/src/cactus/maf/cactus_hal2chains.py
@@ -23,14 +23,17 @@ from cactus.shared.common import cactus_override_toil_options
 from cactus.shared.common import cactus_call
 from cactus.shared.common import getOptionalAttrib, findRequiredNode
 from cactus.shared.version import cactus_commit
+from cactus.progressive.multiCactusTree import MultiCactusTree
 from toil.job import Job
 from toil.common import Toil
 from toil.statsAndLogging import logger
 from toil.statsAndLogging import set_logging_from_options
 from toil.realtimeLogger import RealtimeLogger
 from cactus.shared.common import cactus_cpu_count
+from cactus.shared.common import cactus_clamp_memory
 from toil.lib.humanize import bytes2human
 from sonLib.bioio import getTempDirectory
+from sonLib.nxnewick import NXNewick
 
 def main():
     parser = ArgumentParser()
@@ -38,14 +41,18 @@ def main():
 
     parser.add_argument("halFile", help = "HAL file to convert to MAF")
     parser.add_argument("outDir", help = "Output directory")
-
-    parser.add_argument("--refGenome", required=True,
-                        help="name of reference genome (root if empty)",
-                        default=None)
-    parser.add_argument("--targetGenomes",
-                        help="comma-separated (no spaces) list of target "
-                        "genomes (others are excluded) (vist all non-ancestral if empty)",
-                        default=None)
+    parser.add_argument("--targetGenomes", nargs='*',
+                        help="name(s) of target genomes (all leaves if empty).",
+                        default=[])
+    parser.add_argument("--queryGenomes", nargs='*',
+                        help="name(s) of query genomes (all leaves if empty).",
+                        default=[])
+    parser.add_argument("--includeSelfAlignments", action="store_true",
+                        help="include genome-vs-self chains (which are trivial one-block alignments)",
+                        default=False)
+    parser.add_argument("--bigChain", action="store_true",
+                        help="output bigChain.bb and bigChain.link.bb files as well",
+                        default=False)
     parser.add_argument("--useHalSynteny",
                         help="use halSynteny instead of halLiftover. halLiftover is default because that's what CAT uses",
                         action="store_true")
@@ -81,6 +88,8 @@ def main():
         raise RuntimeError('--maxAnchorDistance can only be used with --useHalSynteny')
     if options.minBlockSize and not options.useHalSynteny:
         raise RuntimeError('--minBlockSize can only be used with --useHalSynteny')
+    if options.includeSelfAlignments and options.useHalSynteny:
+        raise RuntimeError('--includeSelfAlignments cannot be used with --useHalSynteny')
     
     # Mess with some toil options to create useful defaults.
     cactus_override_toil_options(options)
@@ -109,10 +118,18 @@ def main():
             chains_id_dict = toil.start(Job.wrapJobFn(hal2chains_workflow, config, options, hal_id))
 
         #export the chains
-        for tgt_genome, chain_id in chains_id_dict.items():
-            clean_name = tgt_genome.replace('#', '.').replace(' ', '.')
-            toil.exportFile(chain_id, makeURL(os.path.join(options.outDir, clean_name + ".chain.gz")))
-        
+        for query_genome in chains_id_dict.keys():
+            clean_query_name = query_genome.replace('#', '.').replace(' ', '.')
+            for target_genome in chains_id_dict[query_genome].keys():                
+                clean_target_name = target_genome.replace('#', '.').replace(' ', '.')
+                chain_id = chains_id_dict[query_genome][target_genome]['chains']
+                toil.exportFile(chain_id, makeURL(os.path.join(options.outDir, clean_query_name + '_vs_' + clean_target_name + ".chain.gz")))
+                if options.bigChain:
+                    bigchain_id = chains_id_dict[query_genome][target_genome]['bigChain']
+                    toil.exportFile(bigchain_id, makeURL(os.path.join(options.outDir, clean_query_name + '_vs_' + clean_target_name + ".bigChain.bb")))
+                    biglink_id = chains_id_dict[query_genome][target_genome]['bigLink']
+                    toil.exportFile(biglink_id, makeURL(os.path.join(options.outDir, clean_query_name + '_vs_' + clean_target_name + ".bigChain.link.bb")))                   
+
     end_time = timeit.default_timer()
     run_time = end_time - start_time
     logger.info("cactus-hal2chains has finished after {} seconds".format(run_time))
@@ -121,14 +138,19 @@ def main():
 def hal2chains_workflow(job, config, options, hal_id):
     root_job = Job()
     job.addChild(root_job)
-    check_tools_job = root_job.addChildJobFn(hal2chains_check_tools)
-    ref_info_job = check_tools_job.addFollowOnJobFn(hal2chains_ref_info, config, options, hal_id)
-    hal2chains_all_job = ref_info_job.addFollowOnJobFn(hal2chains_all, config, options, hal_id, ref_info_job.rv())
+    check_tools_job = root_job.addChildJobFn(hal2chains_check_tools, options)
+    get_genomes_job = check_tools_job.addFollowOnJobFn(hal2chains_get_genomes, config, options, hal_id)
+    leaf_genomes = get_genomes_job.rv()
+    chrom_info_job = get_genomes_job.addFollowOnJobFn(hal2chains_chrom_info_all, config, options, hal_id, leaf_genomes)
+    hal2chains_all_job = chrom_info_job.addFollowOnJobFn(hal2chains_all, config, options, hal_id, chrom_info_job.rv())
     return hal2chains_all_job.rv()
 
-def hal2chains_check_tools(job):
+def hal2chains_check_tools(job, options):
     """ make sure we have the required ucsc commands available on the PATH"""
-    for tool in ['axtChain', 'faToTwoBit', 'pslPosTarget']:
+    tools = ['axtChain', 'faToTwoBit', 'pslPosTarget']
+    if options.bigChain:
+        tools += ['hgLoadChain', 'bedToBigBed']
+    for tool in tools:
         try:
             cactus_call(parameters=[tool])
         except Exception as e:
@@ -136,86 +158,147 @@ def hal2chains_check_tools(job):
             if "usage:" in str(e):
                 continue
         raise RuntimeError('Required tool, {}, not found in PATH. Please download it with wget -q https://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/{}'.format(tool, tool))
+
+def hal2chains_get_genomes(job, config, options, hal_id):    
+    """ get the genomes in the hal file"""
+    work_dir = job.fileStore.getLocalTempDir()
+    hal_path = os.path.join(work_dir, os.path.basename(options.halFile.replace(' ', '.')))
+    RealtimeLogger.info("Reading HAL file from job store to {}".format(hal_path))    
+    job.fileStore.readGlobalFile(hal_id, hal_path)
+    tree_str = cactus_call(parameters=['halStats', hal_path, '--tree'], check_output=True).strip()
+    mc_tree = MultiCactusTree(NXNewick().parseString(tree_str, addImpliedRoots=False))
+    graph_event = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap"), "assemblyName", default="_MINIGRAPH_")
+    leaf_genomes = []
+    anc_genomes = []
+    for node in mc_tree.preOrderTraversal():
+        if node == graph_event:
+            continue
+        if mc_tree.isLeaf(node):
+            leaf_genomes.append(mc_tree.getName(node))
+        else:
+            anc_genomes.append(mc_tree.getName(node))
+
+    if options.targetGenomes:
+        for input_genome in options.targetGenomes:
+            if input_genome not in leaf_genomes and input_genome not in anc_genomes:
+                raise RuntimeError('Input --targetGenomes {} not found in HAL file'.format(input_genome))
+
+    if options.queryGenomes:
+        for input_genome in options.queryGenomes:
+            if input_genome not in leaf_genomes and input_genome not in anc_genomes:
+                raise RuntimeError('Input --queryGenomes {} not found in HAL file'.format(input_genome))
             
-def hal2chains_ref_info(job, config, options, hal_id):
-    """ get the BED and 2bit file for the reference genome from the hal """
+    return leaf_genomes
+    
+def hal2chains_chrom_info(job, config, options, hal_id, genome):
+    """ get the BED and 2bit file for the genome from the hal """
     work_dir = job.fileStore.getLocalTempDir()
     hal_path = os.path.join(work_dir, os.path.basename(options.halFile.replace(' ', '.')))
     RealtimeLogger.info("Reading HAL file from job store to {}".format(hal_path))    
     job.fileStore.readGlobalFile(hal_id, hal_path)
     RealtimeLogger.info("Computing chromosomes and 2bit ref sequence")
 
-    bed_path = os.path.join(work_dir, options.refGenome + '.bed')
-    cactus_call(parameters=[['halStats', hal_path, '--chromSizes', options.refGenome],
+    bed_path = os.path.join(work_dir, genome + '.bed')
+    cactus_call(parameters=[['halStats', hal_path, '--chromSizes', genome],
                             ['awk', '{{print $1 "\t0\t" $2}}']],
                 outfile=bed_path)
+    if options.bigChain:
+        sizes_path = os.path.join(work_dir, genome + '.chrom.sizes')
+        cactus_call(parameters=['halStats', hal_path, '--chromSizes', genome], outfile=sizes_path)
 
-    tbit_path = os.path.join(work_dir, options.refGenome + '.2bit')    
-    cactus_call(parameters=[['hal2fasta', hal_path, options.refGenome],
+    tbit_path = os.path.join(work_dir, genome + '.2bit')    
+    cactus_call(parameters=[['hal2fasta', hal_path, genome],
                             ['faToTwoBit', 'stdin', tbit_path]])
 
-    genomes=cactus_call(parameters=['halStats', '--genomes', hal_path], check_output=True).split()
+    out_dict = { 'bed' : job.fileStore.writeGlobalFile(bed_path),
+                 '2bit' : job.fileStore.writeGlobalFile(tbit_path) }
+    if options.bigChain:
+        out_dict['sizes'] = job.fileStore.writeGlobalFile(sizes_path)
+    return out_dict
 
-    graph_event = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap"), "assemblyName", default="_MINIGRAPH_")
-    leaf_genomes = []
-    for genome in genomes:
-        if genome != options.refGenome and genome != graph_event and \
-           not cactus_call(parameters=['halStats', hal_path, '--children', genome], check_output=True).strip():
-            leaf_genomes.append(genome)
-    
-    return { 'bed' : job.fileStore.writeGlobalFile(bed_path),
-             '2bit' : job.fileStore.writeGlobalFile(tbit_path),
-             'genomes' : genomes,
-             'leaf_genomes' : leaf_genomes }
+def hal2chains_chrom_info_all(job, config, options, hal_id, genomes):
+    """ get the 2bit and chrom sizes of every relevant genome"""
 
-def hal2chains_all(job, config, options, hal_id, ref_info):
+    # TODO: this is gonna fall down on huge hal files because it runs a separate job
+    # for each pair, and each job is going to require copying the full hal.  only work-around
+    # would be to do something like cacts-hal2maf where jobs are done in multithread batches...
+
+    # default query / target genome sets to all leaves if they weren't input
+    if not options.queryGenomes:
+        options.queryGenomes = genomes
+    if not options.targetGenomes:
+        options.targetGenomes = genomes
+
+    chrom_info_dict = {}
+    for genome in set(options.queryGenomes + options.targetGenomes):
+        chrom_info_dict[genome] = job.addChildJobFn(hal2chains_chrom_info, config, options, hal_id, genome).rv()
+    return chrom_info_dict        
+
+def hal2chains_all(job, config, options, hal_id, chrom_info_dict):    
     """ convert all the genomes in parallel """
-    tgt_genomes = []
-    hal_genomes = set(ref_info['genomes'])
-    if options.targetGenomes:
-        for opt_target_genome in options.targetGenomes.split(','):
-            if opt_target_genome not in hal_genomes:
-                raise RuntimeError('--targetGenome {} not found in HAL'.format(opt_target_genome))
-            else:
-                tgt_genomes.append(opt_target_genome)
-    else:
-        tgt_genomes = ref_info['leaf_genomes']
+
+    # default query / target genome sets to all leaves if they weren't input
+    if not options.queryGenomes:
+        options.queryGenomes = list(chrom_info_dict.keys())
+    if not options.targetGenomes:
+        options.targetGenomes = list(chrom_info_dict.keys())
+
+    # TODO: this is gonna fall down on huge hal files because it runs a separate job
+    # for each pair, and each job is going to require copying the full hal.  only work-around
+    # would be to do something like cacts-hal2maf where jobs are done in multithread batches...
         
-    chains_output_dict = {}
-    for tgt_genome in tgt_genomes:
-        chains_job = job.addChildJobFn(hal2chains_genome, config, options, hal_id, ref_info, tgt_genome,
-                                       disk=int(hal_id.size * 1.2),
-                                       memory=(ref_info['2bit'].size * 10))
-        chains_output_dict[tgt_genome] = chains_job.rv()
-    return chains_output_dict
+    output_dict = {}
+    hal_mem = hal_id.size if options.inMemory else int(hal_id.size / 10)
+    for query_genome in options.queryGenomes:
+        output_dict[query_genome] = {}
+        query_info = chrom_info_dict[query_genome]
+        for target_genome in options.targetGenomes:
+            target_info = chrom_info_dict[target_genome]
+            if options.includeSelfAlignments or target_genome != query_genome:
+                chains_job = job.addChildJobFn(hal2chains_genome, config, options, hal_id,
+                                               query_genome, query_info, target_genome,
+                                               disk=int(hal_id.size * 1.2) + query_info['2bit'].size * 10 + target_info['2bit'].size * 10,
+                                               memory=cactus_clamp_memory(query_info['2bit'].size * 10 + target_info['2bit'].size * 10 + hal_mem))
+                output_dict[query_genome][target_genome] = {}
+                output_dict[query_genome][target_genome]['chains'] = chains_job.rv()
+                if options.bigChain:
+                    bigchains_job = chains_job.addFollowOnJobFn(chain2bigchain, options, query_genome,
+                                                                target_genome, chrom_info_dict[target_genome], chains_job.rv(),
+                                                                disk = query_info['2bit'].size * 20 + target_info['2bit'].size * 20,
+                                                                memory = cactus_clamp_memory(query_info['2bit'].size * 10 + target_info['2bit'].size * 10))
+                    output_dict[query_genome][target_genome]['bigChain'] = bigchains_job.rv(0)
+                    output_dict[query_genome][target_genome]['bigLink'] = bigchains_job.rv(1)
+
+    return output_dict
+
     
-def hal2chains_genome(job, config, options, hal_id, ref_info, tgt_genome):
+def hal2chains_genome(job, config, options, hal_id, query_genome, query_info, target_genome):
     """ convert one genome to chains """
     work_dir = job.fileStore.getLocalTempDir()
     hal_path = os.path.join(work_dir, os.path.basename(options.halFile.replace(' ', '.')))
     RealtimeLogger.info("Reading HAL file from job store to {}".format(hal_path))    
     job.fileStore.readGlobalFile(hal_id, hal_path)
-    RealtimeLogger.info("Computing chains for {}".format(tgt_genome))
+    RealtimeLogger.info("Computing chains for query {} to target {}".format(query_genome, target_genome))
 
-    bed_path = os.path.join(work_dir, options.refGenome + '.bed')
-    job.fileStore.readGlobalFile(ref_info['bed'], bed_path)
-    ref_2bit_path = os.path.join(work_dir, options.refGenome + '.2bit')
-    job.fileStore.readGlobalFile(ref_info['2bit'], ref_2bit_path)
+    bed_path = os.path.join(work_dir, query_genome + '.bed')
+    job.fileStore.readGlobalFile(query_info['bed'], bed_path)
+    query_2bit_path = os.path.join(work_dir, query_genome + '.2bit')
+    job.fileStore.readGlobalFile(query_info['2bit'], query_2bit_path)
 
     # we need the target sequence for axtChain
-    tgt_2bit_path = os.path.join(work_dir, tgt_genome + '.2bit')    
-    cactus_call(parameters=[['hal2fasta', hal_path, tgt_genome],
-                            ['faToTwoBit', 'stdin', tgt_2bit_path]])
+    target_2bit_path = os.path.join(work_dir, target_genome + '.2bit')    
+    cactus_call(parameters=[['hal2fasta', hal_path, target_genome],
+                            ['faToTwoBit', 'stdin', target_2bit_path]])
 
     # the output
-    tgt_chain_path = os.path.join(work_dir, tgt_genome + '.chain.gz')
+    query_chain_path = os.path.join(work_dir, query_genome + '_vs_' + target_genome + '.chain.gz')
 
     # make our hal -> psl -> chain piped command
 
     cmd = []
 
     if options.useHalSynteny:
-        hal_synteny_cmd = ['halSynteny', hal_path, '/dev/stdout', '--queryGenome', options.refGenome, '--targetGenome', tgt_genome]
+        hal_synteny_cmd = ['halSynteny', hal_path, '/dev/stdout', '--queryGenome', query_genome, '--targetGenome', target_genome]
         if options.inMemory:
             hal_synteny_cmd.append('--inMemory')
         if options.maxAnchorDistance:
@@ -224,18 +307,102 @@ def hal2chains_genome(job, config, options, hal_id, ref_info, tgt_genome):
             hal_synteny_cmd += ['--minBlockSize', str(options.minBlockSize)]
         cmd.append(hal_synteny_cmd)
     else:
-        hal_liftover_cmd = ['halLiftover', hal_path, options.refGenome, bed_path, tgt_genome, '/dev/stdout', '--outPSL']
+        hal_liftover_cmd = ['halLiftover', hal_path, query_genome, bed_path, target_genome, '/dev/stdout', '--outPSL']
         if options.inMemory:
             hal_liftover_cmd.append('--inMemory')
         cmd.append(hal_liftover_cmd)
 
     cmd.append(['pslPosTarget', '/dev/stdin', '/dev/stdout'])
 
-    cmd.append(['axtChain', '-psl', '-verbose=0', '-linearGap=medium', '/dev/stdin', tgt_2bit_path, ref_2bit_path, '/dev/stdout'])
+    cmd.append(['axtChain', '-psl', '-verbose=0', '-linearGap=medium', '/dev/stdin', target_2bit_path, query_2bit_path, '/dev/stdout'])
 
     cmd.append(['gzip'])
 
-    cactus_call(parameters=cmd, outfile = tgt_chain_path)
+    cactus_call(parameters=cmd, outfile = query_chain_path)
 
-    return job.fileStore.writeGlobalFile(tgt_chain_path)
-            
+    return job.fileStore.writeGlobalFile(query_chain_path)
+
+# https://genome.ucsc.edu/goldenPath/help/examples/bigChain.as
+bigChain_as = \
+'''table bigChain
+"bigChain pairwise alignment"
+    (
+    string chrom;       "Reference sequence chromosome or scaffold"
+    uint   chromStart;  "Start position in chromosome"
+    uint   chromEnd;    "End position in chromosome"
+    string name;        "Name or ID of item, ideally both human readable and unique"
+    uint score;         "Score (0-1000)"
+    char[1] strand;     "+ or - for strand"
+    uint tSize;         "size of target sequence"
+    string qName;       "name of query sequence"
+    uint qSize;         "size of query sequence"
+    uint qStart;        "start of alignment on query sequence"
+    uint qEnd;          "end of alignment on query sequence"
+    uint chainScore;    "score from chain"
+    )
+'''
+
+# https://genome.ucsc.edu/goldenPath/help/examples/bigLink.as
+bigLink_as = \
+'''
+table bigLink
+"bigLink pairwise alignment"
+    (
+    string chrom;       "Reference sequence chromosome or scaffold"
+    uint   chromStart;  "Start position in chromosome"
+    uint   chromEnd;    "End position in chromosome"
+    string name;        "Name or ID of item, ideally both human readable and unique"
+    uint qStart;        "start of alignment on query sequence"
+    )
+'''
+
+def chain2bigchain(job, options, query_genome, target_genome, target_info, chain_id):
+    """ convert the chain to big chain. from https://genome.ucsc.edu/goldenPath/help/bigChain.html """
+    work_dir = job.fileStore.getLocalTempDir()
+    chain_path = os.path.join(work_dir, query_genome + '_vs_' + target_genome + '.chain.gz')
+    job.fileStore.readGlobalFile(chain_id, chain_path)
+    target_sizes_path = os.path.join(work_dir, target_genome + '.chrom.sizes')
+    job.fileStore.readGlobalFile(target_info['sizes'], target_sizes_path)
+
+    # unzip the chains
+    uz_chain_path = chain_path[:-3]
+    cactus_call(parameters=['gzip', '-dc', chain_path], outfile=uz_chain_path)
+
+    # make the bigChain.as file
+    bigchain_as_path = os.path.join(work_dir, 'bigChain.as')
+    with open(bigchain_as_path, 'w') as as_file:
+        as_file.write(bigChain_as)
+
+    # Use the hgLoadChain utility to generate the chain.tab and link.tab files needed to create the bigChain file:
+    cactus_call(parameters=['hgLoadChain', '-noBin', '-test', target_genome, 'bigChain', uz_chain_path])
+
+    # Create the bigChain file from your input chain file using a combination of sed, awk and the bedToBigBed utility:
+    bigchain_path = os.path.join(work_dir, query_genome + '_vs_' + target_genome + '.bigChain')
+    cactus_call(parameters=[['sed', 's/\\.000000//', 'chain.tab'],
+                            ['awk', 'BEGIN {OFS=\"\\t\"} {print $2, $4, $5, $11, 1000, $8, $3, $6, $7, $9, $10, $1}']],
+                outfile=bigchain_path)
+
+    bigchain_bb_path = bigchain_path + '.bb'
+    cactus_call(parameters=['bedToBigBed', '-type=bed6+6', '-as={}'.format(bigchain_as_path),
+                            '-tab', bigchain_path, target_sizes_path, bigchain_bb_path])
+
+    # make the bigLink.as file
+    biglink_as_path = os.path.join(work_dir, 'bigLink.as')
+    with open(biglink_as_path, 'w') as as_file:
+        as_file.write(bigLink_as)
+
+    # To display your date in the Genome Browser, you must also create a binary indexed link file to accompany your bigChain file:
+    biglink_path = bigchain_path + '.link'
+    cactus_call(parameters=[['awk', 'BEGIN {OFS=\"\\t\"} {print $1, $2, $3, $5, $4}', 'link.tab'],
+                            ['sort', '-k1,1', '-k2,2n']],
+                outfile=biglink_path)
+
+    biglink_bb_path = biglink_path + '.bb'
+    cactus_call(parameters=['bedToBigBed', '-type=bed4+1', 'as={}'.format(biglink_as_path),
+                            '-tab', biglink_path, target_sizes_path, biglink_bb_path])
+
+    return (job.fileStore.writeGlobalFile(bigchain_bb_path), job.fileStore.writeGlobalFile(biglink_bb_path))
+    
+         
+
+


### PR DESCRIPTION
This PR adds some basic functionality to `cactus-hal2chains`
* ability to do `all-vs-all` (could previously only do one-vs-all)
* option to output bigChain.bb and bigChain.link.bb as needed for the browser

It also fixes up the terminology.  As pointed out by #1273 the `--targetGenomes` option was backwards with respect to how it's defined in the chain format.  The option names are fixed/changed so that `--queryGenomes` and `--targetGenomes` refer to what you get in the output.  

This script will still be very inefficient for big hal files on clusters (or anwyhwere without file caching), because the hal file will need to be copied to a local job for each pairwise comparison.  I think the only work-around is to implement a batching system like in `cactus-hal2maf` eventually...