### PR TITLE
Use bigChain.as from kent src

### DIFF
--- a/src/cactus/maf/cactus_hal2chains.py
+++ b/src/cactus/maf/cactus_hal2chains.py
@@ -340,7 +340,7 @@ def hal2chains_genome(job, config, options, hal_id, query_genome, query_info, ta
 
     return job.fileStore.writeGlobalFile(query_chain_path)
 
-# https://genome.ucsc.edu/goldenPath/help/examples/bigChain.as
+# https://raw.githubusercontent.com/ucscGenomeBrowser/kent/cb3cd0e9c5b9006b7d316df7905faa516f880c6b/src/hg/lib/bigChain.as
 bigChain_as = \
 '''table bigChain
 "bigChain pairwise alignment"
@@ -356,7 +356,7 @@ bigChain_as = \
     uint qSize;         "size of query sequence"
     uint qStart;        "start of alignment on query sequence"
     uint qEnd;          "end of alignment on query sequence"
-    uint chainScore;    "score from chain"
+    double chainScore;    "score from chain"
     )
 '''
 

--- a/src/cactus/maf/cactus_hal2chains.py
+++ b/src/cactus/maf/cactus_hal2chains.py
@@ -396,10 +396,8 @@ def chain2bigchain(job, options, query_genome, target_genome, target_info, chain
 
     # Create the bigChain file from your input chain file using a combination of sed, awk and the bedToBigBed utility:
     bigchain_path = os.path.join(work_dir, target_genome + '_vs_' + query_genome + '.bigChain')
-    # Note we cap the score to avoid "integer overflowed, limit=4294967295 in field 12.." error in bedToBigBed
-    # but it seems suspicious to have to do this...
     cactus_call(parameters=[['sed', 's/\\.000000//', 'chain.tab'],
-                            ['awk', 'BEGIN {OFS=\"\\t\"} {print $2, $4, $5, $11, 1000, $8, $3, $6, $7, $9, $10, ($1 < 4294967295 ? $1 : 4294967295)}']],
+                            ['awk', 'BEGIN {OFS=\"\\t\"} {print $2, $4, $5, $11, 1000, $8, $3, $6, $7, $9, $10, $1}']],
                 outfile=bigchain_path)
 
     bigchain_bb_path = bigchain_path + '.bb'


### PR DESCRIPTION
Apparently the BigChain documentation https://genome.ucsc.edu/goldenPath/help/bigChain.html and https://genome.ucsc.edu/goldenPath/help/examples/bigChain.as is wrong about `chainScore` being a `uint`.  Which explains a lot, because `bedToBigBed` fails with an `integer overflowed, limit=4294967295 ...` whenever trying to produce any kind of chains at scale.  I'd previously hacked `cactus-hal2chains` to clamp this before bigBed conversion, but @diekhans has pointed me to the [official bigChain.as](https://raw.githubusercontent.com/ucscGenomeBrowser/kent/cb3cd0e9c5b9006b7d316df7905faa516f880c6b/src/hg/lib/bigChain.as) which uses a `double` so this PR removes the clamp and switches to using this version. 