### PR TITLE
Turn vcf left-shifting off by default.

### DIFF
--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -395,8 +395,9 @@
 	<!-- odgiDrawOptions: options to odgi draw, used for 2d viz -->
 	<!-- rindexOptions: options to vg gbwt -r (r-index construction) as used to make haplotype sampling index -->
 	<!-- haplOptions: options to vg haplotypes as used to make haplotype sampling index -->
-	<!-- vcfwaveOptions: options to pass to vcfwave (from vcflib)-->
-	<!-- bcftoolsNorm: Run bcftools norm -f (left shifting) on all non-raw VCF output -->
+	<!-- vcfwaveOptions: options to pass to vcfwave (from vcflib) -->
+	<!-- vcfwaveNorm: run bcftools norm -f (left shift) after vcfwave -->
+	<!-- bcftoolsNorm: Run bcftools norm -f (left shifting) on (non-raw, non-wave) VCF output (may result in overlapping variants) -->
 	<graphmap_join
 		 gfaffix="1"
 		 clipNonMinigraph="1"		 
@@ -410,7 +411,8 @@
 		 rindexOptions="-p"
 		 haplOptions="-v 2"
 		 vcfwaveOptions="-I 1000"
-		 bcftoolsNorm="1"
+		 vcfwaveNorm="1"
+		 bcftoolsNorm="0"
 		 />
 	<!-- hal2vg options -->
 	<!-- includeMinigraph: include minigraph node sequences as paths in output (note that cactus-graphmap-join will still remove them by default) -->

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -958,10 +958,11 @@ def make_vcf(job, config, out_name, vcf_ref, index_dict, fasta_ref_dict, tag='',
     if max_ref_allele:        
         vcfbub_path = os.path.join(work_dir, 'merged.filtered.vcf.gz')
         bub_cmd = [['vcfbub', '--input', vcf_path, '--max-ref-length', str(max_ref_allele), '--max-level', '0']]
-        if getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_join"), "bcftoolsNorm", typeFn=bool, default=True):
+        if getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_join"), "bcftoolsNorm", typeFn=bool, default=False):
             fa_ref_path = os.path.join(work_dir, vcf_ref + '.fa.gz')
             job.fileStore.readGlobalFile(fasta_ref_dict[vcf_ref], fa_ref_path)
             bub_cmd.append(['bcftools', 'norm', '-f', fa_ref_path])
+            bub_cmd.append(['bcftools', 'norm', '-m', '+any'])
             bub_cmd.append(['bcftools', 'sort'])
         bub_cmd.append(['bgzip', '--threads', str(job.cores)])
         cactus_call(parameters=bub_cmd, outfile=vcfbub_path)
@@ -1069,7 +1070,7 @@ def vcfwave_chr(job, config, vcf_ref, vcf_id, tbi_id, fasta_id, contig, vcfbub_t
                    ['bgzip']]
     cactus_call(parameters=bubwave_cmd, outfile=wave_vcf_path)
     
-    if getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_join"), "bcftoolsNorm", typeFn=bool, default=True):
+    if getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_join"), "vcfwaveNorm", typeFn=bool, default=True):
         fa_ref_path = os.path.join(work_dir, vcf_ref + '.fa.gz')
         job.fileStore.readGlobalFile(fasta_id, fa_ref_path)
         norm_vcf_path = os.path.join(work_dir, '{}{}_norm.vcf.gz'.format(tag, contig))


### PR DESCRIPTION
I added `bcftools norm -f` (left shifting) to the VCF export logic by default in [2.8.2](https://github.com/ComparativeGenomicsToolkit/cactus/releases/tag/v2.8.2).  This makes for more consistent variant representation, but can result in overlapping sites.  This apparently [upsets pangenie](#1460), for which I don't want to break support.  

So this PR backtracks on this, making `bcftools norm` off by default.  Someone wanting to run it can do so pretty easily themselves, or turn it back on in the configuration.  It's still on by default for output normalized by `vcfwave`.  

There's a `vcflib` tool called `vcfcreatemulti` that appears to merge overlapping variants.  I'm a bit reluctant to try running it by default now because I'm not sure what it does to tags and, crucially, I don't have a way right now of putting it into the binary release.  People using the Cactus docker image can try it out if they want as it's pretty easy to run. 

Resolve #1477 and #1460