### PR TITLE
Only trim outgroups if there are any

### DIFF
--- a/src/cactus/progressive/cactus_progressive.py
+++ b/src/cactus/progressive/cactus_progressive.py
@@ -176,18 +176,18 @@ def progressive_step(job, options, config_node, seq_id_map, tree, og_map, event)
     paf_job = job.addChildJobFn(make_paf_alignments, NXNewick().writeString(spanning_tree),
                                 subtree_eventmap, event, config_node).encapsulate()
 
+    outgroups = og_map[event] if event in og_map else []
     # trim the outgroups
-    if int(config_node.find("blast").attrib["trimOutgroups"]):  # Trim the outgroup sequences
-        outgroups = og_map[event] if event in og_map else []
+    if outgroups and int(config_node.find("blast").attrib["trimOutgroups"]):  # Trim the outgroup sequences
         trim_sequences = paf_job.addChildJobFn(trim_unaligned_sequences,
                                                [subtree_eventmap[i] for i in outgroups], paf_job.rv(), config_node)
         cons_job = paf_job.addFollowOnJobFn(progressive_step_2, trim_sequences.rv(), options, config_node, subtree_eventmap,
                                             spanning_tree, og_map, event)
         
-    else:  # Without outgroup trimming
+    else:  # Without outgroup trimming (or if there are no outgroups to trim)
         cons_job = paf_job.addChildJobFn(cactus_cons_with_resources, spanning_tree, event, config_node, subtree_eventmap,
                                          og_map, paf_job.rv(), cons_cores=options.consCores, cons_memory=options.consMemory,
-                                         intermediate_results_url=options.intermediateResultsUrl).rv()
+                                         intermediate_results_url=options.intermediateResultsUrl)
     # erase the paf since its now longer needed
     cons_job.addFollowOnJobFn(clean_jobstore_files, file_ids=[paf_job.rv()])
     return cons_job.rv()


### PR DESCRIPTION
The job `trim_unaligned_sequences` currently estimates its memory as a function of its input size.  
```
memory=cactus_clamp_memory(8*sum([seq.size for seq in sequences]) + 32*alignments.size))
```
This seems to have been working fairly well but @ph09 ran into an issue where it would estimate the minimum value of `2G` while needing roughly `11G`.  It turns out this happens at the root node of 3-human alignment, where the input PAF is `40Mb` but there are no input sequences.  This explains the minimal estimate.  But I guess `paffy to_bed` uses memory proportional to the ingroup sequences, then it runs out of memory.  

This PR changes the logic so that outgroup trimming is turned off when there are no outgroups.  From what I can tell looking at the code, it's not doing anything in these cases other than sometimes running out of memory. 

But @benedictpaten could you please take a quick look at the file delta here and confirm I'm not breaking anything by turning off outgroup trimming this way?  Thanks!