### PR TITLE
update gfaffix to v0.2.0

### DIFF
--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -309,12 +309,12 @@ fi
 
 # gfaffix
 cd ${pangenomeBuildDir}
-wget -q https://github.com/marschall-lab/GFAffix/releases/download/0.1.5b/GFAffix-0.1.5b_linux_x86_64.tar.gz
-tar xzf GFAffix-0.1.5b_linux_x86_64.tar.gz
-chmod +x GFAffix-0.1.5b_linux_x86_64/gfaffix
-if [[ $STATIC_CHECK -ne 1 || $(ldd GFAffix-0.1.5b_linux_x86_64/gfaffix | grep so | wc -l) -eq 0 ]]
+wget -q https://github.com/marschall-lab/GFAffix/releases/download/0.2.0/GFAffix-0.2.0_linux_x86_64.tar.gz
+tar xzf GFAffix-0.2.0_linux_x86_64.tar.gz
+chmod +x GFAffix-0.2.0_linux_x86_64/gfaffix
+if [[ $STATIC_CHECK -ne 1 || $(ldd GFAffix-0.2.0_linux_x86_64/gfaffix | grep so | wc -l) -eq 0 ]]
 then
-	 mv GFAffix-0.1.5b_linux_x86_64/gfaffix ${binDir}
+	 mv GFAffix-0.2.0_linux_x86_64/gfaffix ${binDir}
 else
 	 exit 1
 fi

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -687,7 +687,7 @@ def clip_vg(job, options, config, vg_path, vg_id, phase):
         gfa_out_path = normalized_path + '.gfa'
         # GFAffix's --dont_collapse option doesn't work on W-lines, so we strip them for now with -W
         cactus_call(parameters=['vg', 'convert', '-W', '-f', vg_path], outfile=gfa_in_path, job_memory=job.memory)
-        fix_cmd = ['gfaffix', gfa_in_path, '--output_refined', gfa_out_path, '--check_transformation']
+        fix_cmd = ['gfaffix', gfa_in_path, '--output_refined', gfa_out_path, '--check_transformation', '--threads', str(job.cores)]
         if options.reference:
             fix_cmd += ['--dont_collapse', options.reference[0] + '#[.]*']
         cactus_call(parameters=fix_cmd, job_memory=job.memory)


### PR DESCRIPTION
Updates to the [latest gfaffix](https://github.com/marschall-lab/GFAffix/releases/tag/0.2.0), which has many interesting improvements. Thanks @danydoerr!