### PR TITLE
add vcfwave and bcftools norm

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ variables:
 before_script:
   - whoami
   - sudo apt-get -q -y update
-  - sudo apt-get -q -y install --no-upgrade bcftools parallel libdeflate-dev cmake libjemalloc-dev python3-distutils
+  - sudo apt-get -q -y install --no-upgrade bcftools parallel libdeflate-dev cmake libjemalloc-dev python3-distutils pybind11-dev autoconf libzstd-dev libhts-dev
   - startdocker || true
   - docker info
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ RUN mkdir /home/cactus && mkdir /home/cactus/lib
 COPY --from=builder /home/cactus/cactus_env /home/cactus/cactus_env
 COPY --from=builder /home/cactus/hal_lib/hal /home/cactus/hal
 COPY --from=builder /home/cactus/bin /home/cactus/bin
-COPY --from=builder /home/cactus/bin/*.so* /home/cactus/lib
+COPY --from=builder /home/cactus/lib/*.so* /home/cactus/lib
 
 # update the environment
 ENV PATH="/home/cactus/cactus_env/bin:/home/cactus/bin:$PATH"

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,14 +69,16 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
 RUN bash -c "if ! command -v catchsegv > /dev/null; then apt-get install glibc-tools; fi"
 
 # copy cactus runtime essentials (note: important cactus_env keeps its path)
-RUN mkdir /home/cactus
+RUN mkdir /home/cactus && mkdir /home/cactus/lib
 COPY --from=builder /home/cactus/cactus_env /home/cactus/cactus_env
 COPY --from=builder /home/cactus/hal_lib/hal /home/cactus/hal
 COPY --from=builder /home/cactus/bin /home/cactus/bin
+COPY --from=builder /home/cactus/bin/*.so* /home/cactus/lib
 
 # update the environment
 ENV PATH="/home/cactus/cactus_env/bin:/home/cactus/bin:$PATH"
 ENV PYTHONPATH="/home/cactus"
+ENV LD_LIBRARY_PATH="/home/cactus/lib:$LD_LIBRARY_PATH"
 
 # sanity check to make sure cactus at least runs
 RUN cactus --help

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN rm -rf /home/cactus/hal_lib && \
 FROM quay.io/comparative-genomics-toolkit/ubuntu:22.04
 
 # apt dependencies for runtime
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends git python3 python3-pip python3-distutils zlib1g libbz2-1.0 net-tools libhdf5-103 liblzo2-2 libtokyocabinet9 libkrb5-3 libk5crypto3 time liblzma5 libcurl4 libcurl4-gnutls-dev libxml2 libgomp1 libffi7 parallel libdeflate0 libjemalloc2 libatomic1
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends git python3 python3-pip python3-distutils zlib1g libbz2-1.0 net-tools libhdf5-103 liblzo2-2 libtokyocabinet9 libkrb5-3 libk5crypto3 time liblzma5 libcurl4 libcurl4-gnutls-dev libxml2 libgomp1 libffi7 parallel libdeflate0 libjemalloc2 libatomic1 libhts3
 
 # required for ubuntu22 but won't work anywhere else
 RUN bash -c "if ! command -v catchsegv > /dev/null; then apt-get install glibc-tools; fi"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/comparative-genomics-toolkit/ubuntu:22.04 AS builder
 
 # apt dependencies for build
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential git python3 python3-dev python3-pip zlib1g-dev wget libbz2-dev pkg-config libhdf5-dev liblzo2-dev libtokyocabinet-dev wget liblzma-dev libxml2-dev libssl-dev libpng-dev uuid-dev libcurl4-gnutls-dev libffi-dev python3-virtualenv rsync python-is-python3 libdeflate-dev cmake libjemalloc-dev python3-distutils
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential git python3 python3-dev python3-pip zlib1g-dev wget libbz2-dev pkg-config libhdf5-dev liblzo2-dev libtokyocabinet-dev wget liblzma-dev libxml2-dev libssl-dev libpng-dev uuid-dev libcurl4-gnutls-dev libffi-dev python3-virtualenv rsync python-is-python3 libdeflate-dev cmake libjemalloc-dev python3-distutils pybind11-dev autoconf libzstd-dev libhts-dev
 
 # copy cactus
 RUN mkdir -p /home/cactus

--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,9 @@ evolver_test_minigraph_local: all ${CWD}/test/primates-truth.maf
 evolver_test_primates_pangenome_local: all ${CWD}/test/primates-truth.maf
 	PYTHONPATH="${CWD}/submodules/" CACTUS_BINARIES_MODE=local CACTUS_DOCKER_MODE=0 ${PYTHON} -m pytest ${pytestOpts} -s test/evolverTest.py::TestCase::testEvolverPrimatesPangenomeLocal
 
+evolver_test_primates_pangenome_docker: all ${CWD}/test/primates-truth.maf
+	PYTHONPATH="${CWD}/submodules/" CACTUS_BINARIES_MODE=docker CACTUS_DOCKER_MODE=1 ${PYTHON} -m pytest ${pytestOpts} -s test/evolverTest.py::TestCase::testEvolverPrimatesPangenomeDocker
+
 
 evolver_test_all_local: evolver_test_local evolver_test_prepare_toil evolver_test_decomposed_local evolver_test_prepare_no_outgroup_local evolver_test_poa_local evolver_test_refmap_local evolver_test_minigraph_local
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Cactus uses many different algorithms and individual code contributions, princip
 - The authors of [Mash](https://github.com/marbl/Mash)
 - Andrea Guarracino, Erik Garrison and co-authors for [odgi](https://github.com/pangenome/odgi). Make sure to [cite odgi](https://doi.org/10.1093/bioinformatics/btac308) when using it or its visualizations.
 - Hani Z. Girgis for [RED](http://toolsmith.ens.utulsa.edu/)
+- Erik Garrison and co-authors for [vcfwave](https://github.com/vcflib/vcflib/blob/master/doc/vcfwave.md). [vcflib citation](https://doi.org/10.1371/journal.pcbi.1009123)
 
 ## Installing Manually From Source
 
@@ -83,6 +84,10 @@ make -j 8
 In order to run the Minigraph-Cactus pipeline, you must also run
 ```
 build-tools/downloadPangenomeTools
+```
+In order to run `cactus-pangenome --vcfwave` you may need to then run
+```
+export LD_LIBRARY_PATH=$(pwd)/lib:$LD_LIBRARY_PATH
 ```
 
 If you want to work with MAF, including running `cactus-hal2maf`, you must also run

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -119,6 +119,25 @@ else
 	 exit 1
 fi
 
+#bcftools
+cd ${pangenomeBuildDir}
+wget -q https://github.com/samtools/bcftools/releases/download/1.19/bcftools-1.19.tar.bz2
+tar -xf bcftools-1.19.tar.bz2
+cd bcftools-1.19
+SAMTOOLS_CONFIG_OPTS=""
+if [[ $STATIC_CHECK -eq 1 ]]
+then
+	 SAMTOOLS_CONFIG_OPTS="--disable-bcftools-plugins"
+fi
+./configure $SAMTOOLS_CONFIG_OPTS
+make -j ${numcpu}
+if [[ $STATIC_CHECK -ne 1 || $(ldd bcftools | grep so | wc -l) -eq 0 ]]
+then
+	 mv bcftools ${binDir}
+else
+	 exit 1
+fi
+
 #bedtools
 cd ${pangenomeBuildDir}
 wget -q https://github.com/arq5x/bedtools2/releases/download/v2.30.0/bedtools.static.binary
@@ -339,8 +358,25 @@ else
     exit 1
 fi
 
+# vcfwave
+cd ${pangenomeBuildDir}
+# todo: it's be nice to figure out a static build. for now we skip entirely if static enabled.
+if [[ $STATIC_CHECK -ne 1 ]]
+then
+    git clone https://github.com/vcflib/vcflib.git
+    cd vcflib
+    git checkout 0a05bece60b9fce5ed6ffe02a06f596ee8054adb
+    git submodule update --init --recursive
+    mkdir build
+    cd build
+    cmake -DCMAKE_BUILD_TYPE=Release -DZIG=OFF ..
+    make -j ${numcpu}
+    mv vcfwave vcfcreatemulti vcfbreakmulti ${binDir}
+fi
+    
 cd ${CWD}
 rm -rf ${pangenomeBuildDir}
+
 
 set +x
 echo ""

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -371,8 +371,8 @@ then
     cd build
     cmake -DZIG=OFF -DCMAKE_BUILD_TYPE=Debug ..
     cmake --build . -- -j ${numcpu}
-    mv vcfwave vcfcreatemulti vcfbreakmulti ${binDir}
-    mv libwfa2.so.0 ${libDir}
+    mv vcfwave vcfcreatemulti vcfbreakmulti vcfuniq ${binDir}
+    mv ./contrib/WFA2-lib/libwfa2.so.0 ${libDir}
 fi
     
 cd ${CWD}

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -363,14 +363,13 @@ cd ${pangenomeBuildDir}
 # todo: it's be nice to figure out a static build. for now we skip entirely if static enabled.
 if [[ $STATIC_CHECK -ne 1 ]]
 then
-    git clone https://github.com/vcflib/vcflib.git
+    git clone --recursive https://github.com/vcflib/vcflib.git
     cd vcflib
-    git checkout 0a05bece60b9fce5ed6ffe02a06f596ee8054adb
-    git submodule update --init --recursive
+    git checkout 7c1a31a430d339adcb9a0c2fd3fd02d3b30e3549
     mkdir build
     cd build
-    cmake -DCMAKE_BUILD_TYPE=Release -DZIG=OFF ..
-    make -j ${numcpu}
+    cmake -DZIG=OFF -DCMAKE_BUILD_TYPE=Debug ..
+    cmake --build . -- -j ${numcpu}
     mv vcfwave vcfcreatemulti vcfbreakmulti ${binDir}
 fi
     

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -21,6 +21,7 @@ set -beEu -o pipefail
 
 pangenomeBuildDir=$(realpath -m build-pangenome-tools)
 binDir=$(pwd)/bin
+libDir=$(pwd)/lib
 # just use cactusRootPath for now
 dataDir=$(pwd)/src/cactus
 CWD=$(pwd)
@@ -371,6 +372,7 @@ then
     cmake -DZIG=OFF -DCMAKE_BUILD_TYPE=Debug ..
     cmake --build . -- -j ${numcpu}
     mv vcfwave vcfcreatemulti vcfbreakmulti ${binDir}
+    mv libwfa2.so.0 ${libDir}
 fi
     
 cd ${CWD}

--- a/doc/pangenome.md
+++ b/doc/pangenome.md
@@ -216,7 +216,13 @@ Note that by default, only GFA is output, so the above options need to be used t
 
 Different clipping and filtering thresholds can be specified using the `--clip` and `--filter` options, respectively. For larger graphs, you probably want to use `--filter N` where `N` represents about 10% of the haplotypes.  It is indeed a shame to remove rarer variants before mapping, but is a necessity to get the best performance out of (the current version) of `vg giraffe`.  
 
+### VCF Normalization
+
 The `--vcf` option will produce two VCFs for each selected graph type. One VCF is a "raw" VCF which contains nested variants, indicated by the `LV` and `PS` tags. The second VCF is one that has gone through [vcfbub](https://github.com/pangenome/vcfbub) to remove nested sites, as well as those greater than 100kb.  Unless you want to explicitly handle nested variants, you are probably best to use the `vcfbub` VCF.  Switch off `vcfbub` with `--vcfbub 0` or specify a different threshold with `--vcfbub N`.
+
+By default (since version v2.8.2), all non-raw VCF output is normalized with `bcftools norm -f` which left-aligns and normalizes indels.  You can turn this off in the config XML by setting `bcftoolsNorm` to `"0"`.
+
+Also new in v2.8.2, you can use the `--vcfwave` option to create a version of the VCF(s) that has been normalized with [vcfwave](https://github.com/vcflib/vcflib/blob/master/doc/vcfwave.md). `vcfwave` can take a while to run on larger graphs, but it can do a good job of smoothing out small variants in complex regions. `vcfwave` is included in the Cactus docker images but **not** the the Cactus binary release. So you must either run Cactus from inside Docker, or run outside docker with the `--binariesMode docker` option. If you cannot run docker and still want to use `--vcfwave`, you must [build it yourself](https://github.com/vcflib/vcflib) and make sure its on your `PATH` before running cactus.
 
 ### Haplotype Sampling Instead of Filtering (NEW)
 

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -391,6 +391,8 @@
 	<!-- odgiDrawOptions: options to odgi draw, used for 2d viz -->
 	<!-- rindexOptions: options to vg gbwt -r (r-index construction) as used to make haplotype sampling index -->
 	<!-- haplOptions: options to vg haplotypes as used to make haplotype sampling index -->
+	<!-- vcfwaveOptions: options to pass to vcfwave (from vcflib)-->
+	<!-- bcftoolsNorm: Run bcftools norm -f (left shifting) on all non-raw VCF output -->
 	<graphmap_join
 		 gfaffix="1"
 		 clipNonMinigraph="1"		 
@@ -403,6 +405,8 @@
 		 odgiDrawOptions="-H 1000"
 		 rindexOptions="-p"
 		 haplOptions="-v 2"
+		 vcfwaveOptions="-I 1000"
+		 bcftoolsNorm="1"
 		 />
 	<!-- hal2vg options -->
 	<!-- includeMinigraph: include minigraph node sequences as paths in output (note that cactus-graphmap-join will still remove them by default) -->

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -131,6 +131,7 @@ def graphmap_join_options(parser):
     parser.add_argument("--vcf", nargs='*', default=None, help = "Generate a VCF from the given graph type(s). Valid types are 'full', 'clip' and 'filter'. If no type specified, 'clip' will be used ('full' used if clipping disabled). Multipe types can be provided separated by space")
     parser.add_argument("--vcfReference", nargs='+', default=None, help = "If multiple references were provided with --reference, this option can be used to specify a subset for vcf creation with --vcf. By default, --vcf will create VCFs for the first reference only")
     parser.add_argument("--vcfbub", type=int, default=100000, help = "Use vcfbub to flatten nested sites (sites with reference alleles > this will be replaced by their children)). Setting to 0 will disable, only prudcing full VCF [default=100000].")
+    parser.add_argument("--vcfwave", action='store_true', default=False, help = "Create a vcfwave-normalized VCF. vcfwave realigns alt alleles to the reference, and can help correct messy regions in the VCF. This option will output an additional VCF with 'wave' in its filename, other VCF outputs will not be affected")
     
     parser.add_argument("--giraffe", nargs='*', default=None, help = "Generate Giraffe (.dist, .min) indexes for the given graph type(s). Valid types are 'full', 'clip' and 'filter'. If not type specified, 'filter' will be used (will fall back to 'clip' than full if filtering, clipping disabled, respectively). Multiple types can be provided seperated by a space")
 
@@ -266,11 +267,14 @@ def graphmap_join_validate_options(options):
         if vcf == 'clip' and not options.clip:
             raise RuntimError('--vcf cannot be set to clip since clipping is disabled')
         if vcf == 'filter' and not options.filter:
-            raise RuntimeError('--vcf cannot be set to filter since filtering is disabled')
+            raise RuntimeError('--vcf cannot be set to filter since filtering is disabled')        
 
     # if someone used --vcfReference they probably want --vcf too
     if options.vcfReference and not options.vcf:
         raise RuntimeError('--vcfReference cannot be used without --vcf')
+
+    if options.vcfwave and not options.vcf:
+        raise RuntimeError('--vcfwave cannot be used without --vcf')
         
     if not options.vcfReference:
         options.vcfReference = [options.reference[0]]
@@ -347,6 +351,11 @@ def graphmap_join_workflow(job, options, config, vg_ids, hal_ids):
     root_job = Job()
     job.addChild(root_job)
 
+    # vcfwave isn't included in the static binary release, so we start by checking it's available
+    if options.vcfwave and options.vcf:
+        vcfwave_check_job = root_job.addFollowOnJobFn(check_vcfwave)
+        root_job = vcfwave_check_job
+        
     # make sure reference doesn't have a haplotype suffix, as it will have been changed upstream
     ref_base, ref_ext = os.path.splitext(options.reference[0])
     assert len(ref_base) > 0
@@ -473,7 +482,11 @@ def graphmap_join_workflow(job, options, config, vg_ids, hal_ids):
     max_system_memory = config.getSystemMemory()
     if max_system_memory and index_mem > max_system_memory:
         RealtimeLogger.info("Clamping index memory {} to system limit of {}".format(index_mem, max_system_memory))
-        index_mem = max_system_memory    
+        index_mem = max_system_memory
+
+    # keep track of unclipped reference fastas for bcftools norm
+    need_nonref_fasta = options.vcfReference and any([s != options.reference[0] for s in options.vcfReference])
+    nonref_fasta_job = None
         
     workflow_phases = [('full', full_vg_ids, join_job)]
     if options.clip:
@@ -488,6 +501,8 @@ def graphmap_join_workflow(job, options, config, vg_ids, hal_ids):
         gfa_ids = []
         current_out_dict = None
         do_gbz = workflow_phase in options.gbz + options.vcf + options.giraffe + options.xg
+        if workflow_phase == 'full' and need_nonref_fasta:
+            do_gbz = True
         if do_gbz or workflow_phase in options.gfa:
             assert len(options.vg) == len(phase_vg_ids) == len(vg_ids)
             for vg_path, vg_id, input_vg_id in zip(options.vg, phase_vg_ids, vg_ids):
@@ -505,6 +520,12 @@ def graphmap_join_workflow(job, options, config, vg_ids, hal_ids):
             out_dicts.append(gfa_merge_job.rv())
             prev_job = gfa_merge_job
             current_out_dict = gfa_merge_job.rv()
+            if workflow_phase == 'full' and need_nonref_fasta or (workflow_phase in options.vcf and nonref_fasta_job is None):
+                # we need fasta references from the gbz for vcf normalization
+                nonref_fasta_job = gfa_merge_job.addFollowOnJobFn(extract_gbz_fasta, options, current_out_dict,
+                                                                  tag=workflow_phase + '.',
+                                                                  memory=index_mem,
+                                                                  disk=sum(f.size for f in vg_ids) * 2)
 
         # optional xg
         if workflow_phase in options.xg:
@@ -520,13 +541,26 @@ def graphmap_join_workflow(job, options, config, vg_ids, hal_ids):
             for vcf_ref in options.vcfReference:
                 vcftag = vcf_ref + '.' + workflow_phase if vcf_ref != options.reference[0] else workflow_phase
                 deconstruct_job = prev_job.addFollowOnJobFn(make_vcf, config, options.outName, vcf_ref, current_out_dict,
+                                                            nonref_fasta_job.rv(),
                                                             max_ref_allele=options.vcfbub,
                                                             tag=vcftag + '.', ref_tag = workflow_phase + '.',
                                                             cores=options.indexCores,
                                                             disk = sum(f.size for f in vg_ids) * 6,
                                                             memory=index_mem)
-                out_dicts.append(deconstruct_job.rv())                
-
+                assert nonref_fasta_job is not None
+                nonref_fasta_job.addFollowOn(deconstruct_job)
+                out_dicts.append(deconstruct_job.rv())
+                
+                # optional vcfwave
+                if options.vcfwave:
+                    vcfwave_job = deconstruct_job.addFollowOnJobFn(vcfwave, config, vcf_ref, current_out_dict,
+                                                                   deconstruct_job.rv(), nonref_fasta_job.rv(), options.vcfbub,
+                                                                   tag=vcftag + '.', ref_tag = workflow_phase + '.',
+                                                                   cores=options.indexCores,
+                                                                   disk = sum(f.size for f in vg_ids) * 6,
+                                                                   memory=index_mem)
+                    out_dicts.append(vcfwave_job.rv())
+                    
         # optional giraffe
         if workflow_phase in options.giraffe:
             giraffe_job = gfa_merge_job.addFollowOnJobFn(make_giraffe_indexes, options, config, current_out_dict,
@@ -837,6 +871,25 @@ def make_vg_indexes(job, options, config, gfa_ids, tag="", do_gbz=False):
         out_dict['{}snarls'.format(tag)] =  job.fileStore.writeGlobalFile(snarls_path)
     return out_dict
 
+def extract_gbz_fasta(job, options, index_dict, tag):
+    """ get the reference fasta files from the unclipped gbz so they can be used with bcftools norm
+    """
+    work_dir = job.fileStore.getLocalTempDir()
+    gbz_path = os.path.join(work_dir, tag + os.path.basename(options.outName) + '.gbz')
+    print ("YAN", index_dict)
+    job.fileStore.readGlobalFile(index_dict['{}gbz'.format(tag)], gbz_path)
+
+    out_dict = {}
+    for vcf_ref in options.vcfReference:
+        fa_ref_path = os.path.join(work_dir, vcf_ref + '.fa.gz')            
+        cactus_call(parameters=[['vg', 'paths', '-x', gbz_path, '-S', vcf_ref, '-F'],
+                                ['sed', '-e', 's/{}#.\+#//g'.format(vcf_ref)],
+                                ['bgzip', '--threads', str(job.cores)]],
+                    outfile=fa_ref_path)
+        out_dict[vcf_ref] = job.fileStore.writeGlobalFile(fa_ref_path)
+
+    return out_dict
+
 def make_xg(job, config, out_name, index_dict, tag='', drop_haplotypes=False):
     """ make the xg from the gbz
     """
@@ -853,7 +906,7 @@ def make_xg(job, config, out_name, index_dict, tag='', drop_haplotypes=False):
 
     return { '{}xg'.format(tag) : job.fileStore.writeGlobalFile(xg_path) }
 
-def make_vcf(job, config, out_name, vcf_ref, index_dict, tag='', ref_tag='', max_ref_allele=None):
+def make_vcf(job, config, out_name, vcf_ref, index_dict, fasta_ref_dict, tag='', ref_tag='', max_ref_allele=None):
     """ make the vcf
     """ 
     work_dir = job.fileStore.getLocalTempDir()
@@ -881,11 +934,16 @@ def make_vcf(job, config, out_name, vcf_ref, index_dict, tag='', ref_tag='', max
         output_dict['{}raw.vcf.gz.tbi'.format(tag)] = job.fileStore.writeGlobalFile(tbi_path)
 
     # make the filtered vcf
-    if max_ref_allele:
+    if max_ref_allele:        
         vcfbub_path = os.path.join(work_dir, 'merged.filtered.vcf.gz')
-        cactus_call(parameters=[['vcfbub', '--input', vcf_path, '--max-ref-length', str(max_ref_allele), '--max-level', '0'],
-                                ['bgzip', '--threads', str(job.cores)]],
-                outfile=vcfbub_path)
+        bub_cmd = [['vcfbub', '--input', vcf_path, '--max-ref-length', str(max_ref_allele), '--max-level', '0']]
+        if getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_join"), "bcftoolsNorm", typeFn=bool, default=True):
+            fa_ref_path = os.path.join(work_dir, vcf_ref + '.fa.gz')
+            job.fileStore.readGlobalFile(fasta_ref_dict[vcf_ref], fa_ref_path)
+            bub_cmd.append(['bcftools', 'norm', '-f', fa_ref_path])
+            bub_cmd.append(['bcftools', 'sort'])
+        bub_cmd.append(['bgzip', '--threads', str(job.cores)])
+        cactus_call(parameters=bub_cmd, outfile=vcfbub_path)
         try:
             cactus_call(parameters=['tabix', '-p', 'vcf', vcfbub_path])
             tbi_path = vcfbub_path + '.tbi'
@@ -898,7 +956,64 @@ def make_vcf(job, config, out_name, vcf_ref, index_dict, tag='', ref_tag='', max
             output_dict['{}vcf.gz.tbi'.format(tag)] = job.fileStore.writeGlobalFile(vcfbub_path + '.tbi')
 
     return output_dict
+
+def check_vcfwave(job):
+    """ check to make sure vcfwave is installed """
+    try:
+        cactus_call(parameters=['vcfwave', '-h'])
+    except:
+        raise RuntimeError('--vcfwave option used, but vcfwave tool not found in PATH. vcfwave is *not* included in the cactus binary release, but it is in the cactus Docker image. If you have Docker installed, you can try running again with --binariesMode docker. Or running your whole command with docker run. If you cannot use Docker, then you will need to build vcflib yourself before retrying: source code and details here: https://github.com/vcflib/vcflib')
+
+ 
+def vcfwave(job, config, vcf_ref, index_dict, deconstruct_out_dict, fasta_ref_dict, vcfbub_thresh, tag, ref_tag):
+    """ run vcfwave """
+    work_dir = job.fileStore.getLocalTempDir()
+    raw_vcf_path = os.path.join(work_dir, '{}raw.vcf.gz'.format(tag))
+    raw_tbi_path = raw_vcf_path + '.tbi'
+    job.fileStore.readGlobalFile(deconstruct_out_dict['{}raw.vcf.gz'.format(tag)], raw_vcf_path)
+    job.fileStore.readGlobalFile(deconstruct_out_dict['{}raw.vcf.gz.tbi'.format(tag)], raw_tbi_path)
+
+    wave_vcf_path = os.path.join(work_dir, '{}wave.vcf.gz'.format(tag))
+    wave_tbi_path = wave_vcf_path + '.tbi'
     
+    # re-using my usual vcfwave script which uses parallel-based multithreading. TODO: toilify? """
+    vcf_bubwave= \
+'''#!/bin/bash
+INFILE=$1
+OUTFILE=$2
+JOBS=$3
+MAXLEN=$4
+WAVE_OPTS=$5
+for chr in `bcftools view -h $INFILE | perl -ne 'if (/^##contig=<ID=([^,]+)/) { print "$1\n" }'`; do echo $chr; done | parallel -j ${JOBS} "bcftools view $INFILE -r {} | bgzip > $INFILE-{}.input.vcf.gz ; tabix -fp vcf $INFILE-{}.input.vcf.gz ; vcfbub --input $INFILE-{}.input.vcf.gz -l 0 -a ${MAXLEN} | vcfwave ${WAVE_OPTS} | bgzip  > ${INFILE}-{}.vcf.gz; rm -f $INFILE-{}.input.vcf.gz $INFILE-{}.input.vcf.gz.tbi"
+bcftools concat ${INFILE}-*.vcf.gz | bcftools sort | bgzip --threads ${JOBS} > ${OUTFILE}
+tabix -fp vcf ${OUTFILE}
+'''
+    script_path = os.path.join(work_dir, 'vcf-bubwave.sh')
+    with open(script_path, 'w') as script_file:
+        script_file.write(vcf_bubwave)
+    os.chmod(script_path, 0o777)
+
+    wave_opts = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_join"), "vcfwaveOptions", typeFn=str, default=None)
+    assert wave_opts
+    cactus_call(parameters=[script_path, raw_vcf_path, wave_vcf_path, str(job.cores), str(vcfbub_thresh), wave_opts])
+
+    if getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_join"), "bcftoolsNorm", typeFn=bool, default=True):
+        fa_ref_path = os.path.join(work_dir, vcf_ref + '.fa.gz')
+        job.fileStore.readGlobalFile(fasta_ref_dict[vcf_ref], fa_ref_path)
+        norm_path = os.path.join(work_dir, '{}wave.norm.vcf.gz'.format(tag))
+        cactus_call(parameters=[['bcftools', 'norm', '-f', fa_ref_path, wave_vcf_path],
+                                ['bcftools', 'sort'],
+                                ['bgzip', '--threads', str(job.cores)]],
+                    outfile=norm_path)
+        cactus_call(parameters=['tabix', '-fp', 'vcf', norm_path])
+
+        wave_vcf_path = norm_path
+        wave_tbi_path = norm_path + '.tbi'
+        
+
+    return { '{}wave.vcf.gz'.format(tag) : job.fileStore.writeGlobalFile(wave_vcf_path),
+             '{}wave.vcf.gz.tbi'.format(tag) : job.fileStore.writeGlobalFile(wave_tbi_path) }
+
 def make_giraffe_indexes(job, options, config, index_dict, haplotype_indexes=False, tag=''):
     """ make giraffe-specific indexes: distance and minimaer """
     work_dir = job.fileStore.getLocalTempDir()

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -995,7 +995,9 @@ tabix -fp vcf ${OUTFILE}
 
     wave_opts = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_join"), "vcfwaveOptions", typeFn=str, default=None)
     assert wave_opts
-    cactus_call(parameters=[script_path, raw_vcf_path, wave_vcf_path, str(job.cores), str(vcfbub_thresh), wave_opts])
+    cactus_call(parameters=['./' + os.path.basename(script_path),
+                            raw_vcf_path, wave_vcf_path, str(job.cores), str(vcfbub_thresh), wave_opts],
+                work_dir=work_dir)
 
     if getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_join"), "bcftoolsNorm", typeFn=bool, default=True):
         fa_ref_path = os.path.join(work_dir, vcf_ref + '.fa.gz')

--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -435,8 +435,9 @@ class TestCase(unittest.TestCase):
         subprocess.check_call(['mv', os.path.join(out_dir, out_name + '.full.hal'), os.path.join(out_dir, out_name + '.hal')])
 
         # make sure it made output
-        wave_vcf_bytes = os.path.getsize(os.path.join(out_dir, out_name + '.simChimp.wave.vcf.gz'))
-        self.assertGreaterEqual(wave_vcf_bytes, 500000)
+        if binariesMode == 'docker':
+            wave_vcf_bytes = os.path.getsize(os.path.join(out_dir, out_name + '.simChimp.wave.vcf.gz'))
+            self.assertGreaterEqual(wave_vcf_bytes, 500000)
 
 
     def _run_yeast_pangenome_step_by_step(self, binariesMode):


### PR DESCRIPTION
I've been wasting a lot of time lately by manually running vcf normalization commands.  This PR adds two normalization steps to the pipeline:

* `bcftools norm -f`: On by default, but can be toggled in the config XML
* `vcfwave`: Toggle on with `--vcfwave` (this will output an *additional* VCF that has bee n `vcfwave`-normalized in addition to the usual output)

Because I couldn't figure out how to make a static `vcfwave` binary, I'm only including it in the Docker release for now.  There's a hopefully-helpful error checker to help users work around this. 