### PR TITLE
Revert "Reapply "update gfaffix to v0.2.0""

### DIFF
--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -310,12 +310,12 @@ fi
 
 # gfaffix
 cd ${pangenomeBuildDir}
-wget -q https://github.com/marschall-lab/GFAffix/releases/download/0.2.0/GFAffix-0.2.0_linux_x86_64.tar.gz
-tar --no-same-owner -xzf GFAffix-0.2.0_linux_x86_64.tar.gz
-chmod +x GFAffix-0.2.0_linux_x86_64/gfaffix
-if [[ $STATIC_CHECK -ne 1 || $(ldd GFAffix-0.2.0_linux_x86_64/gfaffix | grep so | wc -l) -eq 0 ]]
+wget -q https://github.com/marschall-lab/GFAffix/releases/download/0.1.5b/GFAffix-0.1.5b_linux_x86_64.tar.gz
+tar --no-same-owner -xzf GFAffix-0.1.5b_linux_x86_64.tar.gz
+chmod +x GFAffix-0.1.5b_linux_x86_64/gfaffix
+if [[ $STATIC_CHECK -ne 1 || $(ldd GFAffix-0.1.5b_linux_x86_64/gfaffix | grep so | wc -l) -eq 0 ]]
 then
-	 mv GFAffix-0.2.0_linux_x86_64/gfaffix ${binDir}
+	 mv GFAffix-0.1.5b_linux_x86_64/gfaffix ${binDir}
 else
 	 exit 1
 fi

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -696,17 +696,20 @@ def clip_vg(job, options, config, vg_path, vg_id, phase):
         normalized_path = vg_path + '.gfaffixed'
         gfa_in_path = vg_path + '.gfa'
         gfa_out_path = normalized_path + '.gfa'
-        # GFAffix supports W-lines as reference paths since v0.2.0
-        cactus_call(parameters=['vg', 'convert', '-f', vg_path], outfile=gfa_in_path, job_memory=job.memory)
-        fix_cmd = ['gfaffix', gfa_in_path, '--output_refined', gfa_out_path, '--check_transformation', '--threads', str(job.cores)]
+        # GFAffix's --dont_collapse option doesn't work on W-lines, so we strip them for now with -W
+        cactus_call(parameters=['vg', 'convert', '-W', '-f', vg_path], outfile=gfa_in_path, job_memory=job.memory)
+        fix_cmd = ['gfaffix', gfa_in_path, '--output_refined', gfa_out_path, '--check_transformation']
         if options.reference:
             fix_cmd += ['--dont_collapse', options.reference[0] + '#[.]*']
         cactus_call(parameters=fix_cmd, job_memory=job.memory)
+        # GFAffix strips the header, until this is fixed we need to add it back (for the RS tag)
+        gfa_header = cactus_call(parameters=['head', '-1', gfa_in_path], check_output=True).strip()
+        cactus_call(parameters=['sed', '-i', gfa_out_path, '-e', '1s/.*/{}/'.format(gfa_header)])
         # Come back from gfa to vg
         conv_cmd = [['vg', 'convert', '-g', '-p', gfa_out_path]]
         # GFAFfix doesn't unchop, so we do that in vg after
         conv_cmd.append(['vg', 'mod', '-u', '-'])
-        cactus_call(parameters=conv_cmd, outfile=normalized_path)
+        cactus_call(parameters=conv_cmd, outfile=normalized_path)        
         vg_path = normalized_path
 
     # run clip-vg no matter what, but we don't actually remove anything in full


### PR DESCRIPTION
Sigh.. this reverts commit 5cc60204ff075cdc540ff7edc7984a8fa65a90e0.

See https://github.com/marschall-lab/GFAffix/issues/17