### PR TITLE
Cap number of minigraph construction batches

### DIFF
--- a/src/cactus/refmap/cactus_minigraph.py
+++ b/src/cactus/refmap/cactus_minigraph.py
@@ -314,6 +314,13 @@ def minigraph_construct_in_batches(job, options, config_node, seq_id_map, seq_or
     max_batch_size = getOptionalAttrib(xml_node, "minigraphConstructBatchSize", int, default=-1)
     assert max_batch_size > 0
     num_batches = int(math.ceil(len(seq_order) / max_batch_size))
+    if num_batches >= 990:
+        # Toil will fail with a python recursion error if we try to chain too many jobs
+        new_max_batch_size = int(len(seq_order) / 990 + 1)
+        job.fileStore.logToMaster('WARNING: Increasing minigraphConstructBatchSize from {} to {} to avoid Toil error from chaining too many jobs'.format(max_batch_size, new_max_batch_size))
+        max_batch_size = new_max_batch_size
+        num_batches = int(math.ceil(len(seq_order) / max_batch_size))
+        assert num_batches > 0 and num_batches <= 991
     prev_job = None
     prev_gfa_path = None
     for i in range(num_batches):        


### PR DESCRIPTION
They are run in a follow-on chain and Toil apparently handles them with recursive calls.  So having more than 999 results in a Python exception about a recursion limit being exceeded.  

The default batch size is 50.  This PR will boost it to whatever's needed (with a warning) to keep the number of jobs comfortably under 999, allowing inputs of more than 50k genomes to run through (this part of the pipeline) ok. 