### PR TITLE
update to patched vcfwave; let it work with multiallelics

### DIFF
--- a/build-tools/downloadVCFWave
+++ b/build-tools/downloadVCFWave
@@ -24,7 +24,7 @@ mkdir -p ${binDir}
 cd ${pangenomeBuildDir}
 git clone --recursive https://github.com/vcflib/vcflib.git
 cd vcflib
-git checkout 404b98a6a0601a8668fb039eae5196fa1ae12525
+git checkout f8425d239e1bc406cdfe46a2e37f47ac3476dd8a
 mkdir build
 cd build
 cmake -DZIG=OFF -DWFA_GITMODULE=ON -DCMAKE_BUILD_TYPE=Debug ..

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -1127,14 +1127,11 @@ def vcfwave_chr(job, config, vcf_ref, vcf_id, tbi_id, fasta_id, contig, vcfbub_t
     wave_vcf_path = os.path.join(work_dir, '{}{}_wave.vcf.gz'.format(tag, contig))
     wave_tbi_path = wave_vcf_path + '.tbi'
 
-    # vfwave has some bugs: https://github.com/vcflib/vcflib/issues/403
-    # that produce wrong genotypes and AT fields.  we try to hack around the former
-    # by splitting multiallelic sites beforehand, and the latter just by dropping 
+    # AT fields don't mean much after vcfwave (and have been invalid in the past, so we strip them)
     wave_opts = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_join"), "vcfwaveOptions", typeFn=str, default=None)
     assert wave_opts
     bubwave_cmd = [['vcfbub', '--input', chrom_vcf_path, '-l', '0', '-a', str(vcfbub_thresh)],
                    ['bcftools', 'annotate', '-x', 'INFO/AT'],                   
-                   ['bcftools', 'norm', '-m', '-any'],
                    ['vcfwave'] + wave_opts.split(' ') + ['-t', str(job.cores)],
                    ['bgzip']]
     cactus_call(parameters=bubwave_cmd, outfile=wave_vcf_path)


### PR DESCRIPTION
Pull in latest vcflib with fix for https://github.com/vcflib/vcflib/issues/403 

I was using multi-allelic splitting as kind of a workaround for this issue (output seemed less wrong on biallelics), but if the issue is resolved then this shouldn't be needed anymore so I've removed it.  
