### PR TITLE
Move maxRefNFrac and minLines filters from hal2maf to maf2bigmaf

### DIFF
--- a/doc/progressive.md
+++ b/doc/progressive.md
@@ -167,7 +167,6 @@ These issues are all at least partially addressed by a new tool, `cactus-hal2maf
 * `--maximumBlockLengthToMerge`: Merge adjacent blocks if one or both is less than this many bases long (see [TAFFY](https://github.com/ComparativeGenomicsToolkit/taffy) documentation for default value and more explanation).
 * `--maximumGapLength`: Merge adjacent blocks if the maximum number of unaligned bases between them is less than this value (see [TAFFY](https://github.com/ComparativeGenomicsToolkit/taffy) documentation for default value and more explanation).
 * `--fractionSharedRows`: Minimum fraction of shared rows between adjacent blocks in order to merge (see [TAFFY](https://github.com/ComparativeGenomicsToolkit/taffy) documentation for default value and more explanation).
-* `--maxRefNFrac`: Filter out blocks whose reference row has a greater proportion of `N`s than the given fraction
 
 **Duplication Filtering** is specified with the `--dupeMode` option. Possible values are:
 * "single" : Uses greedy heuristics to pick the copy for each species that results in fewest mutations and block breaks.

--- a/src/cactus/maf/cactus_hal2maf.py
+++ b/src/cactus/maf/cactus_hal2maf.py
@@ -116,10 +116,6 @@ def main():
     parser.add_argument("--filterGapCausingDupes",
                         help="Turn on (experimental) taffy norm -d filter that removes duplications that would induce gaps > maximumGapLength [default=Off unless --dupeMode single]",
                         action="store_true")
-    parser.add_argument("--maxRefNFrac",
-                        help="Filter out MAF blocks whose reference (first) line has a greater fraction of Ns than the given amount. Should be between 0.0 (filter everything) and 1.0 (filter nothing). [default=0.95]",
-                        type=float,
-                        default=0.95)
 
     # coverage options
     parser.add_argument("--coverage",
@@ -462,10 +458,6 @@ def taf_cmd(hal_path, chunk, chunk_num, genome_list_path, sed_script_paths, opti
     if sed_script_paths:
         # rename to alphanumeric names
         cmd += ' | sed -f {}'.format(os.path.basename(sed_script_paths[0]))    
-    if options.maxRefNFrac:
-        cmd += ' | mafFilter -m - -N {}'.format(options.maxRefNFrac)
-    # get rid of single-row (ie ref-only) blcks while we're filtering
-    cmd += ' | mafFilter -m - -l 2'
     if options.dupeMode == 'single':
         cmd += ' | mafDuplicateFilter -m - -k'                                               
     elif options.dupeMode == 'consensus':


### PR DESCRIPTION
`cactus-hal2maf` filters out gaps and unaligned regions automatically. I think this was originally done to better fit what the Genome Browser expects.  But at least a few people have been disappointed to not find their entire reference interval in the MAF whether or not it's aligned.  

So this PR takes this filter step out of `cactus-hal2maf` and, since it's browser-specific, moves it into `cactus-maf2bigmaf`

Resolves #1362