### PR TITLE
add check for empty fasta header

### DIFF
--- a/preprocessor/cactus_sanitizeFastaHeaders.c
+++ b/preprocessor/cactus_sanitizeFastaHeaders.c
@@ -41,6 +41,12 @@ void addUniqueFastaPrefix(void* destination, const char *fastaHeader, const char
         return;
     }
 
+    // pipeline does not support nameless sequences
+    if (strlen(fastaHeader) == 0) {
+        fprintf(stderr, "Error: empty fasta header (> with nothing after) found in event \"%s\"\n", eventName);
+        exit(1);
+    }
+
     // we cut at whitespace (like preprocessor does by default)
     // optionally cut out up to last #
     int64_t start = 0;


### PR DESCRIPTION
I was trying to reproduce the `lastz` failure from #1466 by adding a sequence like
```
>
ACACACACCAC
```
to the FASTA.  `lastz` seems to support this okay by inventing its own sequence name for it, but it crashes downstream in `consolidated`.  

Anyway, this patches the `fasta` checker to through an error right away in this case.  But I don't think helps at all with the original issue. 