### PR TITLE
prep release v2.9.7

### DIFF
--- a/BIN-INSTALL.md
+++ b/BIN-INSTALL.md
@@ -6,17 +6,17 @@ pre-compile binary, static linked distribution.
 ## Extracting
 If you have not already extract the distribution and cd into the cactus directory:
 ```
-tar -xzf cactus-bin-v2.9.6.tar.gz
-cd cactus-bin-v2.9.6
+tar -xzf cactus-bin-v2.9.7.tar.gz
+cd cactus-bin-v2.9.7
 ```
 
 ## Setup
 
 To build a python virtualenv and activate, do the following steps. This requires Python version >= 3.9 (so Ubuntu 18.04 users should use `-p python3.9` below):
 ```
-virtualenv -p python3 venv-cactus-v2.9.6
-printf "export PATH=$(pwd)/bin:\$PATH\nexport PYTHONPATH=$(pwd)/lib:\$PYTHONPATH\nexport LD_LIBRARY_PATH=$(pwd)/lib:\$LD_LIBRARY_PATH\n" >> venv-cactus-v2.9.6/bin/activate
-source venv-cactus-v2.9.6/bin/activate
+virtualenv -p python3 venv-cactus-v2.9.7
+printf "export PATH=$(pwd)/bin:\$PATH\nexport PYTHONPATH=$(pwd)/lib:\$PYTHONPATH\nexport LD_LIBRARY_PATH=$(pwd)/lib:\$LD_LIBRARY_PATH\n" >> venv-cactus-v2.9.7/bin/activate
+source venv-cactus-v2.9.7/bin/activate
 python3 -m pip install -U setuptools pip wheel
 python3 -m pip install -U .
 python3 -m pip install -U -r ./toil-requirement.txt

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,8 @@
+# Release 2.9.7 2025-03-17
+
+- Resolve `vcfwave` normalization crash on reference chromosomes with zero variation, ex `chrEBV`. 
+- Fix bug introduced in v2.9.6 where per-chromosome outputs could be misnamed.
+
 # Release 2.9.6 2025-03-15
 
 This release contains yet another `gfaffix` patch (hopefully the last for a long time), as well as a fix for `deconstruct`

--- a/doc/progressive.md
+++ b/doc/progressive.md
@@ -278,12 +278,12 @@ The Cactus Docker image contains everything you need to run Cactus (python envir
 
 ```
 wget -q https://raw.githubusercontent.com/ComparativeGenomicsToolkit/cactus/master/examples/evolverMammals.txt -O evolverMammals.txt
-docker run -v $(pwd):/data --rm -it quay.io/comparative-genomics-toolkit/cactus:v2.9.6 cactus /data/jobStore /data/evolverMammals.txt /data/evolverMammals.hal
+docker run -v $(pwd):/data --rm -it quay.io/comparative-genomics-toolkit/cactus:v2.9.7 cactus /data/jobStore /data/evolverMammals.txt /data/evolverMammals.hal
 ```
 
 Or you can proceed interactively by running
 ```
-docker run -v $(pwd):/data --rm -it quay.io/comparative-genomics-toolkit/cactus:v2.9.6 bash
+docker run -v $(pwd):/data --rm -it quay.io/comparative-genomics-toolkit/cactus:v2.9.7 bash
 cactus /data/jobStore /data/evolverMammals.txt /data/evolverMammals.hal
 
 ```

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ class PostInstallCommand(install):
 
 setup(
     name = "Cactus",
-    version = "2.9.6",
+    version = "2.9.7",
     author = "Benedict Paten",
     package_dir = {'': 'src'},
     packages = find_packages(where='src'),

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -313,7 +313,7 @@ def getDockerTag(gpu=False):
         return "latest"    
     else:
         # must be manually kept current with each release        
-        return 'v2.9.6' + ('-gpu' if gpu else '')
+        return 'v2.9.7' + ('-gpu' if gpu else '')
 
 def getDockerImage(gpu=False):
     """Get fully specified Docker image name."""


### PR DESCRIPTION
I rushed [2.9.6](https://github.com/ComparativeGenomicsToolkit/cactus/releases/tag/v2.9.6) too much and it contains some bugs:

* `vcf`-pipeline crashed at `vcfwave` stage for grch38-based hprc graphs on chrEBV contig
* chromosome graph files got wrong names (ie chr1 might be in chr19.vg etc) -- really dumb bug introduced for no good reason in previous release.

Both these sadly necessitate another release.... 