### PR TITLE
switch to patched vg to fix paths -n

### DIFF
--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -298,7 +298,8 @@ fi
 
 # vg
 cd ${pangenomeBuildDir}
-wget -q https://github.com/vgteam/vg/releases/download/v1.60.0/vg
+#wget -q https://github.com/vgteam/vg/releases/download/v1.60.0/vg
+wget https://public.gi.ucsc.edu/~hickey/vg-patch/vg.51e512ded330c6887555830713043ab20ad930fe -O vg
 chmod +x vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd vg | grep so | wc -l) -eq 0 ]]
 then


### PR DESCRIPTION
`vg paths -n` (path normalization) is now a default part of minigraph-cactus.  but on certain graphs, it can take a really long time.  I'm still not sure why, but it's simple enough to patch by [switching to the older snarls api](https://github.com/vgteam/vg/pull/4421).  This PR updates cactus to use a vg version containing this patch.   