### PR TITLE
Adjust default overlap filter behaviour

### DIFF
--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -372,7 +372,7 @@
 		 minGAFQueryOverlapFilter="0"
 		 GAFOverlapFilterRatio="5"
 		 GAFOverlapFilterMinLengthRatio="0.25"
-		 PAFOverlapFilterRatio="5"
+		 PAFOverlapFilterRatio="0"
 		 PAFOverlapFilterMinLengthRatio="0"
 		 maskFilter="-1"
 		 delFilter="10000000"

--- a/src/cactus/refmap/cactus_graphmap.py
+++ b/src/cactus/refmap/cactus_graphmap.py
@@ -537,7 +537,7 @@ def self_align(job, config, seq_name, seq_id):
         cactus_call(parameters=cmd, outfile=paf_path, outappend=True)
     return job.fileStore.writeGlobalFile(paf_path)        
 
-def filter_paf(job, paf_id, config, reference=None):
+def filter_paf(job, paf_id, config, reference=None, skip_overlap_filter=False):
     """ run basic paf-filtering.  these are quick filters that are best to do on-the-fly when reading the paf and 
         as such, they are called by cactus-graphmap-split and cactus-align, not here """
     work_dir = job.fileStore.getLocalTempDir()
@@ -590,7 +590,7 @@ def filter_paf(job, paf_id, config, reference=None):
     length_ratio = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap"), "PAFOverlapFilterMinLengthRatio", typeFn=float, default=0)
     allow_collapse = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap"), "collapse", typeFn=str, default="none") != "none"
 
-    if overlap_ratio and not allow_collapse:
+    if not skip_overlap_filter and overlap_ratio and not allow_collapse:
         overlap_filter_paf_path = filter_paf_path + ".overlap"
         cactus_call(parameters=['gaffilter', filter_paf_path, '-p', '-r', str(overlap_ratio), '-m', str(length_ratio),
                                 '-b', str(min_block), '-q', str(min_mapq), '-i', str(min_ident)],

--- a/src/cactus/refmap/cactus_graphmap_split.py
+++ b/src/cactus/refmap/cactus_graphmap_split.py
@@ -243,6 +243,7 @@ def graphmap_split_workflow(job, options, config, seq_id_map, seq_name_map, gfa_
     # do some basic paf filtering
     paf_filter_mem = max(paf_id.size * 10, 2**32)
     paf_filter_job = root_job.addFollowOnJobFn(filter_paf, paf_id, config, reference=options.reference,
+                                               skip_overlap_filter=True,
                                                disk = paf_id.size * 10, memory=cactus_clamp_memory(paf_filter_mem))
     paf_id = paf_filter_job.rv()
     root_job = paf_filter_job


### PR DESCRIPTION
the pangenome pipeline does some filtering on the minigraph mappings.  this happens mostly after they've been converted from gaf to paf (so they can be adjusted later in the pipeline to facilitate tuning).  but some filters, namely the query overlap filter, need to be run on the original gaf blocks.  but for some reason, this filter is also applied (with slightly different settings) at the paf level. the upshot being that big, confident gaf blocks that might pass the gaf filter, may be partially filtered at the paf level where they overlaps.  

This PR 
* turns off all paf overlap filtering by default
* when it is on, never do it before chromosome splitting (doesn't impact the output much, just makes it easier to debug)