### PR TITLE
Fix fatal error when deconstructing chromosome with no alt paths

### DIFF
--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -430,7 +430,7 @@ def graphmap_join_workflow(job, options, config, vg_ids, hal_ids):
     # run the "full" phase to do pre-clipping stuff
     full_vg_ids = []
     assert len(options.vg) == len(vg_ids)
-    for vg_path, vg_id in zip(options.vg, vg_ids):
+    for vg_path, vg_id in sorted(zip(options.vg, vg_ids)):
         full_job = Job.wrapJobFn(clip_vg, options, config, vg_path, vg_id, 'full',
                                  disk=vg_id.size * 20, memory=max(2**31, min(vg_id.size * 20, max_mem)))
         root_job.addChild(full_job)


### PR DESCRIPTION
Not sure how this one snuck under the radar for so long.  A few releases ago mc changes to make VCF chromosome by chromosome.  But when treating `chrEBV` in the GRCh38 analysis set alone, `vg deconstruct` now gives an error to the effect of

```
RuntimeError: Command /usr/bin/time -f "CACTUS-LOGGED-MEMORY-IN-KB: %M" bash -c 'set -eo pipefail && vg deconstruct /data/tmp/toilwf-fb7424c02be05fdaad61e9a49ad4471a/1e59/job/tmpv3wg5ehg/hprc-v2.0-mc-grch38-eval.chrEBV.clip.vg -P GRCh38 -C -a -t 64 | bgzip --threads 64' exited 1: stderr=Error [vg deconstruct]: No paths other than selected reference(s) found in the graph, so no alt alleles can be generated. Note that exhaustive path-free traversal finding is no longer supported, and vg deconstruct now only works on embedded paths and GBWT threads.
```

This PR fixes this by bypassing `vg deconstruct` on chromosomes without non-reference paths.  The workaround (at least for hg38)  in the meantime is to use `--refContigs / --otherContig` to make sure `chrEBV` gets deconstructed with all the other unplaced contigs. 