### PR TITLE
apply local TMPDIR redirect to all singularity commands

### DIFF
--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -793,11 +793,12 @@ def cactus_call(tool=None,
     else:
         errfile = subprocess.PIPE
 
-    # hack to force consolidated to keep tmp files local (required to run at all in some singularity setups where /tmp is not writable)
+    # hack to keep tmp files local (required to run at all in some singularity setups where /tmp is not writable)
     sub_env = None
-    if (shell and 'cactus_consolidated' in call) or (not shell and any(['cactus_consolidated' in c for c in call])):
+    if mode == 'singularity':
         sub_env = os.environ.copy()
         sub_env['TMPDIR']='.'
+        sub_env['TEMPDIR']='.'
 
     process = subprocess.Popen(call, shell=shell, encoding=None,
                                stdin=stdinFileHandle, stdout=stdoutFileHandle,


### PR DESCRIPTION
`singularity exec` takes in the environment from the caller, which in turn takes its `TMPDIR` from `--workDir` etc.  But what's a valid directory outside the container, may not be, apparently, valid inside the container.  

This had evidently come up before, as there's code to reset `TMPDIR` to `.` for `cactus_consoldiated` invocations.  This PR applies this to any command run via `singularity`.   

I think this may be a safer, more general patch than #1517 which addresses the same issue but for `bcftools sort` in particular. 

This does *not* seem to be an issue with docker as `docker run` doesn't import the environment.  

