### PR TITLE
add vcfwave installation as option to BIN-INSTALL instructions

### DIFF
--- a/BIN-INSTALL.md
+++ b/BIN-INSTALL.md
@@ -15,7 +15,7 @@ cd cactus-bin-v2.9.2
 To build a python virtualenv and activate, do the following steps. This requires Python version >= 3.7 (so Ubuntu 18.04 users should use `-p python3.8` below):
 ```
 virtualenv -p python3 venv-cactus-v2.9.2
-printf "export PATH=$(pwd)/bin:\$PATH\nexport PYTHONPATH=$(pwd)/lib:\$PYTHONPATH\n" >> venv-cactus-v2.9.2/bin/activate
+printf "export PATH=$(pwd)/bin:\$PATH\nexport PYTHONPATH=$(pwd)/lib:\$PYTHONPATH\nexport LD_LIBRARY_PATH=$(pwd)/lib:\$LD_LIBRARY_PATH\n" >> venv-cactus-v2.9.2/bin/activate
 source venv-cactus-v2.9.2/bin/activate
 python3 -m pip install -U setuptools pip wheel
 python3 -m pip install -U .
@@ -29,6 +29,11 @@ a license for commercial use.  Static binaries are not available, but the follow
 should set them up successfully on many 64 bit Linux systems:
 ```
 cd bin && for i in wigToBigWig faToTwoBit bedToBigBed bigBedToBed axtChain pslPosTarget bedSort hgGcPercent mafToBigMaf hgLoadMafSummary hgLoadChain; do wget -q http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/${i}; chmod +x ${i}; done
+```
+
+`vcfwave` isn't included in the release binaries (but is in the docker image).  You can can try building it and adding it to `bin/` with the following command
+```
+build-tools/downloadVCFWave
 ```
 
 ## Testing

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -360,19 +360,13 @@ else
 fi
 
 # vcfwave
-cd ${pangenomeBuildDir}
+cd ${CWD}
 # todo: it's be nice to figure out a static build. for now we skip entirely if static enabled.
 if [[ $STATIC_CHECK -ne 1 ]]
 then
-    git clone --recursive https://github.com/vcflib/vcflib.git
-    cd vcflib
-    git checkout 404b98a6a0601a8668fb039eae5196fa1ae12525
-    mkdir build
-    cd build
-    cmake -DZIG=OFF -DWFA_GITMODULE=ON -DCMAKE_BUILD_TYPE=Debug ..
-    cmake --build . -- -j ${numcpu}
-    mv vcfwave vcfcreatemulti vcfbreakmulti vcfuniq ${binDir}
-    mv ./contrib/WFA2-lib/libwfa2.so.0 ${libDir}
+    build-tools/downloadVCFWave
+    cd ${CWD}
+    mkdir -p ${pangenomeBuildDir}
 fi
 
 # last
@@ -409,7 +403,6 @@ fi
 
 cd ${CWD}
 rm -rf ${pangenomeBuildDir}
-
 
 set +x
 echo ""

--- a/build-tools/downloadVCFWave
+++ b/build-tools/downloadVCFWave
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Download vcfwave. You can run this when installing the release binaries because vcfwave
+# isn't included in the release (because no static build)
+
+set -beEu -o pipefail
+
+# Note: this bit below should be kept consistent with downloadPangenomeTools
+pangenomeBuildDir=$(realpath -m build-pangenome-tools)
+binDir=$(pwd)/bin
+libDir=$(pwd)/lib
+# just use cactusRootPath for now
+dataDir=$(pwd)/src/cactus
+CWD=$(pwd)
+# works on MacOS and Linux
+if [ -z ${numcpu+x} ]; then
+	 numcpu=$(getconf _NPROCESSORS_ONLN)
+fi
+
+set -x
+rm -rf ${pangenomeBuildDir}
+mkdir -p ${pangenomeBuildDir}
+mkdir -p ${binDir}
+
+cd ${pangenomeBuildDir}
+git clone --recursive https://github.com/vcflib/vcflib.git
+cd vcflib
+git checkout 404b98a6a0601a8668fb039eae5196fa1ae12525
+mkdir build
+cd build
+cmake -DZIG=OFF -DWFA_GITMODULE=ON -DCMAKE_BUILD_TYPE=Debug ..
+cmake --build . -- -j ${numcpu}
+mv vcfwave vcfcreatemulti vcfbreakmulti vcfuniq ${binDir}
+mv ./contrib/WFA2-lib/libwfa2.so.0 ${libDir}
+ 
+cd ${CWD}
+rm -rf ${pangenomeBuildDir}


### PR DESCRIPTION
If I'm installing the cactus binaries release on our cluster, `vcfwave` is not included because there's no static binary for it. 

This PR breaks `vcflib` compilation into its own script and adds it as an option to the `BIN-INSTALL` instructions.  This way, it's relatively easy to download the binary release, then add in `vcwave` (via local build) if desired, so the release can be used without going through docker...