### PR TITLE
Bump gpu docker to ubuntu 22 as Toil 7.0 seems to want Python version > 3.8

### DIFF
--- a/Dockerfile.segalign
+++ b/Dockerfile.segalign
@@ -1,5 +1,5 @@
 # Reminder: if updating this image, also update it in build-tools/makeGpuDockerRelease
-FROM nvidia/cuda:11.4.3-devel-ubuntu20.04 as builder
+FROM nvidia/cuda:11.7.1-devel-ubuntu22.04 as builder
 
 # Prevent dpkg from trying to ask any questions, ever
 ENV DEBIAN_FRONTEND noninteractive
@@ -20,7 +20,7 @@ RUN git clone https://github.com/ComparativeGenomicsToolkit/SegAlign.git /WGA_GP
 RUN cd /WGA_GPU && rm -rf build && ./scripts/installUbuntu.sh -c && git rev-parse HEAD > /Segalign.commit
 
 # Create a thinner final Docker image with only runtime dependencies
-FROM nvidia/cuda:11.4.3-runtime-ubuntu20.04
+FROM nvidia/cuda:11.7.1-runtime-ubuntu22.04
 
 # Install runtime dependencies
 RUN apt-get -qq -y update && \

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Cactus uses many different algorithms and individual code contributions, princip
 
 ## Installing Manually From Source
 
-**Cactus requires Python >= 3.7 along with Python development headers and libraries**
+**Cactus requires Python >= 3.9 along with Python development headers and libraries**
 
 Clone cactus and submodules
 ```

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Cactus uses many different algorithms and individual code contributions, princip
 
 ## Installing Manually From Source
 
-**Cactus requires Python >= 3.9 along with Python development headers and libraries**
+**Cactus requires Python >= 3.8 along with Python development headers and libraries**
 
 Clone cactus and submodules
 ```

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -5,7 +5,7 @@ This release fixes some bugs and updates to the latest Toil.
 - Fix broken `--restart` option in `cactus-graphmap`
 - Raise Toil job memory requirement for `filter-paf-deletions`
 - Update to `vg` v1.57.0
-- Update `Toil` to v7.0 **NOTE** this seems to bring minimum python requirement up to 3.9!
+- Update `Toil` to v7.0
 - Fix bug where trim-outgroups job could requeset way too little memory when there are no outgroups
 - Fix typo that broke `cactus-maf2bigmaf` on uncompressed inputs
 - More robust implementation of `vcfwave`

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -5,7 +5,7 @@ This release fixes some bugs and updates to the latest Toil.
 - Fix broken `--restart` option in `cactus-graphmap`
 - Raise Toil job memory requirement for `filter-paf-deletions`
 - Update to `vg` v1.57.0
-- Update `Toil` to v7.0
+- Update `Toil` to v7.0 **NOTE** this seems to bring minimum python requirement up to 3.9!
 - Fix bug where trim-outgroups job could requeset way too little memory when there are no outgroups
 - Fix typo that broke `cactus-maf2bigmaf` on uncompressed inputs
 - More robust implementation of `vcfwave`

--- a/build-tools/makeGpuDockerRelease
+++ b/build-tools/makeGpuDockerRelease
@@ -26,7 +26,7 @@ git submodule update --init --recursive
 CFLAGS="" CXXFLAGS="" docker build . -f Dockerfile.segalign -t segalign:local
 # switch the runtime image to segalign, and the build image to the build image from Dockerfile.segalign
 # important, if the build image in Dockerfile.segaling changes, the line below needs to be updated too
-sed '0,/FROM/! s/FROM.*/FROM segalign:local/' Dockerfile  | sed -e '0,/FROM/s/FROM.*/FROM nvidia\/cuda:11.4.3-devel-ubuntu20.04 as builder/g' > Dockerfile.gpu
+sed '0,/FROM/! s/FROM.*/FROM segalign:local/' Dockerfile  | sed -e '0,/FROM/s/FROM.*/FROM nvidia\/cuda:11.7.1-devel-ubuntu22.04 as builder/g' > Dockerfile.gpu
 # enable gpu by default
 sed -i src/cactus/cactus_progressive_config.xml -e 's/gpu="0"/gpu="all"/g' -e 's/realign="1"/realign="0"/'
 docker build . -f Dockerfile.gpu -t ${dockname}:${REL_TAG}-gpu

--- a/doc/progressive.md
+++ b/doc/progressive.md
@@ -517,3 +517,7 @@ That said, cactus can handle multifurcations up to a point: runtime increases qu
 **Q**: I get an error to the effect of `toil.batchSystems.abstractBatchSystem.InsufficientSystemResources: The job cactus_cons is requesting 66623310306 bytes of memory, more than the maximum of 34359738368 bytes of memory that SingleMachineBatchSystem was configured with, or enforced by --maxMemory. Scale is set to 1.0.”`.  What's going on?
 
 **A**: As of version 2.6.0, Cactus is now trying to (conservatively) estimate the memory usage of each job, which is required for must cluster schedulers.  This can be annoying if, like in the above scenario, the estimate is too conservative to even try running on your machine.  So you can use the `--consMemory` option to override it.  Ex. use `--consMemory 32Gi` to force Cactus to reserve exactly 32 Gigs for each cactus consolidated job. `--maxMemory` and `--defaultMemory` can also be used to clamp the memory of big jobs from above and below, respectively. 
+
+**Q**: I get a `ModuleNotFoundError: No module named 'backports'` when I run Cactus.
+
+**A**: This is a bug in Toil 7.0 that affects Python3.8.  If you run into this, run `python3 -m pip install -U backports.zoneinfo`

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     # We use the __file__ attribute so this package isn't zip_safe.
     zip_safe = False,
 
-    python_requires = '>=3.7',
+    python_requires = '>=3.9',
 
     install_requires = [
         'decorator',

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     # We use the __file__ attribute so this package isn't zip_safe.
     zip_safe = False,
 
-    python_requires = '>=3.9',
+    python_requires = '>=3.8',
 
     install_requires = [
         'decorator',

--- a/toil-requirement.txt
+++ b/toil-requirement.txt
@@ -1,1 +1,2 @@
+backports.zoneinfo[tzdata];python_version<"3.9"
 toil[aws]==7.0.0


### PR DESCRIPTION
The GPU docker image builder script failed for [v2.8.3](https://github.com/ComparativeGenomicsToolkit/cactus/releases/tag/v2.8.3) at the very end when it verifies that `cactus --help` runs through
```
Traceback (most recent call last):
  File "/cactus/venv-cactus/bin/cactus", line 5, in <module>
    from cactus.progressive.cactus_progressive import main
  File "/cactus/venv-cactus/lib/python3.8/site-packages/cactus/progressive/cactus_progressive.py", line 20, in <module>
    from toil.lib.bioio import getTempFile
  File "/cactus/venv-cactus/lib/python3.8/site-packages/toil/lib/bioio.py", line 18, in <module>
    from toil.test import get_temp_file
  File "/cactus/venv-cactus/lib/python3.8/site-packages/toil/test/__init__.py", line 54, in <module>
    from backports import zoneinfo
ModuleNotFoundError: No module named 'backports'
```
As far as I can tell, this error comes from an incompatibility between Toil 7.0 and Python 3.8, which the GPU image was still pinned to.  I think the GPU image being built on Ubuntu 20.04 dates back to Terra driver compatibility.  This PR keeps Cuda at 11 (which should hopefully be compatible with the same drivers) but bumps up the image to Ubuntu 22.04.  

Even though this patch is not part of the v2.8.3 tag, I used it (out of necessity) to build the GPU docker image for v2.8.3.

I think having to upgrade to Cuda 12 is probably inevitable in the next year or so, but I'll save that rabbit hole for a bit later. 

To avoid further confusion, this PR also updates Cactus's minimum Python version to 3.9! 

