### PR TITLE
include downloadVCFWave script in binary release

### DIFF
--- a/build-tools/makeBinRelease
+++ b/build-tools/makeBinRelease
@@ -112,6 +112,9 @@ cp -r .git ${binPackageDir}
 rm -rf ${binPackageDir}/.git/modules
 # remove test executables
 rm -f ${binPackageDir}/bin/*test ${binPackageDir}/bin/*tests ${binPackageDir}/bin/*Test ${binPackageDir}/bin/*Tests
+# we now mention running downloadVCFWave in the BIN-INSTALL.md, so it should be included too
+mkdir ${binPackageDir}/build-tools
+cp build-tools/downloadVCFWave  ${binPackageDir}/build-tools
 # make binaries smaller, but leave debug info in cactus_consolidated
 bash -O extglob -c "strip -d ${binPackageDir}/bin/!(cactus_consolidated) 2> /dev/null || true"
 if [ -z ${CACTUS_LEGACY_ARCH+x} ]	


### PR DESCRIPTION
I updated BIN-INSTALL.md to mention how to add `vcfwave` to a binary installation, but the relevant script wasn't actually in the release -- this PR fixes that. 