### PR TITLE
Only use abPOA's progressive mode if input lengths all (about) the same

### DIFF
--- a/bar/impl/bar.c
+++ b/bar/impl/bar.c
@@ -71,6 +71,7 @@ void bar(stList *flowers, CactusParams *params, CactusDisk *cactusDisk, stList *
     int64_t poaWindow = cactusParams_get_int(params, 3, "bar", "poa", "partialOrderAlignmentWindow");
     int64_t maskFilter = cactusParams_get_int(params, 3, "bar", "poa", "partialOrderAlignmentMaskFilter");
     int64_t poaMaxProgRows = cactusParams_get_int(params, 3, "bar", "poa", "partialOrderAlignmentProgressiveMaxRows");
+    double poaMaxLenDiff = cactusParams_get_float(params, 3, "bar", "poa", "partialOrderAlignmentProgressiveMaxLengthDiff");
     abpoa_para_t *poaParameters = usePoa ? abpoaParamaters_constructFromCactusParams(params) : NULL;
 
     //////////////////////////////////////////////
@@ -102,7 +103,8 @@ void bar(stList *flowers, CactusParams *params, CactusDisk *cactusDisk, stList *
              *
              * It does not use any precomputed alignments, if they are provided they will be ignored
              */
-            alignments = make_flower_alignment_poa(flower, maximumLength, poaWindow, maskFilter, poaMaxProgRows, poaParameters);
+            alignments = make_flower_alignment_poa(flower, maximumLength, poaWindow, maskFilter,
+                                                   poaMaxProgRows, poaMaxLenDiff, poaParameters);
             st_logDebug("Created the poa alignments: %" PRIi64 " poa alignment blocks for flower\n", stList_length(alignments));
         } else {
             alignments = makeFlowerAlignment3(sM, flower, listOfEndAlignmentFiles, spanningTrees, maximumLength,

--- a/bar/impl/endAligner.c
+++ b/bar/impl/endAligner.c
@@ -215,11 +215,11 @@ stSortedSet *loadEndAlignmentFromDisk(Flower *flower, FILE *fileHandle, End **en
     if(i != 2 || lineNumber < 0) {
         st_errAbort("We encountered a mis-specified name in loading the first line of an end alignment from the disk: '%s'\n", line);
     }
-    free(line);
     *end = flower_getEnd(flower, flowerName);
     if(*end == NULL) {
         st_errAbort("We encountered an end name that is not in the database: '%s'\n", line);
     }
+    free(line);    
     for(int64_t i=0; i<lineNumber; i++) {
         line = stFile_getLineFromFile(fileHandle);
         if(line == NULL) {

--- a/bar/impl/poaBarAligner.c
+++ b/bar/impl/poaBarAligner.c
@@ -564,8 +564,8 @@ Msa *msa_make_partial_order_alignment(char **seqs, int *seq_lens, int64_t seq_no
         // init abpoa
         abpoa_t *ab = abpoa_init();
         abpoa_para_t *abpt = copy_abpoa_params(poa_parameters);
-        assert(msa->seq_lens[msa->seq_no-1] <= msa->seq_lens[0]);
         if (msa->seq_no > max_prog_rows ||
+            // note: these are sorted by length excep in unit tests
             (1. - (double)msa->seq_lens[msa->seq_no-1] / (double)msa->seq_lens[0] > max_prog_length_diff)) {
             abpt->progressive_poa = 0;
         }

--- a/bar/inc/poaBarAligner.h
+++ b/bar/inc/poaBarAligner.h
@@ -69,6 +69,7 @@ void msa_print(Msa *msa, FILE *f);
  * @param seq_no The number of strings
  * @param window_size Sliding window size which limits length of poa sub-alignments.  Memory usage is quardatic in this. 
  * @param max_prog_rows Disable abpoas progressive alignment if there are more than this many rows (avoid quadratic dist mat blowup)
+ * @param max_prog_length_diff Disable abpoa's progresive alignment if the 1 - shortest (last) sequence / longest (first) sequence is more than this 
  * @param poa_parameters abpoa parameters
  * @return An msa of the strings.
  */
@@ -77,6 +78,7 @@ Msa *msa_make_partial_order_alignment(char **seqs,
                                       int64_t seq_no,
                                       int64_t window_size,
                                       int64_t max_prog_rows,
+                                      double max_prog_length_diff,
                                       abpoa_para_t *poa_parameters);
 
 /**
@@ -99,12 +101,13 @@ Msa *msa_make_partial_order_alignment(char **seqs,
  * @param overlaps For each prefix string, the length of the overlap with its reverse complement adjacency
  * @param window_size Sliding window size which limits length of poa sub-alignments.  Memory usage is quardatic in this. 
  * @param max_prog_rows Disable abpoas progressive alignment if there are more than this many rows (avoid quadratic dist mat blowup)
+ * @param max_prog_length_diff Disable abpoa's progresive alignment if the 1 - shortest (last) sequence / longest (first) sequence is more than this 
  * @param poa_parameters abpoa parameters
  * @return A consistent Msa for each end
  */
 Msa **make_consistent_partial_order_alignments(int64_t end_no, int64_t *end_lengths, char ***end_strings,
         int **end_string_lengths, int64_t **right_end_indexes, int64_t **right_end_row_indexes, int64_t **overlaps,
-        int64_t window_size, int64_t max_prog_rows, abpoa_para_t *poa_parameters);
+        int64_t window_size, int64_t max_prog_rows, double max_prog_length_diff, abpoa_para_t *poa_parameters);
 
 /**
  * Represents a gapless alignment of a set of sequences.
@@ -139,7 +142,8 @@ char *get_adjacency_string(Cap *cap, int *length, bool return_string);
  * to attempt to align.
  * @param window_size Sliding window size which limits length of poa sub-alignments.  Memory usage is quardatic in this. 
  * @param mask_filter Trim input sequences if encountering this many consecutive soft of hard masked bases (0 = disabled)
- * @param max_prog_rows Disable abpoas progressive alignment if there are more than this many rows (avoid quadratic dist mat blowup)
+ * @param max_prog_rows Disable abpoa's progressive alignment if there are more than this many rows (avoid quadratic dist mat blowup)
+ * @param max_prog_length_diff Disable abpoa's progresive alignment if the 1 - shortest (last) sequence / longest (first) sequence is more than this
  * @param poa_parameters abpoa parameters
  */
 stList *make_flower_alignment_poa(Flower *flower,
@@ -147,6 +151,7 @@ stList *make_flower_alignment_poa(Flower *flower,
                                   int64_t window_size,
                                   int64_t mask_filter,
                                   int64_t max_prog_rows,
+                                  double max_prog_length_diff,
                                   abpoa_para_t * poa_parameters);
 
 /**

--- a/bar/tests/poaBarTest.c
+++ b/bar/tests/poaBarTest.c
@@ -65,7 +65,7 @@ void test_make_partial_order_alignment(CuTest *testCase) {
             }
 
             // generate the alignment
-            Msa *msa = msa_make_partial_order_alignment(seqs, seq_lens, seq_no, poa_window_size, 1000, abpt);
+            Msa *msa = msa_make_partial_order_alignment(seqs, seq_lens, seq_no, poa_window_size, 1000, 0.02, abpt);
 
             // print the msa
 #ifdef stderr_logging
@@ -145,7 +145,8 @@ void test_make_consistent_partial_order_alignments_two_ends(CuTest *testCase) {
 
         // generate the alignments
         Msa **msas = make_consistent_partial_order_alignments(end_no, end_lengths, end_strings, end_string_lengths,
-                                                              right_end_indexes, right_end_row_indexes, overlaps, 1000000, 100, abpt);
+                                                              right_end_indexes, right_end_row_indexes, overlaps,
+                                                              1000000, 100, 0.02, abpt);
 
         // print the msas
 #ifdef stderr_logging
@@ -212,7 +213,7 @@ void test_make_flower_alignment_poa(CuTest *testCase) {
     }
     flower_destructEndIterator(endIterator);
 
-    stList *alignment_blocks = make_flower_alignment_poa(flower, 2, 1000000, 5, 1000, abpt);
+    stList *alignment_blocks = make_flower_alignment_poa(flower, 2, 1000000, 5, 1000, 0.02, abpt);
 
     for(int64_t i=0; i<stList_length(alignment_blocks); i++) {
         AlignmentBlock *b = stList_get(alignment_blocks, i);
@@ -233,7 +234,7 @@ void test_alignment_block_iterator(CuTest *testCase) {
     abpt->wf = 0.01;
     abpoa_post_set_para(abpt);
 
-    stList *alignment_blocks = make_flower_alignment_poa(flower, 10000, 1000000, 5, 50, abpt);
+    stList *alignment_blocks = make_flower_alignment_poa(flower, 10000, 1000000, 5, 50, 0.05, abpt);
 
     abpoa_free_para(abpt);
 #ifdef stderr_logging

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -250,6 +250,7 @@
 		<!-- partialOrderAlignmentMinimizerMinW abpoa minimum window size. -->
 		<!-- partialOrderAlignmentProgressiveMode use guide tree from jaccard distance matrix to determine poa order -->
 		<!-- partialOrderAlignmentProgressiveMaxRows disable progressive mode if there are more than this many rows to align -->
+		<!-- partialOrderAlignmentProgressiveMaxLengthDif disable progressive mode if 1 - len(smallest seq) / len(biggest seq) is greater than this number. in other words, we stick with sorting by length unless the lengths are all really similar -->
 		<poa
 			partialOrderAlignmentWindow="10000"
 			partialOrderAlignmentMaskFilter="-1"
@@ -266,6 +267,7 @@
 			partialOrderAlignmentMinimizerMinW="500"
 			partialOrderAlignmentProgressiveMode="1"
 			partialOrderAlignmentProgressiveMaxRows="5000"
+			partialOrderAlignmentProgressiveMaxLengthDiff="0.05"
 		/>
 	</bar>
 


### PR DESCRIPTION
It's been a couple of times where it seems that `abPOA`'s "progressive" input sorter (`-p`) which is on by default in cactus only makes things worse.  

Instead of giving up on it entirely (I'm sure I've seen it help before), progressive sorting is now only activated if the input sequences are all the same length.  The logic being that we prefer sorting by length, but there's nothing much to lose  trying progressive when there is no length signal.  

A threshold (defaulting to 5% in the config) is used to determine if the lengths are the same. 