### PR TITLE
Use faster distance index construction

### DIFF
--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -298,7 +298,7 @@ fi
 
 # vg
 cd ${pangenomeBuildDir}
-wget -q https://github.com/vgteam/vg/releases/download/v1.61.0/vg
+wget -q https://github.com/vgteam/vg/releases/download/v1.62.0/vg
 chmod +x vg
 if [[ $STATIC_CHECK -ne 1 || $(ldd vg | grep so | wc -l) -eq 0 ]]
 then

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -1229,9 +1229,9 @@ def make_haplo_index(job, options, config, index_dict, giraffe_dict, tag=''):
     if giraffe_dict:
         job.fileStore.readGlobalFile(giraffe_dict['{}dist'.format(tag)], dist_path)
     else:
-        # note we are using --snarl-limit 1 here to reduce memory, and its all haplo sampling needs
+        # note we are using --no-nested-distance here to reduce memory, and its all haplo sampling needs
         dist_path += '1'
-        cactus_call(parameters=['vg', 'index', '-t', str(job.cores), '-j', dist_path, gbz_path, '--snarl-limit' ,'1'], job_memory=job.memory)
+        cactus_call(parameters=['vg', 'index', '-t', str(job.cores), '-j', dist_path, gbz_path, '--no-nested-distance'], job_memory=job.memory)
         
     # make the r-index
     # note: we don't bother adding it to the output_dict since it's only used for making the .hapl


### PR DESCRIPTION
The `--no-nested-distance` option was [recently added](https://github.com/vgteam/vg/pull/4466) to improve performance when making a top-level distance index (ie as required for `.hapl` construction).  This PR switches to using this instead of `--snarl-limit 1`.  Should help considerably for giant graphs where this step was a bottleneck. 