### PR TITLE
fix: handle scientific notation in awk output by converting to float …

### DIFF
--- a/src/cactus/preprocessor/redMasking.py
+++ b/src/cactus/preprocessor/redMasking.py
@@ -64,7 +64,11 @@ class RedMaskJob(RoundedJob):
                 cactus_call(parameters=['cactus_softmask2hardmask', '-b', in_fa_path], outfile=bed_path)
                 awkres = cactus_call(parameters=['awk', '{sum += $3-$2} END {print sum}', bed_path],
                                                 check_output=True, rt_log_cmd=False).strip()
-                pre_mask_size = int(awkres) if awkres else 0
+                try:
+                    pre_mask_size = int(float(awkres)) if awkres else 0
+                except ValueError as e:
+                    print(f"Error converting awkres to int: {e}")
+                    pre_mask_size = 0
                 
             # run red
             red_cmd = ['Red', '-gnm', red_in_dir, '-msk', red_out_dir]


### PR DESCRIPTION
### Description

This pull request addresses an issue in `redMasking.py` where the conversion of `awkres` to an integer fails if the value is in scientific notation, resulting in a `ValueError`.

#### Details

- **Issue**: When `awkres` is in scientific notation (e.g., '4.31768e+09'), converting it directly to an integer using `int()` causes a `ValueError`.
- **Fix**: The conversion logic has been updated to first convert the string to a float and then to an integer. This ensures that values in scientific notation are correctly handled.

#### Changes Made

1. Modified the code to convert `awkres` to a float before converting it to an integer:
   ```python
   try:
       pre_mask_size = int(float(awkres)) if awkres else 0
   except ValueError as e:
       print(f"Error converting awkres to int: {e}")
       pre_mask_size = 0
