### PR TITLE
Add checks for invalid sequence characters when writing temporary FASTA files

### DIFF
--- a/preprocessor/cactus_sanitizeFastaHeaders.c
+++ b/preprocessor/cactus_sanitizeFastaHeaders.c
@@ -128,6 +128,17 @@ void addUniqueFastaPrefix(void* destination, const char *fastaHeader, const char
         clipped_header = prefixed_header;
     }
     
+    // sanity check
+    int64_t n = strlen(string);
+    for (int64_t i = 0; i < n; ++i) {
+        char c = tolower(string[i]);
+        if (c != 'a' && c != 'c' && c != 'g' && c != 't' && c != 'n') {
+            fprintf(stderr, "Error: Non-ACGTN character '%c' found at position %" PRIi64 " of FASTA sequence %s in event %s\n",
+                    c, i, fastaHeader, eventName);
+            exit(1);
+        }
+    }
+    
     fastaWrite((char*)string, clipped_header, stdout);
     free(clipped_header);
 }


### PR DESCRIPTION
There seem to be gremlins in Cactus causing invalid FASTA files.  In `cactus-pangenome`, this has manifested as slightly truncated files being imported into chromosome alignment jobs.  And in progressive Cactus, there are a couple issues, #1466 #1525, reporting corrupt FASTA chunks (missing newline?) going into `lastz`.  

I still don't know what the underlying problem is, though on the pangenome side it really looks like the corruption is happening at the filesystem level.  

This PR just adds some asserts to try to catch these errors a little earlier to (hopefully) make debugging if / when they come up again.  

* `cactus_sanitizeFastaHeaders` now checks the sequence in addition to headers and reports an error if a non-ACGTN character is found. 
* `faffy chunk` and `faffy extract` changed to check (with an assertion) that they only write valid sequence characters. Because in #1466 it looks like the invalid sequence is coming out of `faffy chunk`.   