### PR TITLE
update vcfbub to v0.1.1

### DIFF
--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -321,7 +321,7 @@ fi
 
 # vcfbub
 cd ${pangenomeBuildDir}
-wget -q https://github.com/pangenome/vcfbub/releases/download/v0.1.0/vcfbub
+wget -q https://github.com/pangenome/vcfbub/releases/download/v0.1.1/vcfbub
 chmod +x vcfbub
 if [[ $STATIC_CHECK -ne 1 || $(ldd vcfbub | grep so | wc -l) -eq 0 ]]
 then


### PR DESCRIPTION
This fixes an [issue](https://github.com/pangenome/pggb/issues/287) where `vcfbub` could write records that are invalid because they are missing genotype columns.  

Resolves #1416.  