### PR TITLE
catch errors in vcf-bubwave script

### DIFF
--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -985,7 +985,7 @@ OUTFILE=$2
 JOBS=$3
 MAXLEN=$4
 WAVE_OPTS=$5
-for chr in `bcftools view -h $INFILE | perl -ne 'if (/^##contig=<ID=([^,]+)/) { print "$1\n" }'`; do echo $chr; done | parallel -j ${JOBS} "bcftools view $INFILE -r {} | bgzip > $INFILE-{}.input.vcf.gz ; tabix -fp vcf $INFILE-{}.input.vcf.gz ; vcfbub --input $INFILE-{}.input.vcf.gz -l 0 -a ${MAXLEN} | vcfwave ${WAVE_OPTS} | bgzip  > ${INFILE}-{}.vcf.gz; rm -f $INFILE-{}.input.vcf.gz $INFILE-{}.input.vcf.gz.tbi"
+for chr in `bcftools view -h $INFILE | perl -ne 'if (/^##contig=<ID=([^,]+)/) { print "$1\n" }'`; do echo $chr; done | parallel -j ${JOBS} "set -eo pipefail && bcftools view $INFILE -r {} | bgzip > $INFILE-{}.input.vcf.gz && tabix -fp vcf $INFILE-{}.input.vcf.gz && vcfbub --input $INFILE-{}.input.vcf.gz -l 0 -a ${MAXLEN} | vcfwave ${WAVE_OPTS} | bgzip  > ${INFILE}-{}.vcf.gz && rm -f $INFILE-{}.input.vcf.gz $INFILE-{}.input.vcf.gz.tbi"
 bcftools concat ${INFILE}-*.vcf.gz | bcftools sort | bgzip --threads ${JOBS} > ${OUTFILE}
 tabix -fp vcf ${OUTFILE}
 '''

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -979,6 +979,7 @@ def vcfwave(job, config, vcf_ref, index_dict, deconstruct_out_dict, fasta_ref_di
     # re-using my usual vcfwave script which uses parallel-based multithreading. TODO: toilify? """
     vcf_bubwave= \
 '''#!/bin/bash
+set -eo pipefail
 INFILE=$1
 OUTFILE=$2
 JOBS=$3


### PR DESCRIPTION
#1402 brings up a good point about errors within this script not being handled properly.  The right thing to do is push this logic into Toil jobs rather than calling out to the bash script.  But in the meantime, this patch should hopefully prevent it from silently producing truncated output in the event of a crash.  