### PR TITLE
Revise mash ordering for minigraph construct

### DIFF
--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -339,6 +339,7 @@
 	<!-- collapse: Toggles self-alignment logic. Supported values are "none" and "all". Experimental values "reference" and "nonref" can also be tried.  -->
 	<!-- maxCollapseDistanceRatio: filter out self-alignments that are more than this value times the alignment lenght apart. Setting to 0 would only accept tandem (or overlapping alignments). Raising it allows alignments further apart. Set to -1 to completely disable. --> 
 	<!-- minigraphSortInput: Method used to determine input order. Valid values are "mash", "none" / "0" which refer to (decreasing) mash distance to reference, or no sorting (order in seqfile), respectively -->
+	<!-- minigraphSortReference: If more than one reference set, specify whether or not 2nd reference etc are sorted as above ("1"). Or left in the position they are set in the seqfile ("0"). -->
 	<!-- minMAPQ: ignore minigraph alignments with mapping quality less than this -->
 	<!-- minGAFBlockLength: ignore minigraph alignments with block length less than this -->
 	<!-- minGAFQueryOverlapFilter: if 2 or more query regions in blocks of at least this size, filter them out. -->
@@ -365,6 +366,7 @@
 		 maxCollapseDistanceRatio="5"
 		 minigraphConstructBatchSize="50"
 		 minigraphSortInput="mash"
+		 minigraphSortReference="1"
 		 minMAPQ="5"
 		 minGAFBlockLength="250000"
 		 minGAFQueryOverlapFilter="0"

--- a/src/cactus/progressive/seqFile.py
+++ b/src/cactus/progressive/seqFile.py
@@ -73,6 +73,7 @@ class SeqFile:
         self.tree = None
         self.pathMap = dict()
         self.outgroups = []
+        self.seqOrder = []
         seqFile = open(path, "r")
         for l in seqFile:
             line = l.strip()
@@ -98,6 +99,7 @@ class SeqFile:
                     if name in self.pathMap:
                         raise RuntimeError("Duplicate name found: %s" % name)
                     self.pathMap[name] = path
+                    self.seqOrder.append(name)
                 elif len(tokens) > 0:
                     sys.stderr.write("Skipping line %s\n" % l)
 


### PR DESCRIPTION
Previously, genomes passed in via the `--reference` option would be added to minigraph first (and in the order they are passed), while remaining genomes would be added in decreasing order of their mash distance to the first reference. 

This PR changes it so that references 2...N are sorted with mash along with everything else.  

While the first genome passed with `--reference` must always be first, the order of the remaining genomes can be controlled with: 

* `minigraphSortInput="0"` use the ordering from the input file or
* [new] `minigraphSortReference="0"` use the ordering from the input file only for reference genomes.  

So for example, if I pass `--reference CHM13 GRCh38 GRCh37` and want to force `GRCh38` and `GRCh37` to be last, I would make sure they are at the end of the input seqfile and set `minigraphSortReference="0"` to force them to remain last.  `CHM13` will be added first, and all other samples would be added in their mash distance order relative to `CHM13`.  To mimic the old default logic of them going first, I'd put them at the top of the seqfile and use the same config...