### PR TITLE
fix toil dependency bug in recent vcf refactor

### DIFF
--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -580,11 +580,13 @@ def graphmap_join_workflow(job, options, config, vg_ids, hal_ids):
 
         # optional vcf
         if workflow_phase in options.vcf:
-            vcf_prev_job = ref_fasta_job if ref_fasta_job else gfa_root_job
             for vcf_ref in options.vcfReference:
-                vcf_job = vcf_prev_job.addFollowOnJobFn(make_vcf, config, options, workflow_phase,
+                vcf_job = gfa_root_job.addFollowOnJobFn(make_vcf, config, options, workflow_phase,
                                                         index_mem, vcf_ref, phase_vg_ids,
                                                         ref_fasta_job.rv() if ref_fasta_job else None)
+                if ref_fasta_job:
+                    ref_fasta_job.addFollowOn(vcf_job)
+
                 out_dicts.append(vcf_job.rv())
                     
         # optional giraffe


### PR DESCRIPTION
This made it into master because it doesn't always cause the tests to fail, but now it's causing unrelated PRs to sometimes fail tests.  

There's a patch in #1536, but making a separate PR to get it in right away. 