### PR TITLE
Update to patched mafTools

### DIFF
--- a/build-tools/downloadMafTools
+++ b/build-tools/downloadMafTools
@@ -66,7 +66,7 @@ fi
 cd ${mafBuildDir}
 git clone https://github.com/ComparativeGenomicsToolkit/mafTools.git
 cd mafTools
-git checkout b88cd313cb18764d87bc801fbbbb00f982c1a48f
+git checkout 259e5b47fa2ee17ff5ad1bba9cebf2992cbb7228
 find . -name "*.mk" | xargs sed -ie "s/-Werror//g"
 find . -name "Makefile*" | xargs sed -ie "s/-Werror//g"
 # hack in flags support


### PR DESCRIPTION
Patch `mafTools` to [fix issue](https://github.com/ComparativeGenomicsToolkit/mafTools/pull/10) where taffy normalization phase would crash on genomes with `-letter names. 

Resolves #1522 