### PR TITLE
Forbid --haplo with --collapse

### DIFF
--- a/doc/pangenome.md
+++ b/doc/pangenome.md
@@ -147,6 +147,8 @@ You can also use the `--scoresFile` to input any `.train` file from `last-train`
 
 The `--collapse` option, added as an experimental prototype in [v2.9.1](https://github.com/ComparativeGenomicsToolkit/cactus/releases/tag/v2.9.1), can be used to incorporate self-alignments into the pangenome, *including the reference sample*.  This will produce a more compact graph with, for example, tandem duplications being represented as cycles (like PGGB) rather than insertions (like minigraph). It also drops the invariant (see above) that the reference path by acyclic -- with this option, the reference path can contain cycles. The `--collapse` option is implemented by running `minimap2` using options found in the `minimapCollapseOptions` parameter in the configuration XML to align each input *contig* with itself. These self alignments are fed into Cactus alongide the usual sequence-to-minigraph alignments.
 
+Note: Haplotype indexes (`--haplo`) cannot always be built for collapsed graphs. If haplotype indexing fails when using `--collapse`, a warning will be printed in the log and the failing index will not appear in the output (but the program will not crash).
+
 #### Multiple Reference Samples
 
 The `--reference` option can accept multiple samples (separated by space). If multiple samples are specified beyond the first, they will be clipped as usual, but end up as "reference-sense" paths in the vg/gbz output.  They can also be used as basis for VCF, and VCF files can be created based on them with the `--vcfReference` sample.

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -342,6 +342,9 @@ def graphmap_join_validate_options(options):
         if haplo not in options.gbz:
             logger.warning("Activating --gbz {} since --haplo {} was specified".format(haplo, haplo))
             options.gbz.append(haplo)
+
+    if options.collapse and options.haplo:
+        raise RuntimError('--haplo not allowed with --collapse, as it can lead to indexing errors')
         
     # Prevent some useless compute due to default param combos
     if options.clip and 'clip' not in options.gfa + options.gbz + options.odgi + options.chrom_vg + options.chrom_og + options.vcf + options.giraffe + options.viz + options.draw\

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -1471,8 +1471,14 @@ def make_haplo_index(job, options, config, index_dict, giraffe_dict, tag=''):
     # make the haplotype index
     hapl_path = os.path.join(work_dir, tag + os.path.basename(options.outName) + '.hapl')
     hapl_opts = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_join"), "haplOptions", default='').split()
-    cactus_call(parameters=['vg', 'haplotypes'] + hapl_opts + ['-t', str(job.cores), '-H', hapl_path, '-d', dist_path, '-r', ri_path, gbz_path])
-
+    try:
+        cactus_call(parameters=['vg', 'haplotypes'] + hapl_opts + ['-t', str(job.cores), '-H', hapl_path, '-d', dist_path, '-r', ri_path, gbz_path])
+    except Exception as e:
+        if options.collapse:
+            RealtimeLogger.warning('Unable to produce .hapl index on graph due to collapsing from --collapse')
+            return dict()
+        else:
+            raise e
     return { '{}hapl'.format(tag) : job.fileStore.writeGlobalFile(hapl_path) }
 
 def odgi_squeeze(job, config, vg_paths, og_ids, tag=''):

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -342,9 +342,6 @@ def graphmap_join_validate_options(options):
         if haplo not in options.gbz:
             logger.warning("Activating --gbz {} since --haplo {} was specified".format(haplo, haplo))
             options.gbz.append(haplo)
-
-    if options.collapse and options.haplo:
-        raise RuntimError('--haplo not allowed with --collapse, as it can lead to indexing errors')
         
     # Prevent some useless compute due to default param combos
     if options.clip and 'clip' not in options.gfa + options.gbz + options.odgi + options.chrom_vg + options.chrom_og + options.vcf + options.giraffe + options.viz + options.draw\


### PR DESCRIPTION
While it'd be nice to get this working eventually, for now there are no guarantees that graphs constructed with `--collapse` satisfy the conditions (ie one top-level chain) that `vg haplotypes` needs to run.  So this PR forbids the two from being used together so as not to waste anyone's time (#1603) with cryptic errors.  Resolves #1603

On second thought, going to keep allowing `--collapse` with `--haplo`, since `--collapse` is an experimental option and the combination often works.  This PR now downgrades any failures of `vg haplotypes` to warnings when the `--collapse` option is used.