### PR TITLE
deprecated cactus-maf2bigmaf --chromSizes

### DIFF
--- a/doc/progressive.md
+++ b/doc/progressive.md
@@ -229,7 +229,7 @@ cactus-maf2bigmaf ./js ./evolverMammals.maf.gz ./evolverMammals.bigmaf.bb --refG
 
 This will produce the BigMaf file `evolverMammals.bigmaf.bb` along with the summary file `evolverMammals.bigmaf.summary.bb` which is used by the browser for zoomed out summary display.
 
-The chromosome sizes of the reference genome must be provided as input either directly with `--chromSizes` or via the original hal file via `--halFile`.
+The chromosome sizes of the reference genome must be provided via the original hal file via `--halFile`.
 
 ### Chains
 

--- a/src/cactus/maf/cactus_maf2bigmaf.py
+++ b/src/cactus/maf/cactus_maf2bigmaf.py
@@ -42,8 +42,7 @@ def main():
     parser.add_argument("--refGenome", help = "reference genome to get chrom sizes from", required=True)
 
     
-    parser.add_argument("--halFile", help = "HAL file to use to get chrom sizes from. Will also be used to work around dots in genome names")
-    parser.add_argument("--chromSizes", help = "File of chromosome sizes (can be obtained with halStats --chromSizes)")
+    parser.add_argument("--halFile", help = "HAL file to use to get chrom sizes from. Will also be used to work around dots in genome names", required=True)
     
     #Progressive Cactus Options
     parser.add_argument("--configFile", dest="configFile",
@@ -64,8 +63,6 @@ def main():
     set_logging_from_options(options)
     enableDumpStack()
 
-    if bool(options.halFile) == bool(options.chromSizes):
-        raise RuntimeError('Either --chromSizes or --halFile must be used to get the chromosome sizes, not both')
     if not options.outFile.endswith('.bb'):
         raise RuntimeError('output file path must end with .bb')
     
@@ -89,16 +86,12 @@ def main():
             
             logger.info("Importing {}".format(options.mafFile))
             maf_id = toil.importFile(options.mafFile)
-            chrom_sizes_id = None
-            if options.chromSizes:
-                logger.info("Importing {}".format(options.chromSizes))
-                chrom_sizes_id = toil.importFile(options.chromSizes)
             hal_id = None
             if options.halFile:
                 logger.info("Importing {}".format(options.halFile))
                 hal_id = toil.importFile(options.halFile)
                 
-            bigmaf_id_dict = toil.start(Job.wrapJobFn(maf2bigmaf_workflow, config, options, maf_id, chrom_sizes_id, hal_id))
+            bigmaf_id_dict = toil.start(Job.wrapJobFn(maf2bigmaf_workflow, config, options, maf_id, hal_id))
 
         #export the big maf
         out_bm_path = makeURL(options.outFile)
@@ -114,27 +107,23 @@ def main():
     logger.info("cactus-maf2bigmaf has finished after {} seconds".format(run_time))
 
 
-def maf2bigmaf_workflow(job, config, options, maf_id, chrom_sizes_id, hal_id):
+def maf2bigmaf_workflow(job, config, options, maf_id, hal_id):
     root_job = Job()
     job.addChild(root_job)
     check_tools_job = root_job.addChildJobFn(maf2bigmaf_check_tools)
     genomes_list = None
-    if not chrom_sizes_id:
-        chrom_sizes_job = check_tools_job.addFollowOnJobFn(maf2bigmaf_chrom_sizes, options, hal_id,
-                                                           disk=hal_id.size)
-        prev_job = chrom_sizes_job
-        chrom_sizes_id = chrom_sizes_job.rv(0)
-        genomes_list = chrom_sizes_job.rv(1)
-    else:
-        prev_job = check_tools_job
+    chrom_sizes_job = check_tools_job.addFollowOnJobFn(maf2bigmaf_chrom_sizes, options, hal_id,
+                                                       disk=hal_id.size)
+    chrom_sizes_id = chrom_sizes_job.rv(0)
+    genomes_list = chrom_sizes_job.rv(1)
     if options.mafFile.endswith('.gz'):
         disk_mult = 7
     else:
         disk_mult = 3
-    bigmaf_job = prev_job.addFollowOnJobFn(maf2bigmaf, maf_id, chrom_sizes_id, genomes_list, options,
+    bigmaf_job = chrom_sizes_job.addFollowOnJobFn(maf2bigmaf, maf_id, chrom_sizes_id, genomes_list, options,
                                            disk=disk_mult * maf_id.size,
                                            memory=min(2**32, max(maf_id.size, 2**36)))
-    bigmaf_summary_job = prev_job.addFollowOnJobFn(maf2bigmaf_summary, maf_id, chrom_sizes_id, genomes_list, options,
+    bigmaf_summary_job = chrom_sizes_job.addFollowOnJobFn(maf2bigmaf_summary, maf_id, chrom_sizes_id, genomes_list, options,
                                                    disk=2 * maf_id.size,
                                                    memory=min(2**32, max(maf_id.size, 2**36)))
 


### PR DESCRIPTION
Bigmaf conversion is very sensitive to "." characters in genome names. `cactus-maf2bigmaf` hacks around this using genome names in the halfile.  But this logic doesn't work when running withpout the halfile.   Simplest fix seems to just make the hal file mandatory, which is what this PR does. 

Resolves #1332