### PR TITLE
[experimental] FastGA support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,6 @@
 [submodule "submodules/red"]
 	path = submodules/red
 	url = https://github.com/glennhickey/red.git
+[submodule "submodules/FASTGA"]
+	path = submodules/FASTGA
+	url = https://github.com/thegenemyers/FASTGA.git

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ modules = api setup caf bar hal reference pipeline preprocessor
 
 # submodules are in multiple pass to handle dependencies cactus2hal being dependent on
 # both cactus and sonLib
-submodules1 = sonLib cPecan hal matchingAndOrdering pinchesAndCacti abPOA lastz paffy red
+submodules1 = sonLib cPecan hal matchingAndOrdering pinchesAndCacti abPOA lastz paffy red FASTGA
 submodules2 = cactus2hal
 submodules = ${submodules1} ${submodules2}
 
@@ -270,6 +270,14 @@ suball.paffy:
 suball.red:
 	cd submodules/red && ${MAKE}
 	ln -f submodules/red/bin/Red ${BINDIR}
+
+suball.FASTGA:
+	cd submodules/FASTGA && ${MAKE}
+	ln -f submodules/FASTGA/FastGA ${BINDIR}
+	ln -f submodules/FASTGA/ALNtoPAF ${BINDIR}
+	ln -f submodules/FASTGA/FAtoGDB ${BINDIR}
+	ln -f submodules/FASTGA/GIXmake ${BINDIR}
+	ln -f submodules/FASTGA/GIXrm ${BINDIR}
 
 subclean.%:
 	cd submodules/$* && ${MAKE} clean

--- a/src/cactus/blast/cactus_blast.py
+++ b/src/cactus/blast/cactus_blast.py
@@ -106,7 +106,7 @@ def runCactusBlastOnly(options):
             config_wrapper.substituteAllPredefinedConstantsWithLiterals(options)
             config_wrapper.applySlurmChunkScaling(options)
             # apply gpu override
-            config_wrapper.initGPU(options)
+            config_wrapper.initLastz(options)
             mc_tree, input_seq_map, og_candidates = parse_seqfile(options.seqFile, config_wrapper)
             og_map = compute_outgroups(mc_tree, config_wrapper, set(og_candidates), chrom_info_file = options.chromInfo)
             event_set = get_event_set(mc_tree, config_wrapper, og_map, options.root)

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -36,8 +36,9 @@
 	<!-- Params for blast -->
 	<!-- chunkSize The size of sequences in a blast job. Increase the chunkSize in the caf tag to reduce the number of blast jobs approximately quadratically -->
 	<!-- overlapSize The amount of basepair overlap between chunks -->
-	<!-- mapper The local alignment program to use, currently either lastz or minimap2 -->
+	<!-- mapper The local alignment program to use, currently either lastz or minimap2 or fastga -->
 	<!-- minimap2_params Parameters to use with minimap2 -->
+	<!-- fastga_params Parameters to use with fastga -->
 	<!-- compressFiles Compress the local alignments. (I think this may be broken) -->
 	<!-- filterByIdentity Filter alignments by % identity -->
 	<!-- identityRatio Let L be the sum of the branch lengths in the guide tree on the path connecting the genomes to be aligned.
@@ -70,6 +71,7 @@
 		   overlapSize="10000"
 		   mapper="lastz"
 		   minimap2_params="-x asm20"
+		   fastga_params="-pafx"
 		   minimumSequenceLengthForBlast="30"
 		   compressFiles="1"
 		   filterByIdentity="0"
@@ -104,7 +106,7 @@
 				four="--step=3 --ambiguous=iupac,100,100 --ydrop=3000"
 				five="--step=2 --ambiguous=iupac,100,100 --ydrop=3000"
 				default="--step=1 --ambiguous=iupac,100,100 --ydrop=3000"
-		/>
+				/>
 	</blast>
 
 	<setup makeEventHeadersAlphaNumeric="0"/>

--- a/src/cactus/paf/local_alignment.py
+++ b/src/cactus/paf/local_alignment.py
@@ -171,7 +171,8 @@ def merge_combined_chunks(job, combined_chunks):
 def make_chunked_alignments(job, event_a, genome_a, event_b, genome_b, distance, params):
     lastz_params_node = params.find("blast")
     gpu = getOptionalAttrib(lastz_params_node, 'gpu', typeFn=int, default=0)
-    if gpu:
+    fastga = getOptionalAttrib(lastz_params_node, 'mapper', typeFn=str) == 'fastga'
+    if gpu or fastga:
         # wga-gpu has a 6G limit, so we always override
         lastz_params_node.attrib['chunkSize'] = '6000000000'
     lastz_cores = getOptionalAttrib(lastz_params_node, 'cpu', typeFn=int, default=None)

--- a/src/cactus/paf/local_alignment.py
+++ b/src/cactus/paf/local_alignment.py
@@ -100,11 +100,35 @@ def run_minimap2(job, name_A, genome_A, name_B, genome_B, distance, params):
     minimap2_params = params.find("blast").attrib["minimap2_params"]
     
     # Generate the alignment
-    minimap2_cmd = ['minimap2',
-                    '-c',
-                    job.fileStore.readGlobalFile(genome_A),
-                    job.fileStore.readGlobalFile(genome_B)] + minimap2_params.split(' ')
+    minimap2_cmd = ['minimap2', '-c', genome_a_file, genome_b_file] + minimap2_params.split(' ')
     cactus_call(parameters=minimap2_cmd, outfile=alignment_file, job_memory=job.memory)
+
+    # Return the alignment file
+    return job.fileStore.writeGlobalFile(alignment_file)
+
+def run_fastga(job, name_A, genome_A, name_B, genome_B, distance, params):
+    # Create a local temporary file to put the alignments in.
+    work_dir = job.fileStore.getLocalTempDir()
+    fastga_tempdir = os.path.join(work_dir, 'fgatmp')
+    os.mkdir(fastga_tempdir)
+    
+    alignment_file = os.path.join(work_dir, '{}_{}.paf'.format(name_A, name_B))
+
+    # Get the input files
+    genome_a_file = os.path.join(work_dir, '{}.fa'.format(name_A))
+    genome_b_file = os.path.join(work_dir, '{}.fa'.format(name_B))
+    job.fileStore.readGlobalFile(genome_A, genome_a_file)
+    job.fileStore.readGlobalFile(genome_B, genome_b_file)
+
+    fastga_params = params.find("blast").attrib["fastga_params"]
+    
+    # Generate the alignment
+    # note: FastGA very picky about spacking and ordering of parameters
+    fastga_cmd = ['FastGA']
+    if fastga_params:
+        fastga_cmd += fastga_params.split(' ')
+    fastga_cmd += ['-P{}'.format(fastga_tempdir), '-T{}'.format(job.cores), genome_b_file, genome_a_file]
+    cactus_call(parameters=fastga_cmd, outfile=alignment_file, job_memory=job.memory)
 
     # Return the alignment file
     return job.fileStore.writeGlobalFile(alignment_file)
@@ -172,7 +196,7 @@ def make_chunked_alignments(job, event_a, genome_a, event_b, genome_b, distance,
     chunked_alignment_files = []
     for i, chunk_a in enumerate(chunks_a):
         for j, chunk_b in enumerate(chunks_b):
-            mappers = { "lastz":run_lastz, "minimap2":run_minimap2}
+            mappers = { "lastz":run_lastz, "minimap2":run_minimap2, "fastga":run_fastga}
             mappingFn = mappers[params.find("blast").attrib["mapper"]]
             memory = lastz_memory if lastz_memory else max(200000000, 15*(chunk_a.size+chunk_b.size))
             chunked_alignment_files.append(job.addChildJobFn(mappingFn, '{}_{}'.format(event_a, i), chunk_a,
@@ -227,6 +251,7 @@ def make_ingroup_to_outgroup_alignments_1(job, ingroup_event, outgroup_events, e
 
 def make_ingroup_to_outgroup_alignments_2(job, alignments, ingroup_event, outgroup_events,
                                           event_names_to_sequences, distances, params):
+    
     # a job should never set its own follow-on, so we hang everything off root_job here to encapsulate
     root_job = Job()
     job.addChild(root_job)
@@ -234,17 +259,21 @@ def make_ingroup_to_outgroup_alignments_2(job, alignments, ingroup_event, outgro
     # identify all ingroup sub-sequences that remain unaligned longer than a threshold as follows:
 
     # run paffy to_bed to create a bed of aligned coverage
-    bed_file = job.fileStore.getLocalTempFile()  # Get a temporary file to store the bed file in
+    work_dir = job.fileStore.getLocalTempDir()
+    alignments_file = os.path.join(work_dir, '{}.paf'.format(ingroup_event.iD))
+    job.fileStore.readGlobalFile(alignments, alignments_file)
+    bed_file = os.path.join(work_dir, '{}.bed'.format(ingroup_event.iD))  # Get a temporary file to store the bed file in
     messages = cactus_call(parameters=['paffy', 'to_bed', "--excludeAligned", "--binary",
                                        "--minSize", params.find("blast").attrib["trimMinSize"],
-                                       "-i", job.fileStore.readGlobalFile(alignments),
+                                       "-i", alignments_file,
                                        "--logLevel", getLogLevelString()],
                                        outfile=bed_file, returnStdErr=True, job_memory=job.memory)
     logger.info("paffy to_bed event:{}\n{}".format(ingroup_event.iD, messages[:-1]))  # Log paffy to_bed
 
     # run faffy extract to extract unaligned sequences longer than a threshold creating a reduced subset of A
-    seq_file = job.fileStore.getLocalTempFile()  # Get a temporary file to store the subsequences in
-    ingroup_seq_file = job.fileStore.readGlobalFile(event_names_to_sequences[ingroup_event.iD])  # The ingroup sequences
+    seq_file = os.path.join(work_dir, '{}_subseq.fa'.format(ingroup_event.iD))  # Get a temporary file to store the subsequences in
+    ingroup_seq_file = os.path.join(work_dir, '{}.fa'.format(ingroup_event.iD))
+    job.fileStore.readGlobalFile(event_names_to_sequences[ingroup_event.iD], ingroup_seq_file)  # The ingroup sequences
     messages = cactus_call(parameters=['faffy', 'extract', "-i", bed_file, ingroup_seq_file,
                                        "--flank", params.find("blast").attrib["trimFlanking"],
                                        "--logLevel", getLogLevelString()],
@@ -553,24 +582,27 @@ def trim_unaligned_sequences(job, sequences, alignments, params, has_resources=F
     if not has_resources:
         return job.addChildJobFn(trim_unaligned_sequences, sequences, alignments, params, has_resources=True,
                                  disk=8*sum([seq.size for seq in sequences]) + 32*alignments.size,
-                                 memory=cactus_clamp_memory(8*sum([seq.size for seq in sequences]) + 32*alignments.size)).rv()        
-    
-    alignments = job.fileStore.readGlobalFile(alignments)  # Download the alignments
+                                 memory=cactus_clamp_memory(8*sum([seq.size for seq in sequences]) + 32*alignments.size)).rv()
+
+    work_dir = job.fileStore.getLocalTempDir()
+    alignments_file = os.path.join(work_dir, 'alignments.paf')    
+    job.fileStore.readGlobalFile(alignments, alignments_file)  # Download the alignments
 
     # Make a bed of aligned sequence
     # run paffy to_bed to create a bed of aligned coverage
-    bed_file = job.fileStore.getLocalTempFile()  # Get a temporary file to store the bed file in
+    bed_file = alignments_file + '.bed' # Get a temporary file to store the bed file in
     messages = cactus_call(parameters=['paffy', 'to_bed', "--binary", "--excludeUnaligned", "--includeInverted",
-                                       '-i', alignments, "--logLevel", getLogLevelString()],
+                                       '-i', alignments_file, "--logLevel", getLogLevelString()],
                            outfile=bed_file, returnStdErr=True, job_memory=job.memory)
     # Log paffy to_bed
     logger.info("paffy to_bed:\n{}".format(messages[:-1]))
 
     trimmed_sequence_files = []
-    for sequence in sequences:
+    for i, sequence in enumerate(sequences):
         # run faffy extract to extract unaligned sequences longer than a threshold creating a reduced subset of A
-        seq_file = job.fileStore.readGlobalFile(sequence)  # Load original sequence file
-        trimmed_seq_file = job.fileStore.getLocalTempFile()  # Get a temporary file to store the extracted subsequences
+        seq_file = os.path.join(work_dir, '{}.fa'.format(i))
+        job.fileStore.readGlobalFile(sequence, seq_file)  # Load original sequence file
+        trimmed_seq_file = seq_file + '.trim'  # Get a temporary file to store the extracted subsequences
         messages = cactus_call(parameters=['faffy', 'extract', "-i", bed_file, seq_file, "--skipMissing", "--minSize", "1",
                                            "--flank", params.find("blast").attrib["trimOutgroupFlanking"],
                                            "--logLevel", getLogLevelString()],
@@ -579,8 +611,8 @@ def trim_unaligned_sequences(job, sequences, alignments, params, has_resources=F
         trimmed_sequence_files.append(trimmed_seq_file)
 
     # Now convert the alignments to refer to the reduced sequences
-    trimmed_alignments = job.fileStore.getLocalTempFile()  # Get a temporary file to store the "trimmed" alignments
-    messages = cactus_call(parameters=['paffy', 'upconvert', "-i", alignments, "--logLevel", getLogLevelString()] +
+    trimmed_alignments = alignments_file + '.trim'  # Get a temporary file to store the "trimmed" alignments
+    messages = cactus_call(parameters=['paffy', 'upconvert', "-i", alignments_file, "--logLevel", getLogLevelString()] +
                            trimmed_sequence_files, outfile=trimmed_alignments, returnStdErr=True)
     logger.info("paffy upconvert\n{}".format(messages[:-1]))  # Log
 

--- a/src/cactus/preprocessor/cactus_preprocessor.py
+++ b/src/cactus/preprocessor/cactus_preprocessor.py
@@ -513,7 +513,7 @@ def main():
 
     # toggle on the gpu
     config_wrapper = ConfigWrapper(configNode)
-    config_wrapper.initGPU(options)
+    config_wrapper.initLastz(options)
 
     # apply pangenome overrides
     if options.pangenome:

--- a/src/cactus/progressive/cactus_progressive.py
+++ b/src/cactus/progressive/cactus_progressive.py
@@ -419,7 +419,7 @@ def main():
                 config_wrapper.setMaxNumOutgroups(options.maxOutgroups)
 
             # apply gpu override
-            config_wrapper.initGPU(options)
+            config_wrapper.initLastz(options)
             mc_tree, input_seq_map, og_candidates = parse_seqfile(options.seqFile, config_wrapper, root_name = options.root)
             logger.info('Tree: {}'.format(NXNewick().writeString(mc_tree)))
             og_map = compute_outgroups(mc_tree, config_wrapper, set(og_candidates), options.root,

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -255,7 +255,7 @@ def make_align_job(options, toil, config_wrapper=None, chrom_name=None):
         config_node = ET.parse(options.configFile).getroot()
         config_wrapper = ConfigWrapper(config_node)
         config_wrapper.substituteAllPredefinedConstantsWithLiterals(options)
-        config_wrapper.initGPU(options)
+        config_wrapper.initLastz(options)
     config_wrapper.setSystemMemory(options)
     
     mc_tree, input_seq_map, og_candidates = parse_seqfile(options.seqFile, config_wrapper,

--- a/src/cactus/shared/configWrapper.py
+++ b/src/cactus/shared/configWrapper.py
@@ -252,17 +252,25 @@ class ConfigWrapper:
                 return getOptionalAttrib(node, "active", default="1" if default_val else "0") == "1"
         return default_val
 
-    def initGPU(self, options):
+    def initLastz(self, options):
         """ Turn on GPU and / or check options make sense """
+        # fastga trumps all.  we explicitly disable gpu if it's on
+        fastga = getOptionalAttrib(findRequiredNode(self.xmlRoot, 'blast'), 'mapper', typeFn=str) == 'fastga'
+        
         # first, we override the config with --gpu from the options
         # (we'll never use the options.gpu after -- only the config)
-        if options.gpu:
-            findRequiredNode(self.xmlRoot, "blast").attrib["gpu"] = str(options.gpu)
+        if options.gpu or fastga:            
+            findRequiredNode(self.xmlRoot, "blast").attrib["gpu"] = '0' if fastga else str(options.gpu)
             for node in self.xmlRoot.findall("preprocessor"):
                 if getOptionalAttrib(node, "preprocessJob") == "lastzRepeatMask":
-                    node.attrib["gpu"] = str(options.gpu)
-            if 'latest' in options and options.latest:
+                    node.attrib["gpu"] = '0' if fastga else str(options.gpu)
+                if fastga and getOptionalAttrib(node, "preprocessJob") in ["red", "lastzRepeatMask"]:
+                    node.attrib["active"] = '0'                    
+            if options.gpu and 'latest' in options and options.latest:
                 raise RuntimeError('--latest cannot be used with --gpu')
+            if fastga:
+                logger.warning('Disabling --gpu because FastGA activated')
+                options.gpu = None
             
         # we need to make sure that gpu is set to an integer (replacing 'all' with a count)
         def get_gpu_count():
@@ -307,18 +315,22 @@ class ConfigWrapper:
         if 'lastzMemory' not in options:
             options.lastzMemory = None            
         lastz_cores = options.lastzCores if options.lastzCores else None
-            
-        if getOptionalAttrib(findRequiredNode(self.xmlRoot, "blast"), 'gpu', typeFn=int, default=0):
+
+        if getOptionalAttrib(findRequiredNode(self.xmlRoot, 'blast'), 'gpu', typeFn=int, default=0) or fastga:
             if not lastz_cores:
                 # segalign still can't contorl the number of cores it uses (!).  So we give all available on
-                # single machine.  
+                # single machine.
+                # note: we apply the same logic (default to all cpus) for FastGA, at least for now. 
                 if options.batchSystem.lower() in ['single_machine', 'singlemachine']:
                     if options.maxCores is not None and options.maxCores < 2**20:
                         lastz_cores = options.maxCores
                     else:
                         lastz_cores = cactus_cpu_count()
                 else:
-                    raise RuntimeError('--lastzCores must be used with --gpu on non-singlemachine batch systems')
+                    if fastga:
+                        raise RuntimeError('--lastzCores must be used with FastGA on non-singlemachine batch systems')
+                    else:
+                        raise RuntimeError('--lastzCores must be used with --gpu on non-singlemachine batch systems')
 
         # override blast cores and memory if specified
         if lastz_cores:
@@ -344,6 +356,10 @@ class ConfigWrapper:
             logger.warning("Switching off blast realignment as it is incompatible with GPU mode")
             findRequiredNode(self.xmlRoot, "blast").attrib["realign"] = "0"
 
+        # FastGA doesn't work on fragmented assemblies.  It even crashes on trimmed evolver primates
+        # We work around this a bit by disabling trimming
+        if fastga:
+            findRequiredNode(self.xmlRoot, 'blast').attrib['trimIngroups'] = '0'
 
     def setSystemMemory(self, options):
         """ hide the amount of memory available (on single machine) in the config


### PR DESCRIPTION
[FastGA](https://github.com/thegenemyers/FASTGA) is a new pairwise genome aligner that seems like a good candidate to help speed up Cactus..  This PR adds an option to drop it into progressive cactus as a `lastz` replacement.  

It's got a ways to go before merging though, as it doesn't yet pass the evolver mammals test.  Issues so far:

* `FastGA` aborts when when aligning trimmed ingroups to outgroups.  I've hacked around this by disabling `trimIngroups` when `fastga` is activated.  
* The `Anc0` alignment is empty, leading to a `cactus_consolidated` crash.  I think this is because the ancestor(s) below it are too fragmented for `FastGA` to align. 

Without having spent much time on this, it looks like `FastGA` does not work well with small contigs, at least with its default parameters.  This leads to trouble with trimmed and ancestral sequences in Cactus.  

This branch should still be runnable on pairwise alignments in Cactus, and pairwise tests are probably the next step before seeing how much it's worth pursuing the above issues.  