### PR TITLE
Merge VCF records at the same position together after bcftools norm left shifts them

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,6 @@
 [submodule "submodules/red"]
 	path = submodules/red
 	url = https://github.com/glennhickey/red.git
+[submodule "submodules/collapse-bubble"]
+	path = submodules/collapse-bubble
+	url = https://github.com/Han-Cao/collapse-bubble.git

--- a/Makefile
+++ b/Makefile
@@ -272,7 +272,8 @@ suball.red:
 	ln -f submodules/red/bin/Red ${BINDIR}
 
 suball.collapse-bubble:
-	ln -f submodules/collapse-bubble/scripts/merge_duplicates.py src/cactus/refmap/
+	chmod +x submodules/collapse-bubble/scripts/merge_duplicates.py
+	ln -f submodules/collapse-bubble/scripts/merge_duplicates.py ${BINDIR}
 
 subclean.%:
 	cd submodules/$* && ${MAKE} clean

--- a/Makefile
+++ b/Makefile
@@ -276,7 +276,7 @@ suball.collapse-bubble:
 	ln -f submodules/collapse-bubble/scripts/merge_duplicates.py ${BINDIR}
 
 subclean.%:
-	cd submodules/$* && ${MAKE} clean
+	if [ $(shell ls submodules/$* | grep -i makefile | wc -l) != 0 ]; then cd submodules/$* && ${MAKE} clean; fi
 
 ##
 # docker

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ modules = api setup caf bar hal reference pipeline preprocessor
 
 # submodules are in multiple pass to handle dependencies cactus2hal being dependent on
 # both cactus and sonLib
-submodules1 = sonLib cPecan hal matchingAndOrdering pinchesAndCacti abPOA lastz paffy red
+submodules1 = sonLib cPecan hal matchingAndOrdering pinchesAndCacti abPOA lastz paffy red collapse-bubble
 submodules2 = cactus2hal
 submodules = ${submodules1} ${submodules2}
 
@@ -270,6 +270,9 @@ suball.paffy:
 suball.red:
 	cd submodules/red && ${MAKE}
 	ln -f submodules/red/bin/Red ${BINDIR}
+
+suball.collapse-bubble:
+	ln -f submodules/collapse-bubble/scripts/merge_duplicates.py src/cactus/refmap/
 
 subclean.%:
 	cd submodules/$* && ${MAKE} clean

--- a/Makefile
+++ b/Makefile
@@ -239,12 +239,12 @@ suball.cPecan: suball.sonLib
 
 suball.cactus2hal: suball.sonLib suball.hal all_libs.api
 	cd submodules/cactus2hal && ${MAKE}
-	mkdir -p bin
+	mkdir -p ${BINDIR} ${LIBDIR} ${INCLDIR}	
 	-ln -f submodules/cactus2hal/bin/* bin/
 
 suball.hal: suball.sonLib
 	cd submodules/hal &&  ${MAKE}
-	mkdir -p bin
+	mkdir -p ${BINDIR} ${LIBDIR} ${INCLDIR}	
 	-ln -f submodules/hal/bin/* bin/
 	-ln -f submodules/hal/lib/libHal.a submodules/hal/lib/halLib.a
 
@@ -256,7 +256,7 @@ suball.abPOA:
 
 suball.lastz:
 	cd submodules/lastz && ${MAKE}
-	mkdir -p bin
+	mkdir -p ${BINDIR} ${LIBDIR} ${INCLDIR}	
 	ln -f submodules/lastz/src/lastz bin
 
 suball.paffy:

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Cactus uses many different algorithms and individual code contributions, princip
 - Andrea Guarracino, Erik Garrison and co-authors for [odgi](https://github.com/pangenome/odgi). Make sure to [cite odgi](https://doi.org/10.1093/bioinformatics/btac308) when using it or its visualizations.
 - Hani Z. Girgis for [RED](http://toolsmith.ens.utulsa.edu/)
 - Erik Garrison and co-authors for [vcfwave](https://github.com/vcflib/vcflib/blob/master/doc/vcfwave.md). [vcflib citation](https://doi.org/10.1371/journal.pcbi.1009123)
+- Martin Frith and collaborators for `last-train` from [last](https://gitlab.com/mcfrith/last). [last-train citation](https://academic.oup.com/bioinformatics/article-lookup/doi/10.1093/bioinformatics/btw742)
+- Han Cao for [merge_duplicates](https://github.com/Han-Cao/collapse-bubble) vcf cleanup script
 
 ## Installing Manually From Source
 

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -34,6 +34,7 @@ set -x
 rm -rf ${pangenomeBuildDir}
 mkdir -p ${pangenomeBuildDir}
 mkdir -p ${binDir}
+mkdir -p ${libDir}
 
 # minimap2
 if [ -z ${arm+x} ]

--- a/build-tools/downloadVCFWave
+++ b/build-tools/downloadVCFWave
@@ -20,6 +20,7 @@ set -x
 rm -rf ${pangenomeBuildDir}
 mkdir -p ${pangenomeBuildDir}
 mkdir -p ${binDir}
+mkdir -p ${libDir}
 
 cd ${pangenomeBuildDir}
 git clone --recursive https://github.com/vcflib/vcflib.git

--- a/build-tools/downloadVCFWave
+++ b/build-tools/downloadVCFWave
@@ -30,7 +30,7 @@ mkdir build
 cd build
 cmake -DZIG=OFF -DWFA_GITMODULE=ON -DCMAKE_BUILD_TYPE=Debug ..
 cmake --build . -- -j ${numcpu}
-mv vcfwave vcfcreatemulti vcfbreakmulti vcfuniq ${binDir}
+mv vcfwave vcfcreatemulti vcfbreakmulti vcfuniq vcffixup ${binDir}
 mv ./contrib/WFA2-lib/libwfa2.so.0 ${libDir}
  
 cd ${CWD}

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,8 @@ setup(
         'networkx>=2,<2.8.1',
         'pytest',
         'cigar',
-        'biopython'], 
+        'biopython',
+        'pysam'], 
 
     cmdclass = {
         'install': PostInstallCommand,

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -413,7 +413,7 @@
 	<!-- vcfwaveOptions: options to pass to vcfwave (from vcflib) -->
 	<!-- vcfwaveNorm: run bcftools norm -f (left shift) after vcfwave -->
 	<!-- bcftoolsNorm: Run bcftools norm -f (left shifting) on (non-raw, non-wave) VCF output (may result in overlapping variants) -->
-	<!-- mergeDuplicatesOptions: Run merge_duplicates script with these options after bcftools norm to prevent multiple entries at the same position.  If empty or 0, merge_duplicates will not be run.  This applies to normalization as toggled by vcfwaveNorm and/or bctoolsNorm (and is ever run after bcftools norm) -->
+	<!-- mergeDuplicatesOptions: Run merge_duplicates script with these options (empty string means default options) after bcftools norm to prevent multiple entries at the same position.  If "0", merge_duplicates will not be run.  This applies to normalization as toggled by vcfwaveNorm and/or bctoolsNorm (and is ever run after bcftools norm) -->
 	<graphmap_join
 		 maxNodeLength="1024"
 		 gfaffix="1"
@@ -430,7 +430,7 @@
 		 vcfwaveOptions="-I 1000"
 		 vcfwaveNorm="1"
 		 bcftoolsNorm="0"
-		 mergeDuplicatesOptions="--merge-mis-as-ref"
+		 mergeDuplicatesOptions=""
 		 />
 	<!-- hal2vg options -->
 	<!-- includeMinigraph: include minigraph node sequences as paths in output (note that cactus-graphmap-join will still remove them by default) -->

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -413,6 +413,7 @@
 	<!-- vcfwaveOptions: options to pass to vcfwave (from vcflib) -->
 	<!-- vcfwaveNorm: run bcftools norm -f (left shift) after vcfwave -->
 	<!-- bcftoolsNorm: Run bcftools norm -f (left shifting) on (non-raw, non-wave) VCF output (may result in overlapping variants) -->
+	<!-- mergeDuplicatesOptions: Run merge_duplicates script with these options after bcftools norm to prevent multiple entries at the same position.  If empty or 0, merge_duplicates will not be run.  This applies to normalization as toggled by vcfwaveNorm and/or bctoolsNorm (and is ever run after bcftools norm) -->
 	<graphmap_join
 		 maxNodeLength="1024"
 		 gfaffix="1"
@@ -429,6 +430,7 @@
 		 vcfwaveOptions="-I 1000"
 		 vcfwaveNorm="1"
 		 bcftoolsNorm="0"
+		 mergeDuplicatesOptions="--keep first"
 		 />
 	<!-- hal2vg options -->
 	<!-- includeMinigraph: include minigraph node sequences as paths in output (note that cactus-graphmap-join will still remove them by default) -->

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -438,7 +438,7 @@
 		 rindexOptions="-p"
 		 haplOptions="-v 2"
 		 vcfwaveOptions="-I 1000"
-		 vcfwaveChunkLines="250000"
+		 vcfwaveChunkLines="200000"
 		 vcfwaveNorm="1"
 		 bcftoolsNorm="0"
 		 mergeDuplicatesOptions=""

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -438,7 +438,7 @@
 		 rindexOptions="-p"
 		 haplOptions="-v 2"
 		 vcfwaveOptions="-I 1000"
-		 vcfwaveChunkLines="200000"
+		 vcfwaveChunkLines="100000"
 		 vcfwaveNorm="1"
 		 bcftoolsNorm="0"
 		 mergeDuplicatesOptions=""

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -420,6 +420,7 @@
 	<!-- rindexOptions: options to vg gbwt -r (r-index construction) as used to make haplotype sampling index -->
 	<!-- haplOptions: options to vg haplotypes as used to make haplotype sampling index -->
 	<!-- vcfwaveOptions: options to pass to vcfwave (from vcflib) -->
+	<!-- vcfwaveChunkLines: number of VCF lines to send to each vcfwave job (use <= 0 to disable chunking) -->
 	<!-- vcfwaveNorm: run bcftools norm -f (left shift) after vcfwave -->
 	<!-- bcftoolsNorm: Run bcftools norm -f (left shifting) on (non-raw, non-wave) VCF output (may result in overlapping variants) -->
 	<!-- mergeDuplicatesOptions: Run merge_duplicates script with these options (empty string means default options) after bcftools norm to prevent multiple entries at the same position.  If "0", merge_duplicates will not be run.  This applies to normalization as toggled by vcfwaveNorm and/or bctoolsNorm (and is ever run after bcftools norm) -->
@@ -437,6 +438,7 @@
 		 rindexOptions="-p"
 		 haplOptions="-v 2"
 		 vcfwaveOptions="-I 1000"
+		 vcfwaveChunkLines="250000"
 		 vcfwaveNorm="1"
 		 bcftoolsNorm="0"
 		 mergeDuplicatesOptions=""

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -430,7 +430,7 @@
 		 vcfwaveOptions="-I 1000"
 		 vcfwaveNorm="1"
 		 bcftoolsNorm="0"
-		 mergeDuplicatesOptions="--keep first"
+		 mergeDuplicatesOptions="--merge-mis-as-ref"
 		 />
 	<!-- hal2vg options -->
 	<!-- includeMinigraph: include minigraph node sequences as paths in output (note that cactus-graphmap-join will still remove them by default) -->

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -1124,15 +1124,12 @@ def vcfwave(job, config, out_name, vcf_ref, vcf_id, tbi_id, max_ref_allele, fast
 
     # run vcfbub and vcfwave, using original HPRC recipe
     # allele splitting added here as vcfwave has history of trouble with multi-allelic sites
-    # running bcftools norm -a --atom-overlaps . (important to in sep. command to -m) to
-    # normalize as much as possible without realigning (and therefore changing graph)
     vcfwave_path = os.path.join(work_dir, os.path.basename(out_name) + '.' + vcf_ref + tag + 'wave.vcf.gz')
     wave_opts = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_join"), "vcfwaveOptions", typeFn=str, default=None)
     assert wave_opts
     bubwave_cmd = [['vcfbub', '--input', vcf_path, '-l', '0', '-a', str(max_ref_allele)],
                    ['bcftools', 'annotate', '-x', 'INFO/AT'],
                    ['bcftools', 'norm', '-m', '-any'],
-                   ['bcftools', 'norm', '-a', '--atom-overlaps', '.'],
                    ['vcfwave'] + wave_opts.split(' ') + ['-t', str(job.cores)]]
     run_norm = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_join"), "vcfwaveNorm", typeFn=bool, default=True)
     merge_duplicates_opts = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_join"), "mergeDuplicatesOptions", typeFn=str, default=None)

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -1053,21 +1053,21 @@ def make_vcf(job, config, options, workflow_phase, index_mem, vcf_ref, vg_ids, r
     merge_vcf_job = root_job.addFollowOnJobFn(vcf_cat, raw_vcf_tbi_ids, vcftag + '.raw.',
                                               fix_ploidies=True,
                                               disk = sum(f.size for f in vg_ids) * 16,
-                                              memory = cactus_clamp_memeory(sum(f.size for f in vg_ids)))
+                                              memory = cactus_clamp_memory(sum(f.size for f in vg_ids)))
     out_dict = {'{}.raw.vcf.gz'.format(vcftag) : merge_vcf_job.rv(0),
                 '{}.raw.vcf.gz.tbi'.format(vcftag) : merge_vcf_job.rv(1) }
     if bub_vcf_tbi_ids:
         merge_bub_job = root_job.addFollowOnJobFn(vcf_cat, bub_vcf_tbi_ids, vcftag + '.bub.',
                                                   fix_ploidies=True,
                                                   disk = sum(f.size for f in vg_ids) * 16,
-                                                  memory = cactus_clamp_memeory(sum(f.size for f in vg_ids)))
+                                                  memory = cactus_clamp_memory(sum(f.size for f in vg_ids)))
         out_dict['{}.vcf.gz'.format(vcftag)] = merge_bub_job.rv(0)
         out_dict['{}.vcf.gz.tbi'.format(vcftag)] = merge_bub_job.rv(1)
     if wave_vcf_tbi_ids:
         merge_wave_job = root_job.addFollowOnJobFn(vcf_cat, wave_vcf_tbi_ids, vcftag + '.wave.',
                                                    fix_ploidies=True,
                                                    disk = sum(f.size for f in vg_ids) * 16,
-                                                   memory = cactus_clamp_memeory(sum(f.size for f in vg_ids)))
+                                                   memory = cactus_clamp_memory(sum(f.size for f in vg_ids)))
         out_dict['{}.wave.vcf.gz'.format(vcftag)] = merge_wave_job.rv(0)
         out_dict['{}.wave.vcf.gz.tbi'.format(vcftag)] = merge_wave_job.rv(1)
         

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -1124,12 +1124,15 @@ def vcfwave(job, config, out_name, vcf_ref, vcf_id, tbi_id, max_ref_allele, fast
 
     # run vcfbub and vcfwave, using original HPRC recipe
     # allele splitting added here as vcfwave has history of trouble with multi-allelic sites
+    # running bcftools norm -a --atom-overlaps . (important to in sep. command to -m) to
+    # normalize as much as possible without realigning (and therefore changing graph)
     vcfwave_path = os.path.join(work_dir, os.path.basename(out_name) + '.' + vcf_ref + tag + 'wave.vcf.gz')
     wave_opts = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_join"), "vcfwaveOptions", typeFn=str, default=None)
     assert wave_opts
     bubwave_cmd = [['vcfbub', '--input', vcf_path, '-l', '0', '-a', str(max_ref_allele)],
                    ['bcftools', 'annotate', '-x', 'INFO/AT'],
                    ['bcftools', 'norm', '-m', '-any'],
+                   ['bcftools', 'norm', '-a', '--atom-overlaps', '.'],
                    ['vcfwave'] + wave_opts.split(' ') + ['-t', str(job.cores)]]
     run_norm = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_join"), "vcfwaveNorm", typeFn=bool, default=True)
     merge_duplicates_opts = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_join"), "mergeDuplicatesOptions", typeFn=str, default=None)

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -1213,7 +1213,7 @@ def check_vcfwave(job):
 def chunked_vcfwave(job, config, out_name, vcf_ref, vcf_id, tbi_id, max_ref_allele, fasta_ref_dict, tag):
     """ run vcfwave in parallel chunks """
     work_dir = job.fileStore.getLocalTempDir()
-    vcf_path = os.path.join(work_dir, os.path.basename(out_name) + '.' + vcf_ref + tag + 'raw.vcf.gz')
+    vcf_path = os.path.join(work_dir, os.path.basename(out_name) + '.' + vcf_ref + '.' + tag + 'raw.vcf.gz')
     job.fileStore.readGlobalFile(vcf_id, vcf_path)
     job.fileStore.readGlobalFile(tbi_id, vcf_path + '.tbi')
 
@@ -1224,7 +1224,7 @@ def chunked_vcfwave(job, config, out_name, vcf_ref, vcf_id, tbi_id, max_ref_alle
 
     # run vcfbub using original HPRC recipe
     # allele splitting added here as vcfwave has history of trouble with multi-allelic sites
-    vcfbub_path = os.path.join(work_dir, os.path.basename(out_name) + '.' + vcf_ref + tag + 'bub.vcf.gz')
+    vcfbub_path = os.path.join(work_dir, os.path.basename(out_name) + '.' + vcf_ref + '.' + tag + 'bub.vcf.gz')
     bub_cmd = [['vcfbub', '--input', vcf_path, '-l', '0', '-a', str(max_ref_allele)],
                ['bcftools', 'annotate', '-x', 'INFO/AT'],
                ['bcftools', 'norm', '-m', '-any'],
@@ -1289,8 +1289,10 @@ def chunked_vcfwave(job, config, out_name, vcf_ref, vcf_id, tbi_id, max_ref_alle
 
     # normalize the output
     if getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_join"), "vcfwaveNorm", typeFn=bool, default=True):
+        vcfwave_path = os.path.join(work_dir, os.path.basename(out_name) + '.' + vcf_ref + '.' + tag + 'wave.vcf.gz')
+
         norm_job = vcfwave_cat_job.addFollowOnJobFn(vcfnorm, config, vcf_ref, vcfwave_cat_job.rv(0),
-                                                    vcf_path, vcfwave_cat_job.rv(1), fasta_ref_dict,
+                                                    vcfwave_path, vcfwave_cat_job.rv(1), fasta_ref_dict,
                                                     disk=vcf_id.size*5)
         return norm_job.rv()
     else:

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -1130,17 +1130,21 @@ def vcfwave(job, config, out_name, vcf_ref, vcf_id, tbi_id, max_ref_allele, fast
                    ['bcftools', 'annotate', '-x', 'INFO/AT'],                   
                    ['vcfwave'] + wave_opts.split(' ') + ['-t', str(job.cores)]]
     run_norm = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_join"), "vcfwaveNorm", typeFn=bool, default=True)
+    merge_duplicates_opts = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_join"), "mergeDuplicatesOptions", typeFn=str, default=None)
+    run_merge = merge_duplicates_opts is not None and merge_duplicates_opts != "0" and run_norm    
     if run_norm:
         fa_ref_path = os.path.join(work_dir, tag + 'fa.gz')
         job.fileStore.readGlobalFile(fasta_ref_dict[vcf_ref], fa_ref_path)
         bubwave_cmd.append(['bcftools', 'norm', '-f', fa_ref_path])
         bubwave_cmd.append(['bcftools', 'sort', '-T', os.path.join(work_dir, 'bcftools.XXXXXX')])
+        if run_merge:
+            #merge_duplicates.py want biallelic
+            bubwave_cmd.append(['bcftools', 'norm', '-m', '-any'])
     bubwave_cmd.append(['bgzip'])
 
     cactus_call(parameters=bubwave_cmd, outfile=vcfwave_path)
 
-    merge_duplicates_opts = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_join"), "mergeDuplicatesOptions", typeFn=str, default=None)
-    if merge_duplicates_opts and merge_duplicates_opts != "0" and run_norm:
+    if run_merge:
         #note: merge_duplcates complains about not having a .tbi but I don't think it actually affects anything
         merge_path = os.path.join(work_dir, os.path.basename(out_name) + '.' + vcf_ref + tag + 'wave.merge.vcf.gz')
         cactus_call(parameters=['merge_duplicates.py', '-i', vcfwave_path, '-o', merge_path] + merge_duplicates_opts.split(' '))

--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -434,8 +434,11 @@ class TestCase(unittest.TestCase):
         config_path = 'src/cactus/cactus_progressive_config.xml'
         xml_root = ET.parse(config_path).getroot()
         graphmap_elem = xml_root.find("graphmap")
+        graphmap_join_elem = xml_root.find("graphmap_join")
         # force cactus to use minigraph chunking
         graphmap_elem.attrib["minigraphConstructBatchSize"] = "2"
+        # force cactus use vcfwave chunking
+        graphmap_join_elem.attrib["vcfwaveChunkLines"] = "1000"
         mc_config_path = os.path.join(self.tempDir, "config.mc.xml")
         with open(mc_config_path, 'w') as mc_config_file:
             xmlString = ET.tostring(xml_root, encoding='unicode')


### PR DESCRIPTION
This adds @Han-Cao's [merge_duplicates.py](https://github.com/Han-Cao/collapse-bubble/blob/master/scripts/merge_duplicates.py) as a post-processing step after `bcftools norm -f`.  

It merges together records at the same position that `bcftools norm` can create (see the original issue, #1493, for details). 

Unfortunately, it seems like `bcftools norm` can shift together sites that can't be represented as one without allele conflicts.  So the `--keep first` heuristic is used by default to choose one, but can be toggled in the `mergeDuplicatesOptions` field on the config XML. 

As it stands `bcftools norm -f` and `merge_duplicates.py` are both on by default for `vcfwave` output.  To apply it to the "Default" vcfs, then `bcftoolsNorm="1"` needs to be activated in the config. 

Stacks on #1491