### PR TITLE
Use smaller distance index for --hapl, and decouple from --giraffe

### DIFF
--- a/doc/pangenome.md
+++ b/doc/pangenome.md
@@ -199,7 +199,7 @@ The individual parts of the pipeline can be run independently using the followin
 * `yeast.sv.gfa.gz`: This graph is output by `minigraph`.  It contains SVs only, and doesn't have embedded paths for the input sequences.
 * `yeast.full.gfa.gz`: This is the `full` minigraph-cactus graph. It is normalized, but no sequence is removed. It and its indexes will have `.full` in their filenames. 
 * `yeast.gfa.gz`. This is the default or `clip` graph. Stretches of sequence `>10kb` that were not aligned to the underlying SV/minigraph are removed. "Dangling" nodes (ie that don't have an edge on each side) that aren't on the reference path are also removed, so that each chromosome only has two tips in the graph.
-* `yeast.d2.gfa.gz`: This `filter` graph is made by removing nodes covered by fewer than 2 haplotypes (this value can be changed using the `--filter` option) from the `clip` graph. **Note** in newer versions of vg, you can usually get away without allele frequency filtering by way of haplotype sampling (using the `--haplo` option to make an index for this). 
+* `yeast.d2.gfa.gz`: This `filter` graph is made by removing nodes covered by fewer than 2 haplotypes (this value can be changed using the `--filter` option) from the `clip` graph. **Note** in newer versions of vg, you can usually get away without allele frequency filtering by way of haplotype sampling (using the `--haplo` option (without `--giraffe`)) to make an index for this). 
 
 The `clip` graph is a subgraph of the `full` graph and the `filter` graph is a subgraph of the `clip` graph. Put another way, any node in the `filter` graph exists with the exact same ID and sequence in the `clip` graph, etc. 
 
@@ -227,10 +227,9 @@ Also new in v2.8.2, you can use the `--vcfwave` option to create a version of th
 
 ### Haplotype Sampling Instead of Filtering (NEW)
 
-The `.dX` graphs created with `--filter` were necessary for read mapping, but now `vg` supports dynamic haplotype subsampling (ie personalized pangenomes) and, in most cases, filtering is no longer necessary. In order to use haplotype sampling, run `cactus-pangenome / cactus-graphmap-join` with the `--haplo clip --giraffe clip` options. This will create the `giraffe` indexes for the clipped (unfiltered) graph, as well as the special `.hapl` haplotype index. From there, you can use the `.hapl` and `.gbz` (you do not need the `.dist` or `.min`) to run `vg giraffe` using the current best practices.
+The `.dX` graphs created with `--filter` were necessary for read mapping, but now `vg` supports dynamic haplotype subsampling (ie personalized pangenomes) and, in most cases, filtering is no longer necessary. In order to use haplotype sampling, run `cactus-pangenome / cactus-graphmap-join` with the `--haplo` option (and do not use `--giraffe`). This will create the `giraffe` indexes for the special `.hapl` haplotype index which (with the `.gbz`` is all you need to run `vg giraffe` using the current best practices.
 
-While this process will give better mapping performance than using the `--filter` graphs there are two downsides:
-* In order to make the `.hapl` index, a `.dist` index must be created for the clipped graph (hence the required `--giraffe clip`).  This can be memory intensive for very complex graphs (ie involving different species).
+While this process will give better mapping performance than using the `--filter` graphs there is one downside:
 * Read mapping will now require an invocation of `kmc` to compute a kmer index (see links below). While this adds complexity, it does not seriously affect runtime (the time used making the kmer index and doing the subsampling is balanced out by faster mappings times).
 
 Further reading:

--- a/doc/sa_refgraph_hackathon_2023.md
+++ b/doc/sa_refgraph_hackathon_2023.md
@@ -85,12 +85,14 @@ I am going to run on 32-cores in order to simulate my understanding of an "avera
 
 Here it is, with an explanation of each option following below.
 
+**Update:** Previous versions of this document used `--giraffe clip filter` below.  Since Cactus v2.8.5, this is [no longer necessary](https://github.com/ComparativeGenomicsToolkit/cactus/pull/1424): you can use just `--giraffe filter` (or leave the `--giraffe` option out altogether to go all in on haplotype subsampling). Not using `--giraffe clip` drastically reduces peak memory usage.
+
 ```
 rm -rf cactus-scratch && mkdir cactus-scratch
 
 singularity exec -H $(pwd) docker://quay.io/comparative-genomics-toolkit/cactus:v2.6.13 \
 cactus-pangenome ./js ./hprc10.seqfile --outDir ./hprc10 --outName hprc10 --reference GRCh38 CHM13 \
---filter 2 --haplo --giraffe clip filter --viz --odgi --chrom-vg clip filter --chrom-og --gbz clip filter full \
+--filter 2 --haplo --giraffe filter --viz --odgi --chrom-vg clip filter --chrom-og --gbz clip filter full \
 --gfa clip full --vcf --vcfReference GRCh38 CHM13 --logFile ./hprc10.log --workDir ./cactus-scratch \
 --consCores 8 --mgMemory 128Gi
 ```
@@ -107,7 +109,7 @@ For `cactus-pangenome`:
 * `--reference GRCh38 CHM13`: Specify these two samples as reference genomes. Reference samples are indexed a little different in `vg` to make their coordinates easier to use. Also, the first reference given (GRCh38 in this case), is used to anchor the entire graph and is treated differently than the other samples.  Please see [here for more details](https://github.com/ComparativeGenomicsToolkit/cactus/blob/master/doc/pangenome.md#reference-sample).
 * `--filter 2`: Create an Allele-Frequency filtered (AF) graph that contains only nodes and edges supported by at least 2 haplotypes. This can lead to better mapping performance. `--filter 9` was used for the 90-assembly HPRC graph.  
 * `--haplo`: We are actually phasing out the Allele-Frequency filtering as described above in favour or dynamic creation of personal pangenomes. Using this option will create the necessary indexes for this functionality.
-* `--giraffe clip filter`: Make giraffe indexes for the Allele-Frequency filtered graph in addition to the (default) clipped graph.
+* `--giraffe filter`: Make giraffe indexes for the Allele-Frequency filtered graph.
 * `--viz`: Make an ODGI 1D visualization image for each chromosome.
 * `--odgi`: Make an ODGI formatted whole-genome graph
 * `--chrom-vg clip filter`: Make VG formatted chromosome graphs for the both the AF filtered and (default) clipped pangenome.
@@ -217,13 +219,15 @@ Next, switch to the directory where your input data is and where you want to run
 
 **IMPORTANT** Toil/Cactus do not (yet) understand cluser time limits. This will change soon (our cluster will be adopting time limits this month), but in the meantime, you need to make sure that the default time limit for all jobs is longer than the slowest job (which is almost always minigraph construction). One way to do this is with the `TOIL_SLURM_ARGS` environment variable. In general, this variable lets you add any options you want to every job submitted to the cluster by Cactus (see `sbatch --help` for a listing) of possible options. If you do not specify this, jobs will be submitted with some default limit (3 hours, I think) and get evicted if they go longer. Thanks **Mamana Mbiyavanga** for helping to figure this out!!!
 
+**Update:** Previous versions of this document used `--giraffe clip filter` below.  Since Cactus v2.8.5, this is [no longer necessary](https://github.com/ComparativeGenomicsToolkit/cactus/pull/1424): you can use just `--giraffe filter` (or leave the `--giraffe` option out altogether to go all in on haplotype subsampling). Not using `--giraffe clip` drastically reduces peak memory usage. 
+
 ```
 export TOIL_SLURM_ARGS="-t 1440"
 
 rm -rf slurm-logs ; mkdir -p slurm-logs
 
 cactus-pangenome ./js ./hprc10.seqfile --outDir ./hprc10 --outName hprc10 --reference GRCh38 CHM13 \
---filter 2 --haplo --giraffe clip filter --viz --odgi --chrom-vg clip filter --chrom-og --gbz clip filter full \
+--filter 2 --haplo --giraffe filter --viz --odgi --chrom-vg clip filter --chrom-og --gbz clip filter full \
 --gfa clip full --vcf --vcfReference GRCh38 CHM13 --logFile ./hprc10.log
 --consCores 8 --mgMemory 128Gi --batchSystem slurm --batchLogsDir ./slurm-logs --binariesMode singularity
 ```

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -939,7 +939,7 @@ def make_vcf(job, config, out_name, vcf_ref, index_dict, fasta_ref_dict, tag='',
         output_dict['{}raw.vcf.gz.tbi'.format(tag)] = job.fileStore.writeGlobalFile(tbi_path)
 
     # running bcftools view acts like a sanity check for the vcf
-    cactus_call(parameters=['bcftools', 'view', vcf_path])
+    cactus_call(parameters=[['bcftools', 'view', vcf_path], ['tail']])
 
     # make the filtered vcf
     if max_ref_allele:        
@@ -964,7 +964,7 @@ def make_vcf(job, config, out_name, vcf_ref, index_dict, fasta_ref_dict, tag='',
             output_dict['{}vcf.gz.tbi'.format(tag)] = job.fileStore.writeGlobalFile(vcfbub_path + '.tbi')
 
         # running bcftools view acts like a sanity check for the vcf
-        cactus_call(parameters=['bcftools', 'view', vcfbub_path])
+        cactus_call(parameters=[['bcftools', 'view', vcfbub_path], ['tail']])
 
     return output_dict
 

--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -428,7 +428,7 @@ class TestCase(unittest.TestCase):
         out_dir = os.path.dirname(self._out_hal(binariesMode))
         out_name = os.path.splitext(os.path.basename(self._out_hal(binariesMode)))[0]
         cactus_pangenome_cmd = ['cactus-pangenome', self._job_store(binariesMode), seq_file_path, '--reference', 'simHuman', 'simChimp',
-                                '--outDir', out_dir, '--outName', out_name, '--noSplit', '--odgi', '--chrom-og', '--viz', '--draw', '--giraffe', 'clip', '--haplo']
+                                '--outDir', out_dir, '--outName', out_name, '--noSplit', '--odgi', '--chrom-og', '--viz', '--draw', '--haplo']
 
         subprocess.check_call(cactus_pangenome_cmd + cactus_opts)
         # cactus-pangenome tacks on the .full to the output name
@@ -581,7 +581,7 @@ class TestCase(unittest.TestCase):
 
         if expect_haplo:
             # make sure we have the haplo indexes:
-            for haplo_idx in ['yeast.ri', 'yeast.hapl']:
+            for haplo_idx in ['yeast.hapl']:
                 idx_bytes = os.path.getsize(os.path.join(join_path, haplo_idx))
                 self.assertGreaterEqual(idx_bytes, 10000000)
 


### PR DESCRIPTION
Previously, you needed to run `--hapl --giraffe clip` to make the new haplotype subsampling index.  This is because the `.dist` index generated by `--giraffe` is a requirement for making the `.hapl` index. 

But making the `.dist` index of the clip graph in this way (as opposed to the filter graph) could take loads of time and memory.  And, I just found out, `vg haplotypes` doesn't actually need a full distance index: it can get by on a top-level index constructed with `vg index --snarl-limit 1`.  

For `hprc-v1.1-mc-chm13.dist`, the savings are substantial by using this option.
```
vg index hprc-v1.1-mc-chm13.xg -j top.dist --snarl-limit 1"
        Elapsed (wall clock) time (h:mm:ss or m:ss): 57:22.61
        Maximum resident set size (kbytes): 79057736

vg index hprc-v1.1-mc-chm13.xg -j default.dist"
        Elapsed (wall clock) time (h:mm:ss or m:ss): 1:54:50
        Maximum resident set size (kbytes): 258998352
```

This PR allows you to run `--hapl` without `--giraffe`.  In this case, only the top-level distance index is created. It is used to make the `.hapl` index then thrown away.  This removes a major memory bottleneck especially on large diverse graphs. 


