### PR TITLE
fix cactus-preprocess --maskMode option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,6 +200,9 @@ evolver_test_all_local: evolver_test_local evolver_test_prepare_toil evolver_tes
 yeast_test_local:
 	PYTHONPATH="${CWD}/submodules/" CACTUS_BINARIES_MODE=local CACTUS_DOCKER_MODE=0 ${PYTHON} -m pytest ${pytestOpts} -s test/evolverTest.py::TestCase::testYeastPangenomeLocal
 
+yeast_test_step_by_step_local:
+	PYTHONPATH="${CWD}/submodules/" CACTUS_BINARIES_MODE=local CACTUS_DOCKER_MODE=0 ${PYTHON} -m pytest ${pytestOpts} -s test/evolverTest.py::TestCase::testYeastPangenomeStepByStepLocal
+
 ##
 # clean targets
 ##

--- a/src/cactus/preprocessor/cactus_preprocessor.py
+++ b/src/cactus/preprocessor/cactus_preprocessor.py
@@ -379,8 +379,11 @@ def stageWorkflow(outputSequenceDir, configNode, inputSequences, toil, restart=F
     if configNode.find("constants") != None:
         ConfigWrapper(configNode).substituteAllPredefinedConstantsWithLiterals(options)
     if maskMode:
+        assert maskMode in ['red', 'lastz', 'brnn']
+        red = maskMode == 'red'
         lastz = maskMode == 'lastz'
         brnn = maskMode == 'brnn'
+        ConfigWrapper(configNode).setPreprocessorActive("red", red)
         ConfigWrapper(configNode).setPreprocessorActive("lastzRepeatMask", lastz)
         ConfigWrapper(configNode).setPreprocessorActive("dna-brnn", brnn)
         if brnn and maskAction == 'clip':
@@ -442,7 +445,7 @@ def main():
     parser.add_argument("--inputNames", nargs='*', help='input genome names (not paths) to preprocess (all leaves from Input Seq file if none specified)')
     parser.add_argument("--inPaths", nargs='*', help='Space-separated list of input fasta paths (to be used in place of --inSeqFile')
     parser.add_argument("--outPaths", nargs='*', help='Space-separated list of output fasta paths (one for each inPath, used in place of --outSeqFile)')
-    parser.add_argument("--maskMode", type=str, help='Masking mode, one of {"lastz", "brnn", "red", "none", "config"}. Default="config".', default='lastz')
+    parser.add_argument("--maskMode", type=str, help='Masking mode, one of {"lastz", "brnn", "red", "none", "config"}. Default="config".', default='config')
     parser.add_argument("--maskAction", type=str, help='Masking action, one of {"softmask", "hardmask", "clip"}. Default="softmask"', default='softmask')
     parser.add_argument("--minLength", type=int, help='Minimum interval threshold for masking.  Overrides config')
     parser.add_argument("--maskFile", type=str, help='Add masking from BED or PAF file to sequences, **ignoring all other preprocessors**')

--- a/src/cactus/preprocessor/cactus_preprocessor.py
+++ b/src/cactus/preprocessor/cactus_preprocessor.py
@@ -379,7 +379,7 @@ def stageWorkflow(outputSequenceDir, configNode, inputSequences, toil, restart=F
     if configNode.find("constants") != None:
         ConfigWrapper(configNode).substituteAllPredefinedConstantsWithLiterals(options)
     if maskMode:
-        assert maskMode in ['red', 'lastz', 'brnn']
+        assert maskMode in ['red', 'lastz', 'brnn', 'none']
         red = maskMode == 'red'
         lastz = maskMode == 'lastz'
         brnn = maskMode == 'brnn'


### PR DESCRIPTION
I noticed this while trying to reproduce #1370.  

When I added the RED repeatmasker, the intention was to replace the lastz masker by default.  This is how `cactus` works, but `cactus-preprocess` still runs the lastz masker after Red.  

This PR fixes `cactus-preprocess` to just run Red by default.  It also fixes the `--maskMode` option so that it works as described (runs only the selected masker). 

