### PR TITLE
disable outgroup computation for pangenomes

### DIFF
--- a/src/cactus/refmap/cactus_graphmap.py
+++ b/src/cactus/refmap/cactus_graphmap.py
@@ -114,8 +114,7 @@ def graph_map(options):
             # load up the seqfile and figure out the outgroups and schedule
             config_wrapper.substituteAllPredefinedConstantsWithLiterals(options)
             mc_tree, input_seq_map, og_candidates = parse_seqfile(options.seqFile, config_wrapper, pangenome=True)
-            og_map = compute_outgroups(mc_tree, config_wrapper, set(og_candidates))
-            event_set = get_event_set(mc_tree, config_wrapper, og_map, mc_tree.getRootName())
+            event_set = get_event_set(mc_tree, config_wrapper, {}, mc_tree.getRootName())
 
             # apply path overrides.  this was necessary for wdl which doesn't take kindly to
             # text files of local paths (ie seqfile).  one way to fix would be to add support

--- a/src/cactus/refmap/cactus_refmap.py
+++ b/src/cactus/refmap/cactus_refmap.py
@@ -297,8 +297,7 @@ def main():
         config_wrapper = ConfigWrapper(config_node)
         config_wrapper.substituteAllPredefinedConstantsWithLiterals(options)
         mc_tree, input_seq_map, og_candidates = parse_seqfile(options.seqFile, config_wrapper)
-        og_map = compute_outgroups(mc_tree, config_wrapper, set(og_candidates))
-        event_set = get_event_set(mc_tree, config_wrapper, og_map, mc_tree.getRootName())
+        event_set = get_event_set(mc_tree, config_wrapper, {}, mc_tree.getRootName())
 
         # apply path overrides.  this was necessary for wdl which doesn't take kindly to
         # text files of local paths (ie seqfile).  one way to fix would be to add support

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -260,7 +260,12 @@ def make_align_job(options, toil, config_wrapper=None, chrom_name=None):
     
     mc_tree, input_seq_map, og_candidates = parse_seqfile(options.seqFile, config_wrapper,
                                                           pangenome=options.pangenome)
-    og_map = compute_outgroups(mc_tree, config_wrapper, set(og_candidates), chrom_info_file = options.chromInfo)
+    if options.pangenome:
+        # outgroups not supported in pangenomes
+        # also, compute_outgroups() uses about 300 * N^2 bytes which can be huge for big pangenomes
+        og_map = {}
+    else:
+        og_map = compute_outgroups(mc_tree, config_wrapper, set(og_candidates), chrom_info_file = options.chromInfo)
     event_set = get_event_set(mc_tree, config_wrapper, og_map, options.root if options.root else mc_tree.getRootName())
     if options.includeRoot:
         if options.root not in input_seq_map:


### PR DESCRIPTION
It seems that `compute_outgroups()` uses quadratic memory in the size of the tree, I guess for a big distance matrix.  This has never been an issue for progressive cactus, but as I'm testing making pangenomes with tons of small inputs it's now a bottleneck. 

This PR just disables outgroup computation for pangenomes (they aren't used at all anyway). But at some point it'd be good to revise things so that outgroup computation can work without the full matrix in memory...

Note, this means #1043 will need updating to add more nuanced control / a better fix. 