### PR TITLE
prep release v2.9.5

### DIFF
--- a/BIN-INSTALL.md
+++ b/BIN-INSTALL.md
@@ -6,17 +6,17 @@ pre-compile binary, static linked distribution.
 ## Extracting
 If you have not already extract the distribution and cd into the cactus directory:
 ```
-tar -xzf cactus-bin-v2.9.4.tar.gz
-cd cactus-bin-v2.9.4
+tar -xzf cactus-bin-v2.9.5.tar.gz
+cd cactus-bin-v2.9.5
 ```
 
 ## Setup
 
 To build a python virtualenv and activate, do the following steps. This requires Python version >= 3.9 (so Ubuntu 18.04 users should use `-p python3.9` below):
 ```
-virtualenv -p python3 venv-cactus-v2.9.4
-printf "export PATH=$(pwd)/bin:\$PATH\nexport PYTHONPATH=$(pwd)/lib:\$PYTHONPATH\nexport LD_LIBRARY_PATH=$(pwd)/lib:\$LD_LIBRARY_PATH\n" >> venv-cactus-v2.9.4/bin/activate
-source venv-cactus-v2.9.4/bin/activate
+virtualenv -p python3 venv-cactus-v2.9.5
+printf "export PATH=$(pwd)/bin:\$PATH\nexport PYTHONPATH=$(pwd)/lib:\$PYTHONPATH\nexport LD_LIBRARY_PATH=$(pwd)/lib:\$LD_LIBRARY_PATH\n" >> venv-cactus-v2.9.5/bin/activate
+source venv-cactus-v2.9.5/bin/activate
 python3 -m pip install -U setuptools pip wheel
 python3 -m pip install -U .
 python3 -m pip install -U -r ./toil-requirement.txt

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,14 @@
+# Release 2.9.5 2025-03-12
+
+This release patches a few issues that arose in the previous release
+
+- Toil version updated from 8.0.0 to 8.1.0b1. This fixes slurm partition support by adding the `--slurmPartition` option.
+- Fix (via interface update) how environment variables are passed through to Toil (which was constributing factor to partition selection issue above).
+- Update Cactus's minimum Python requirement to 3.9. This will prevent cryptic Toil install errors. 
+- Fix `--snarlStats` option, which previously returned an invalid gzip file
+- Fix `mash` binary to have same user/group IDs as other files in the Docker image. The fact that it didn't apparently caused singularity issues for some users.
+- Revert from `gfaffix` 0.2.0 back to 0.1.5b, as the decollapsing process of the former still crashes in some cases. 
+
 # Release 2.9.4 2025-02-27
 
 This release fixes compatibility with newer Python versions and improves the `--vcfwave` option, along with a few other patches

--- a/doc/progressive.md
+++ b/doc/progressive.md
@@ -278,12 +278,12 @@ The Cactus Docker image contains everything you need to run Cactus (python envir
 
 ```
 wget -q https://raw.githubusercontent.com/ComparativeGenomicsToolkit/cactus/master/examples/evolverMammals.txt -O evolverMammals.txt
-docker run -v $(pwd):/data --rm -it quay.io/comparative-genomics-toolkit/cactus:v2.9.4 cactus /data/jobStore /data/evolverMammals.txt /data/evolverMammals.hal
+docker run -v $(pwd):/data --rm -it quay.io/comparative-genomics-toolkit/cactus:v2.9.5 cactus /data/jobStore /data/evolverMammals.txt /data/evolverMammals.hal
 ```
 
 Or you can proceed interactively by running
 ```
-docker run -v $(pwd):/data --rm -it quay.io/comparative-genomics-toolkit/cactus:v2.9.4 bash
+docker run -v $(pwd):/data --rm -it quay.io/comparative-genomics-toolkit/cactus:v2.9.5 bash
 cactus /data/jobStore /data/evolverMammals.txt /data/evolverMammals.hal
 
 ```

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ class PostInstallCommand(install):
 
 setup(
     name = "Cactus",
-    version = "2.9.4",
+    version = "2.9.5",
     author = "Benedict Paten",
     package_dir = {'': 'src'},
     packages = find_packages(where='src'),

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -313,7 +313,7 @@ def getDockerTag(gpu=False):
         return "latest"    
     else:
         # must be manually kept current with each release        
-        return 'v2.9.4' + ('-gpu' if gpu else '')
+        return 'v2.9.5' + ('-gpu' if gpu else '')
 
 def getDockerImage(gpu=False):
     """Get fully specified Docker image name."""


### PR DESCRIPTION
I'm pushing this out so soon after v2.9.4 because the slurm partition update is pretty significant.  And I need the gfaffix rollback/patch in a release asap so I can index some candidate hprc graphs asap with a release version of cactus. 