### PR TITLE
Split multiallelic sites and drop AT fields before running vcfwave

### DIFF
--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -437,7 +437,7 @@ class TestCase(unittest.TestCase):
         # make sure it made output
         if binariesMode == 'docker':
             wave_vcf_bytes = os.path.getsize(os.path.join(out_dir, out_name + '.simChimp.wave.vcf.gz'))
-            self.assertGreaterEqual(wave_vcf_bytes, 500000)
+            self.assertGreaterEqual(wave_vcf_bytes, 300000)
 
 
     def _run_yeast_pangenome_step_by_step(self, binariesMode):


### PR DESCRIPTION
There are apparently some bugs in `vcfwave`: https://github.com/vcflib/vcflibissues/403 in that it can produce

* incorrect genotypes
* incorrect `AT` fields

Until they are fixed, I'm adding this quick patch that splits multallelic records and drops `AT` fields *before* `vcfwave` gets run.  This seems to fix the given examples, but I'm not sure if it resolves everything.  The splitting comes at the cost of variants `ID`s no longer being unique, but I think that's still preferred over wrong genotypes. 