### PR TITLE
Turn node chopping on for all output by default

### DIFF
--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -384,12 +384,13 @@
 		 otherContigName="chrOther"
 		 />
 	<!-- cactus-graphmap-join options -->
+	<!-- maxNodeLength: chop graphs so that nodes have at most this many bases. set to 0 to disable chopping. if this value exceeds 1024 then vg-based files will have different node id spaces than GFA (GBZ will contain translation) -->
 	<!-- gfaffix: toggle gfaffix normalization on/off -->
 	<!-- clipNonMinigraph: clip out regions if the don't align to minigraph (if disabled, clip if they don't align to anything) -->
 	<!-- minimizerOptions: options for vg minimizer -->
 	<!-- minFilterFragment: discard fragments that result from the vg clip frequency filter if they are smaller than this -->
 	<!-- removeStubs: remove any nodes dangling off reference paths (ie softclips) -->
-	<!-- GFANodeIDsInVCF: write all node IDs in the VCF (variant names, AT fields etc.) in the (unchopped) GFA namespace by way of the GBZ translation table -->
+	<!-- GFANodeIDsInVCF: write all node IDs in the VCF (variant names, AT fields etc.) in the (unchopped) GFA namespace by way of the GBZ translation table. this is only relevant if maxNodeLength <=0 or > 1024 (otherwise ids are chopped to be consistent anyway) -->
 	<!-- odgiVizOptions: options to odgi viz, used for 1d viz -->
 	<!-- odgiLayoutOptions: options to odgi layout, used for 2d viz -->
 	<!-- odgiDrawOptions: options to odgi draw, used for 2d viz -->
@@ -399,6 +400,7 @@
 	<!-- vcfwaveNorm: run bcftools norm -f (left shift) after vcfwave -->
 	<!-- bcftoolsNorm: Run bcftools norm -f (left shifting) on (non-raw, non-wave) VCF output (may result in overlapping variants) -->
 	<graphmap_join
+		 maxNodeLength="1024"
 		 gfaffix="1"
 		 clipNonMinigraph="1"		 
 		 minimizerOptions="-k 29 -w 11"

--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -525,14 +525,14 @@ class TestCase(unittest.TestCase):
                                 '--refContigs'] + chroms + ['--reference', 'S288C', 'DBVPG6044', '--vcf', '--vcfReference','DBVPG6044', 'S288C',
                                                             '--giraffe', 'clip', 'filter',  '--chrom-vg', 'clip', 'filter',
                                                             '--viz', '--chrom-og', 'clip', 'full', '--odgi', '--haplo', 'clip',
-                                                            '--xg', '--indexCores', '4', '--consCores', '2']
+                                                            '--xg', '--unchopped-gfa', '--indexCores', '4', '--consCores', '2']
         subprocess.check_call(cactus_pangenome_cmd + cactus_opts)
 
         #compatibility with older test
         subprocess.check_call(['mkdir', '-p', os.path.join(self.tempDir, 'chroms')])
         subprocess.check_call(['mv', os.path.join(join_path, 'chrom-subproblems', 'contig_sizes.tsv'), os.path.join(self.tempDir, 'chroms')])
 
-    def _check_yeast_pangenome(self, binariesMode, other_ref=None, expect_odgi=False, expect_haplo=False):
+    def _check_yeast_pangenome(self, binariesMode, other_ref=None, expect_odgi=False, expect_haplo=False, expect_unchopped_gfa=False):
         """ yeast pangenome chromosome by chromosome pipeline
         """
 
@@ -597,6 +597,13 @@ class TestCase(unittest.TestCase):
             for haplo_idx in ['yeast.hapl']:
                 idx_bytes = os.path.getsize(os.path.join(join_path, haplo_idx))
                 self.assertGreaterEqual(idx_bytes, 10000000)
+
+        if expect_unchopped_gfa:
+            # make sure we have the unchopped gfa
+            unchopped_gfa_bytes = os.path.getsize(os.path.join(join_path, 'yeast.unchopped.gfa.gz'))
+            chopped_gfa_bytes = os.path.getsize(os.path.join(join_path, 'yeast.gfa.gz'))
+            self.assertNotEqual(chopped_gfa_bytes, unchopped_gfa_bytes)
+            self.assertGreaterEqual(unchopped_gfa_bytes, 8000000)
 
         # make sure the chrom splitting stats are somewhat sane
         contig_sizes = {}
@@ -1073,7 +1080,7 @@ class TestCase(unittest.TestCase):
         self._run_yeast_pangenome(name)
 
         # check the output
-        self._check_yeast_pangenome(name, other_ref='DBVPG6044', expect_odgi=True, expect_haplo=True)
+        self._check_yeast_pangenome(name, other_ref='DBVPG6044', expect_odgi=True, expect_haplo=True, expect_unchopped_gfa=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
`cactus-pangenome` originally had two types of output
* `giraffe-specific`  (`.gbwt, .xg, .min, .dist`)  whose nodes were chopped to 1024bp 
*  everything else (`.gfa.gz, .vcf.gz, .vg, odgi`) that had no node length limit.

A translation was kept between the two in a `.trans` file, which was later built into the `.gbz` format when we switched to that.  

This was always confusing, as it was difficult to use `vg` to debug the `gfa` or `vcf` and sometimes `giraffe` would produce output in one coordinate system when you expected the other. 

Now that `.gbz` is becoming a more general (not just for `giraffe`) interchange format, and the `.dist` file (which shares the node length limit) is starting to replace the old snarl format, having unchopped files hanging around only gets more confusing.  

Also, a couple of near-future updates (path normalization and off-reference VCFs) will be working on `.vg` files (currently unchopped) but would need chopping for the distance index, and should be consistent with the chopped `gbz`. 

Anyway, that's why this PR changes things to always chop to 1024bp right at the outset.  This should guarantee all output files are node-id compatible with each other.  If someone doesn't want to use `vg` they can use `--unchopped-gfa` to get an (explicitly) unchopped graph with the `.unchopped.gfa.gz` suffix.  If someone prefers the old logic of having *only* the `giraffe`-related files chopped, they can set `maxNodeLength` to `-1` in the config XML to bring it back.