### PR TITLE
Divide minigraph construction into chunks

### DIFF
--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -317,7 +317,8 @@
 	<!-- assemblyName: special name of "virtual" minigraph assembly, which is just the list of sequences from the graph. -->
 	<!-- minigraphMapOptions: flags to pass to minigraph for mapping -->
 	<!-- minigraphConstructOptions: flags to pass to minigraph for construction -->
-	<!-- minigraphSortInput: Method used to determine input order. Valid values are "mash", "size", "none" / "0" which refer to (decreasing) mash distance to reference, (decreasing) size or no sorting (order in seqfile), respectively -->
+	<!-- minigraphConstructBatchSize: break minigraph construction into chunks of this size. this allows recovering from a failure during graph construction, and avoiding really long argument lists for each job. -->
+	<!-- minigraphSortInput: Method used to determine input order. Valid values are "mash", "none" / "0" which refer to (decreasing) mash distance to reference, or no sorting (order in seqfile), respectively -->
 	<!-- minMAPQ: ignore minigraph alignments with mapping quality less than this -->
 	<!-- minGAFBlockLength: ignore minigraph alignments with block length less than this -->
 	<!-- minGAFQueryOverlapFilter: if 2 or more query regions in blocks of at least this size, filter them out. -->
@@ -338,6 +339,7 @@
 		 assemblyName="_MINIGRAPH_"
 		 minigraphMapOptions="-c -xasm"
 		 minigraphConstructOptions="-c -xggs"
+		 minigraphConstructBatchSize="50"
 		 minigraphSortInput="mash"
 		 minMAPQ="5"
 		 minGAFBlockLength="250000"

--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -425,6 +425,19 @@ class TestCase(unittest.TestCase):
             # tack on a vcfwave test for docker binaries
             cactus_opts += ['--vcf', '--vcfReference', 'simChimp', '--clip', '1000', '--vcfwave']
 
+        # use the same logic cactus does to get default config
+        config_path = 'src/cactus/cactus_progressive_config.xml'
+        xml_root = ET.parse(config_path).getroot()
+        graphmap_elem = xml_root.find("graphmap")
+        # force cactus to use minigraph chunking
+        graphmap_elem.attrib["minigraphConstructBatchSize"] = "2"
+        mc_config_path = os.path.join(self.tempDir, "config.mc.xml")
+        with open(mc_config_path, 'w') as mc_config_file:
+            xmlString = ET.tostring(xml_root, encoding='unicode')
+            xmlString = minidom.parseString(xmlString).toprettyxml()
+            mc_config_file.write(xmlString)
+        cactus_opts += ['--configFile', mc_config_path]
+            
         out_dir = os.path.dirname(self._out_hal(binariesMode))
         out_name = os.path.splitext(os.path.basename(self._out_hal(binariesMode)))[0]
         cactus_pangenome_cmd = ['cactus-pangenome', self._job_store(binariesMode), seq_file_path, '--reference', 'simHuman', 'simChimp',


### PR DESCRIPTION
Instead of running a single `minigraph -xggs` construction call on all input sequences at once, it now runs a sequence of such calls on smaller batches, each in a separate Toil job.

The reasons for doing this are:
* Each batch serves as a checkpoint for a possibly resuming a failed workflow from.  For example, when aligning 200 sequences, if you run out of memory on the last one, then you don't need to realign all 200, rather it will start again at 150 (using default batch size of 50).  
* Smaller command lines.  Cactus will sometimes use strings for parameter lists (as per its piping and docker etc logic).  If you have enough input genomes, then it's easy to overrun a system limit like `MAX_ARG_STRLEN` which prevents the `minigraph` command from being run altogether.  It also makes for messy logging.

Both these issues become more likely now that the HAL limitation on input genomes is [fixed](#1436).

This is controlled in `<graphmap minigraphConstructBatchSize="50">` in the config xml (and defaults to 50 as shown). 

