### PR TITLE
Don't keep original user ids when untarring (as root, in docker)

### DIFF
--- a/build-tools/downloadMafTools
+++ b/build-tools/downloadMafTools
@@ -35,7 +35,7 @@ fi
 # taffy
 cd ${mafBuildDir}
 wget -q https://github.com/samtools/samtools/releases/download/1.11/samtools-1.11.tar.bz2
-tar -xf samtools-1.11.tar.bz2
+tar --no-same-owner -xf samtools-1.11.tar.bz2
 cd samtools-1.11
 SAMTOOLS_CONFIG_OPTS=""
 if [[ $STATIC_CHECK -eq 1 ]]

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -90,7 +90,7 @@ fi
 #samtools
 cd ${pangenomeBuildDir}
 wget -q https://github.com/samtools/samtools/releases/download/1.11/samtools-1.11.tar.bz2
-tar -xf samtools-1.11.tar.bz2
+tar --no-same-owner -xf samtools-1.11.tar.bz2
 cd samtools-1.11
 SAMTOOLS_CONFIG_OPTS=""
 if [[ $STATIC_CHECK -eq 1 ]]
@@ -124,7 +124,7 @@ fi
 #bcftools
 cd ${pangenomeBuildDir}
 wget -q https://github.com/samtools/bcftools/releases/download/1.19/bcftools-1.19.tar.bz2
-tar -xf bcftools-1.19.tar.bz2
+tar --no-same-owner -xf bcftools-1.19.tar.bz2
 cd bcftools-1.19
 SAMTOOLS_CONFIG_OPTS=""
 if [[ $STATIC_CHECK -eq 1 ]]
@@ -311,7 +311,7 @@ fi
 # gfaffix
 cd ${pangenomeBuildDir}
 wget -q https://github.com/marschall-lab/GFAffix/releases/download/0.2.0/GFAffix-0.2.0_linux_x86_64.tar.gz
-tar xzf GFAffix-0.2.0_linux_x86_64.tar.gz
+tar --no-same-owner -xzf GFAffix-0.2.0_linux_x86_64.tar.gz
 chmod +x GFAffix-0.2.0_linux_x86_64/gfaffix
 if [[ $STATIC_CHECK -ne 1 || $(ldd GFAffix-0.2.0_linux_x86_64/gfaffix | grep so | wc -l) -eq 0 ]]
 then
@@ -334,7 +334,7 @@ fi
 # mash
 cd ${pangenomeBuildDir}
 wget -q https://github.com/marbl/Mash/releases/download/v2.3/mash-Linux64-v2.3.tar
-tar -xf mash-Linux64-v2.3.tar
+tar --no-same-owner -xf mash-Linux64-v2.3.tar
 cd mash-Linux64-v2.3
 mv mash ${binDir}
 # note:
@@ -345,7 +345,7 @@ mv mash ${binDir}
 # odgi
 cd ${pangenomeBuildDir}
 wget -q https://github.com/pangenome/odgi/releases/download/v0.9.0/odgi-v0.9.0.tar.gz
-tar zxf odgi-v0.9.0.tar.gz
+tar --no-same-owner -zxf odgi-v0.9.0.tar.gz
 cd odgi-v0.9.0
 if [[ $STATIC_CHECK -eq 1 ]]
 then


### PR DESCRIPTION
Apparently when you untar something as root, the user and group ids in the archived files are kept.  In the tarball that `mash` comes from, these IDs happen to be unusually large, that apparently leads to some issues with the released Docker images.  

This PR adds the `--no-same-owner` flag to tar commands, which discards the original ids (as done when running `tar` as a non-root user. 

Resolves #1531 