### PR TITLE
Fix cactus-hal2maf --binariesMode docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ evolver_test_decomposed_docker: all ${CWD}/test/mammals-truth.maf
 	PYTHONPATH="${CWD}/submodules/" CACTUS_DOCKER_ORG=evolvertestdocker CACTUS_USE_LATEST=1 ${PYTHON} -m pytest ${pytestOpts} -s test/evolverTest.py::TestCase::testEvolverDecomposedDocker
 
 evolver_test_docker: all ${CWD}/test/mammals-truth.maf
-	PYTHONPATH="${CWD}/submodules/" CACTUS_BINARIES_MODE=local CACTUS_DOCKER_MODE=0 ${PYTHON} -m pytest ${pytestOpts} -s test/evolverTest.py::TestCase::testEvolverDocker
+	PYTHONPATH="${CWD}/submodules/" CACTUS_BINARIES_MODE=local ${PYTHON} -m pytest ${pytestOpts} -s test/evolverTest.py::TestCase::testEvolverDocker
 
 evolver_test_prepare_no_outgroup_docker: all ${CWD}/test/mammals-truth.maf
 #note make docker needs to be run beforehand

--- a/src/cactus/maf/cactus_hal2maf.py
+++ b/src/cactus/maf/cactus_hal2maf.py
@@ -444,7 +444,7 @@ def taf_cmd(hal_path, chunk, chunk_num, genome_list_path, sed_script_paths, opti
     if genome_list_path:
         # note, using mafRowOrderer instead of taffy sort because latter does not keep reference row
         # (also, using taffy in this spot requires roundtrip maf-taf-maf tho that can be refactored away)
-        cmd += ' | {} mafRowOrderer -m - --order-file {}{} 2> {}.sort.time'.format(time_cmd, genome_list_path, time_end, chunk_num)
+        cmd += ' | {} mafRowOrderer -m - --order-file {}{} 2> {}.sort.time'.format(time_cmd, os.path.basename(genome_list_path), time_end, chunk_num)
     if sed_script_paths:
         # rename to original, since it needs to be compatible with hal in next step
         cmd += ' | sed -f {}'.format(os.path.basename(sed_script_paths[1]))
@@ -472,10 +472,10 @@ def taf_cmd(hal_path, chunk, chunk_num, genome_list_path, sed_script_paths, opti
         cmd += ' | maf_stream merge_dups consensus'
         # need to resort after merge_dups
         if genome_list_path:
-            cmd += ' | mafRowOrderer -m - --order-file {}'.format(genome_list_path)
+            cmd += ' | mafRowOrderer -m - --order-file {}'.format(os.path.basename(genome_list_path))
     if sed_script_paths:
         #rename back to original names
-        cmd += ' | sed -f {}'.format(sed_script_paths[1])
+        cmd += ' | sed -f {}'.format(os.path.basename(sed_script_paths[1]))
     if chunk_num != 0:
         cmd += ' | grep -v ^#'
     if options.outputMAF.endswith('.gz'):

--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -735,7 +735,7 @@ class TestCase(unittest.TestCase):
                 self.assertGreaterEqual(int(oval[i]), int(val[i]) - delta)
                 self.assertLessEqual(int(oval[i]), int(val[i]) + delta)
 
-    def _check_maf_accuracy(self, halPath, delta, dataset="mammals"):
+    def _check_maf_accuracy(self, halPath, delta, dataset="mammals", binariesMode="local"):
         """ Compare mafComparator output of evolver mammals to baseline
         """
         assert dataset in ('mammals', 'primates')
@@ -746,16 +746,16 @@ class TestCase(unittest.TestCase):
 
         # run mafComparator on the evolver output
         subprocess.check_call(['cactus-hal2maf', self._job_store('h2m'), halPath,  halPath + '.maf', '--chunkSize', '10000', '--batchCount', '2',
-                               '--refGenome', 'Anc0', '--index'], shell=False)
+                               '--refGenome', 'Anc0', '--index', '--binariesMode', binariesMode], shell=False)
         self.assertGreaterEqual(os.path.getsize(halPath + '.maf.tai'), 50)        
 
         # run it with --dupeMode consensus just to make sure it doesn't crash
         subprocess.check_call(['cactus-hal2maf', self._job_store('h2m'), halPath,  halPath + '.consensus.maf.gz', '--chunkSize', '10000', '--batchCount', '2',
-                               '--refGenome', 'Anc0', '--dupeMode', 'consensus'], shell=False)
+                               '--refGenome', 'Anc0', '--dupeMode', 'consensus', '--binariesMode', binariesMode], shell=False)
 
         # run it with --coverage just to make sure it doesn't crash
         subprocess.check_call(['cactus-hal2maf', self._job_store('h2m'), halPath,  halPath + '.taftest.taf.gz', '--chunkSize', '10000', '--batchCount', '2',
-                               '--refGenome', 'Anc0', '--coverage'], shell=False)
+                               '--refGenome', 'Anc0', '--coverage', '--binariesMode', binariesMode], shell=False)
         self.assertGreaterEqual(os.path.getsize(halPath + '.taftest.taf.gz'), 5000)
         self.assertGreaterEqual(os.path.getsize(halPath + '.taftest.taf.gz.cov.tsv'), 50)        
 
@@ -802,7 +802,8 @@ class TestCase(unittest.TestCase):
                 subprocess.check_call(cmd, shell=False)
 
             ranges_opt_file = os.path.join(self.tempDir, 'ranges-opt.maf')
-            cmd = ['cactus-hal2maf', self._job_store('h2m'), halPath, ranges_opt_file, '--refGenome', 'simHuman_chr6', '--chunkSize', '500']
+            cmd = ['cactus-hal2maf', self._job_store('h2m'), halPath, ranges_opt_file, '--refGenome', 'simHuman_chr6', '--chunkSize', '500',
+                   '--binariesMode', binariesMode]
             cmd += ['--refSequence'] + [r[0] for r in ranges]
             cmd += ['--start'] + [str(r[1]) for r in ranges]
             cmd += ['--length'] + [str(r[2] - r[1]) for r in ranges]
@@ -822,7 +823,7 @@ class TestCase(unittest.TestCase):
                 for seq, start, end in ranges:
                     bed_file.write('{}\t{}\t{}\n'.format(seq, start, end))
             subprocess.check_call(['cactus-hal2maf', self._job_store('h2m'), halPath, ranges_bed_file, '--refGenome', 'simHuman_chr6',
-                                   '--chunkSize', '699', '--bedRanges', ranges_bed_input, '--raw'], shell=False)
+                                   '--chunkSize', '699', '--bedRanges', ranges_bed_input, '--raw', '--binariesMode', binariesMode], shell=False)
 
             subprocess.check_call(['bin/mafComparator', '--maf1', ranges_bed_file, '--maf2', ranges_truth_file, '--samples', '100000000', '--out', halPath + 'comp_bed.xml'])
             bed_acc = parse_mafcomp_output(halPath + 'comp_bed.xml', ranges_truth_file)
@@ -936,7 +937,7 @@ class TestCase(unittest.TestCase):
         # check the output
         #self._check_stats(self._out_hal("docker"), delta_pct=0.25)
         #self._check_coverage(self._out_hal("docker"), delta_pct=0.20)
-        self._check_maf_accuracy(self._out_hal("docker"), delta=(0.05,0.13))
+        self._check_maf_accuracy(self._out_hal("docker"), delta=(0.05,0.13), binariesMode="docker")
 
     def testEvolverInDocker(self):
         """ Check that the output of halStats on a hal file produced by running cactus in docker


### PR DESCRIPTION
Today I learned that `cactus-hal2maf --binariesMode docker` isn't covered by the automatic tests... with predictable results. 

This PR fixes the tests and `cactus-hal2maf` which has a recentish path-naming bug that stops it from working with docker binaries (but not inside docker images or with local binaries).

Resolves #1349