### PR TITLE
Sort flowers by total-base-length instead of cap-number for bar/ref

### DIFF
--- a/pipeline/cactus_consolidated.c
+++ b/pipeline/cactus_consolidated.c
@@ -176,10 +176,16 @@ stHash *compute_flower_length_hash(stList *flowers) {
     return flower_to_length;
 }
 
-int flower_sizeCmpFn(const void *a, const void *b, void *flower_to_size_hash) {
-    // Sort by hashed size value of the flowers
-    int64_t i = (int64_t)stHash_search((stHash*)flower_to_size_hash, (void*)a);
-    int64_t j = (int64_t)stHash_search((stHash*)flower_to_size_hash, (void*)b);
+int flower_lengthCmpFn(const void *a, const void *b, void *flower_to_length_hash) {
+    // Sort by hashed length value of the flowers
+    int64_t i = (int64_t)stHash_search((stHash*)flower_to_length_hash, (void*)a);
+    int64_t j = (int64_t)stHash_search((stHash*)flower_to_length_hash, (void*)b);
+    return i < j ? 1 : (i > j ? -1 : 0); // Sort in descending order
+}
+
+int flower_sizeCmpFn(const void *a, const void *b) {
+    // Sort by number of caps the flowers contains
+    int64_t i = flower_getCapNumber((Flower *)a), j = flower_getCapNumber((Flower *)b);
     return i < j ? 1 : (i > j ? -1 : 0); // Sort in descending order
 }
 
@@ -435,9 +441,9 @@ int main(int argc, char *argv[]) {
         extendFlowers(flower, leafFlowers, 1); // Get nested flowers to complete
         // Sort by descending order of size, so that we start processing the
         // largest flower as quickly as possible
-        stHash *flower_to_size = compute_flower_length_hash(leafFlowers);
-        stList_sort2(leafFlowers, flower_sizeCmpFn, flower_to_size); 
-        stHash_destruct(flower_to_size);
+        stHash *flower_to_length = compute_flower_length_hash(leafFlowers);
+        stList_sort2(leafFlowers, flower_lengthCmpFn, flower_to_length); 
+        stHash_destruct(flower_to_length);
         st_logInfo("Ran extended flowers ready for bar, %" PRIi64 " seconds have elapsed\n", time(NULL) - startTime);
 
         bar(leafFlowers, params, cactusDisk, NULL);
@@ -462,9 +468,7 @@ int main(int argc, char *argv[]) {
     for(int64_t i=0; i<stList_length(flowerLayers); i++) {
         // Sort by descending order of size, so that we start processing the
         // largest flower as quickly as possible
-        stHash *flower_to_size = compute_flower_length_hash(stList_get(flowerLayers, i));
-        stList_sort2(stList_get(flowerLayers, i), flower_sizeCmpFn, flower_to_size); 
-        stHash_destruct(flower_to_size);
+        stList_sort(stList_get(flowerLayers, i), flower_sizeCmpFn); 
     }
     st_logInfo("There are %" PRIi64 " layers in the flowers hierarchy\n", stList_length(flowerLayers));
 

--- a/pipeline/cactus_consolidated.c
+++ b/pipeline/cactus_consolidated.c
@@ -163,7 +163,7 @@ static bool refSequenceProvided(char *sequenceFilesAndEvents, char *referenceEve
 stHash *compute_flower_length_hash(stList *flowers) {
     // compute lengths in parallel
     stList *flower_lengths = stList_construct2(stList_length(flowers));
-#pragma omp parallel for schedule(dynamic, 1)
+#pragma omp parallel for schedule(dynamic)
     for (int64_t i = 0; i < stList_length(flowers); ++i) {
         stList_set(flower_lengths, i, (void*)flower_getTotalBaseLength((Flower*)stList_get(flowers, i)));
     }

--- a/preprocessor/cactus_sanitizeFastaHeaders.c
+++ b/preprocessor/cactus_sanitizeFastaHeaders.c
@@ -160,7 +160,9 @@ int main(int argc, char *argv[]) {
     }
 
     fastaReadToFunction(fileHandle, (void*)argv[2], addUniqueFastaPrefix);
-    fclose(fileHandle);
+    if (fileHandle != stdin) {
+        fclose(fileHandle);
+    }
     stSet_destruct(header_set);
 
     return 0;

--- a/reference/impl/buildReference.c
+++ b/reference/impl/buildReference.c
@@ -1216,7 +1216,7 @@ void cactus_make_reference(stList *flowers, char *referenceEventString,
 
     double (*temperatureFn)(double) = useSimulatedAnnealing ? exponentiallyDecreasingTemperatureFn : constantTemperatureFn;
 
-#pragma omp parallel for
+#pragma omp parallel for schedule(dynamic, 1)
     for(int64_t i=0; i<stList_length(flowers); i++) {
         Flower *flower = stList_get(flowers, i);
         st_logDebug("Processing flower %" PRIi64 "\n", flower_getName(flower));

--- a/src/cactus/preprocessor/checkUniqueHeaders.py
+++ b/src/cactus/preprocessor/checkUniqueHeaders.py
@@ -68,6 +68,8 @@ def sanitize_fasta_header(job, fasta_id, event, pangenome, log_stats):
     else:
         cmd = ['cactus_sanitizeFastaHeaders', in_fa_path, event] + pg_opts
     cactus_call(parameters=cmd, outfile=out_fa_path)
+    out_fa_id = job.fileStore.writeGlobalFile(out_fa_path)
+    
     job.fileStore.deleteGlobalFile(fasta_id)
 
     if log_stats:
@@ -75,7 +77,7 @@ def sanitize_fasta_header(job, fasta_id, event, pangenome, log_stats):
                                      work_dir=work_dir, check_output=True)
         job.fileStore.logToMaster("Assembly stats for %s: %s" % (event, analysisString))
     
-    return job.fileStore.writeGlobalFile(out_fa_path)
+    return out_fa_id
     
 
     


### PR DESCRIPTION
Flowers are sorted by decreasing size when doing the parallel loops in BAR and Reference phases so longer jobs get queued first.  But the size is measured by `flower_getCapNumber()` and on a small test of chrI of the yeast pangenome, the 3 jobs that stand out as longest running don't have the most caps.  But they do have the longest `flower_getTotalBaseLength()`.  

Granted, this isn't a ton to go on, but this PR tries switching up the sort to use base length instead of caps.  And because base length is more involved to compute, it's done in parallel.  

The idea being to use this branch to run a couple big tests to see if it helps with wall time for some big, parallel, jobs.  It's kind of a long shot, but runtime does seem to be bounded by a single long job for many cases, so anything to make sure it gets queued right away should lead to a measurable gain... 