### PR TITLE
use finer seeds instead of length-delta toggle for poa progressive

### DIFF
--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -266,12 +266,12 @@
 			partialOrderAlignmentTrainedGapOpen2Factor="3"
 			partialOrderAlignmentTrainedGapExtension2Factor="3"
 			partialOrderAlignmentDisableSeeding="1"
-			partialOrderAlignmentMinimizerK="19"
-			partialOrderAlignmentMinimizerW="10"
+			partialOrderAlignmentMinimizerK="15"
+			partialOrderAlignmentMinimizerW="5"
 			partialOrderAlignmentMinimizerMinW="500"
 			partialOrderAlignmentProgressiveMode="1"
 			partialOrderAlignmentProgressiveMaxRows="5000"
-			partialOrderAlignmentProgressiveMaxLengthDiff="0.05"
+			partialOrderAlignmentProgressiveMaxLengthDiff="1.0"
 		/>
 	</bar>
 


### PR DESCRIPTION
`abpoa`'s progressive mode works pretty well (which orders in the input sequences by similarity), which is why it's on by default in cactus.  But it's known to fall down in highly repetitive regions.  To get around this, I hacked in a heuristic to use sequence size (instead of similarity) instead of progressive when there was a signal for it, but I think this was too heavy handed.  

This PR reverts the above change (the logic can be reactivated via the `partialOrderAlignmentProgressiveMaxLengthDiff` option in the config).  Instead it shrinks the k/w minimizer parameters used by abpoa's progressive mode.  By using more/smaller minimizers, it seems to be able to get a better signal out of low-complexity regions, leading to better results in the problem areas I've tested on.. 