### PR TITLE
switch to newer toil argparse interface

### DIFF
--- a/src/cactus/blast/cactus_blast.py
+++ b/src/cactus/blast/cactus_blast.py
@@ -32,8 +32,7 @@ from sonLib.nxnewick import NXNewick
 from sonLib.bioio import getTempDirectory, getTempFile
 
 def main():
-    parser = ArgumentParser()
-    Job.Runner.addToilOptions(parser)
+    parser = Job.Runner.getDefaultArgumentParser()
 
     parser.add_argument("seqFile", help="Seq file")
     parser.add_argument("outputFile", type=str, help="Output pairwise alignment file")

--- a/src/cactus/maf/cactus_hal2chains.py
+++ b/src/cactus/maf/cactus_hal2chains.py
@@ -39,8 +39,7 @@ from sonLib.nxnewick import NXNewick
 from sonLib.bioio import newickTreeParser
 
 def main():
-    parser = ArgumentParser()
-    Job.Runner.addToilOptions(parser)
+    parser = Job.Runner.getDefaultArgumentParser()
 
     parser.add_argument("halFile", help = "HAL file to convert to MAF")
     parser.add_argument("outDir", help = "Output directory")

--- a/src/cactus/maf/cactus_hal2maf.py
+++ b/src/cactus/maf/cactus_hal2maf.py
@@ -41,8 +41,7 @@ from cactus.shared.common import cactus_clamp_memory
 from sonLib.nxnewick import NXNewick
 
 def main():
-    parser = ArgumentParser()
-    Job.Runner.addToilOptions(parser)
+    parser = Job.Runner.getDefaultArgumentParser()
 
     parser.add_argument("halFile", help = "HAL file to convert to MAF")
     parser.add_argument("outputMAF", help = "Output MAF (will be gzipped if ends in .gz). Suffix with .taf or .taf.gz if you want TAF output")

--- a/src/cactus/maf/cactus_maf2bigmaf.py
+++ b/src/cactus/maf/cactus_maf2bigmaf.py
@@ -35,8 +35,7 @@ from toil.lib.humanize import bytes2human
 from sonLib.bioio import getTempDirectory
 
 def main():
-    parser = ArgumentParser()
-    Job.Runner.addToilOptions(parser)
+    parser = Job.Runner.getDefaultArgumentParser()
 
     parser.add_argument("mafFile", help = "MAF file to convert to BigMaf (can be gzipped)")
     parser.add_argument("outFile", help = "Output bigMaf file (.bb)")

--- a/src/cactus/preprocessor/cactus_preprocessor.py
+++ b/src/cactus/preprocessor/cactus_preprocessor.py
@@ -438,8 +438,7 @@ def runCactusPreprocessor(outputSequenceDir, configFile, inputSequences, toilDir
         stageWorkflow(outputSequenceDir, ET.parse(options.configFile).getroot(), inputSequences, toil, options=toilOptions)
 
 def main():
-    parser = ArgumentParser()
-    Job.Runner.addToilOptions(parser)
+    parser = Job.Runner.getDefaultArgumentParser()
     parser.add_argument("inSeqFile", type=str, nargs='?', default=None, help = "Input Seq file")
     parser.add_argument("outSeqFile", type=str, nargs='?', default=None, help = "Output Seq file (ex generated with cactus-prepare)")
     parser.add_argument("--configFile", default=os.path.join(cactusRootPath(), "cactus_progressive_config.xml"))

--- a/src/cactus/progressive/cactus_prepare.py
+++ b/src/cactus/progressive/cactus_prepare.py
@@ -47,7 +47,7 @@ def main_toil():
 def main(toil_mode=False):
     parser = ArgumentParser()
     if toil_mode:
-        Job.Runner.addToilOptions(parser)
+        parser = Job.Runner.getDefaultArgumentParser()
         parser.add_argument("--latest", dest="latest", action="store_true",
                             help="Use the latest version of the docker container "
                             "rather than pulling one matching this version of cactus")

--- a/src/cactus/progressive/cactus_progressive.py
+++ b/src/cactus/progressive/cactus_progressive.py
@@ -318,8 +318,7 @@ def progressive_workflow(job, options, config_node, mc_tree, og_map, input_seq_i
     return hal_export_job.rv()
 
 def main():
-    parser = ArgumentParser()
-    Job.Runner.addToilOptions(parser)
+    parser = Job.Runner.getDefaultArgumentParser()
 
     parser.add_argument("seqFile", help = "Seq file")
     parser.add_argument("outputHal", type=str, help = "Output HAL file")

--- a/src/cactus/refmap/cactus_graphmap.py
+++ b/src/cactus/refmap/cactus_graphmap.py
@@ -40,8 +40,7 @@ from sonLib.nxnewick import NXNewick
 from sonLib.bioio import getTempDirectory
 
 def main():
-    parser = ArgumentParser()
-    Job.Runner.addToilOptions(parser)
+    parser = Job.Runner.getDefaultArgumentParser()
 
     parser.add_argument("seqFile", help = "Seq file (will be modified if necessary to include graph Fasta sequence)")
     parser.add_argument("minigraphGFA", help = "Minigraph-compatible reference graph in GFA format (can be gzipped)")

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -63,8 +63,7 @@ from sonLib.bioio import getTempDirectory, getTempFile, catFiles
 import pysam
 
 def main():
-    parser = ArgumentParser()
-    Job.Runner.addToilOptions(parser)
+    parser = Job.Runner.getDefaultArgumentParser()
 
     parser.add_argument("--vg", required=True, nargs='+',  help = "Input vg files (PackedGraph or HashGraph format)")
     parser.add_argument("--hal", nargs='+', default = [], help = "Input hal files (for merging)")    

--- a/src/cactus/refmap/cactus_graphmap_split.py
+++ b/src/cactus/refmap/cactus_graphmap_split.py
@@ -31,7 +31,7 @@ from cactus.preprocessor.checkUniqueHeaders import sanitize_fasta_headers
 from cactus.refmap.cactus_graphmap import filter_paf
 from cactus.refmap.cactus_minigraph import check_sample_names, minigraph_gfa_from_pansn
 from toil.job import Job
-from toil.common import Toil
+from toil.common import Toil, Job.Runner.getDefaultArgumentParser()
 from toil.statsAndLogging import logger
 from toil.statsAndLogging import set_logging_from_options
 from toil.realtimeLogger import RealtimeLogger
@@ -41,8 +41,7 @@ from sonLib.nxnewick import NXNewick
 from sonLib.bioio import getTempDirectory, getTempFile, catFiles
 
 def main():
-    parser = ArgumentParser()
-    Job.Runner.addToilOptions(parser)
+    parser = Job.Runner.getDefaultArgumentParser()
 
     parser.add_argument("seqFile", help = "Seq file (gzipped fastas supported)")
     parser.add_argument("minigraphGFA", help = "Minigraph-compatible reference graph in GFA format (can be gzipped)")

--- a/src/cactus/refmap/cactus_graphmap_split.py
+++ b/src/cactus/refmap/cactus_graphmap_split.py
@@ -31,7 +31,7 @@ from cactus.preprocessor.checkUniqueHeaders import sanitize_fasta_headers
 from cactus.refmap.cactus_graphmap import filter_paf
 from cactus.refmap.cactus_minigraph import check_sample_names, minigraph_gfa_from_pansn
 from toil.job import Job
-from toil.common import Toil, Job.Runner.getDefaultArgumentParser()
+from toil.common import Toil
 from toil.statsAndLogging import logger
 from toil.statsAndLogging import set_logging_from_options
 from toil.realtimeLogger import RealtimeLogger

--- a/src/cactus/refmap/cactus_minigraph.py
+++ b/src/cactus/refmap/cactus_minigraph.py
@@ -42,8 +42,7 @@ from cactus.progressive.multiCactusTree import MultiCactusTree
 from sonLib.bioio import getTempDirectory
 
 def main():
-    parser = ArgumentParser()
-    Job.Runner.addToilOptions(parser)
+    parser = Job.Runner.getDefaultArgumentParser()
 
     parser.add_argument("seqFile", help = "Seq file (will be modified if necessary to include graph Fasta sequence)")
     parser.add_argument("outputGFA", help = "Output Minigraph GFA")

--- a/src/cactus/refmap/cactus_pangenome.py
+++ b/src/cactus/refmap/cactus_pangenome.py
@@ -48,8 +48,7 @@ from cactus.setup.cactus_align import make_batch_align_jobs, batch_align_jobs
 from cactus.refmap.cactus_graphmap_join import graphmap_join_workflow, export_join_data, graphmap_join_options, graphmap_join_validate_options
 
 def main():
-    parser = ArgumentParser()
-    Job.Runner.addToilOptions(parser)
+    parser = Job.Runner.getDefaultArgumentParser()
 
     parser.add_argument("seqFile", help = "Seq file (will be modified if necessary to include graph Fasta sequence)")
     parser.add_argument("--outDir", help = "Output directory", required=True)

--- a/src/cactus/refmap/cactus_refmap.py
+++ b/src/cactus/refmap/cactus_refmap.py
@@ -226,8 +226,7 @@ def map_a_to_b(job, a, b, dipcall_filter):
 ## main fxn and interface:
 
 def get_options():
-    parser = ArgumentParser()
-    Job.Runner.addToilOptions(parser)
+    parser = Job.Runner.getDefaultArgumentParser()
     # addCactusWorkflowOptions(parser)
     
     # ### For quick debugging of apply_dipcall_bed_filter:

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -47,8 +47,7 @@ from sonLib.nxnewick import NXNewick
 from sonLib.bioio import getTempDirectory, getTempFile
 
 def main():
-    parser = ArgumentParser()
-    Job.Runner.addToilOptions(parser)
+    parser = Job.Runner.getDefaultArgumentParser()
 
     parser.add_argument("seqFile", help = "Seq file")
     parser.add_argument("pafFile", nargs='?', default='', type=str, help = "Pairiwse aliginments (from cactus-blast, cactus-refmap or cactus-graphmap)")
@@ -509,8 +508,7 @@ def main_batch():
           could be ported to Terra
     cons: less efficient use of resources
     """
-    parser = ArgumentParser()
-    Job.Runner.addToilOptions(parser)
+    parser = Job.Runner.getDefaultArgumentParser()
 
     parser.add_argument("chromFile", help = "chroms file")
     parser.add_argument("outHal", type=str, help = "Output directory (can be s3://)")


### PR DESCRIPTION
This came up here: https://github.com/DataBiosphere/toil/pull/5233#issuecomment-2718592241

Where apparently 
```
parser = ArgumentParser()
Job.Runner.addToilOptions(parser)
```
had been deprecated in favour of
```
parser = parser_with_common_options()
```
with one difference being how environment variables are handled. 
