### PR TITLE
use queryhsplimit to avoid super-long lastz runs

### DIFF
--- a/api/tests/cactusParamsTest.c
+++ b/api/tests/cactusParamsTest.c
@@ -14,7 +14,7 @@ static void testCactusParams(CuTest *testCase) {
     CactusParams *p = cactusParams_load(params_file);
 
     const char *c = cactusParams_get_string(p, 3, "blast", "lastzArguments", "default");
-    CuAssertStrEquals(testCase, "--step=1 --ambiguous=iupac,100,100 --ydrop=3000 --queryhsplimit=100000", c);
+    CuAssertStrEquals(testCase, "--step=1 --ambiguous=iupac,100,100 --ydrop=3000 --queryhspbest=100000", c);
 
     int64_t i = cactusParams_get_int(p, 3, "bar", "pecan", "spanningTrees");
     CuAssertIntEquals(testCase, 5, i);

--- a/api/tests/cactusParamsTest.c
+++ b/api/tests/cactusParamsTest.c
@@ -14,7 +14,7 @@ static void testCactusParams(CuTest *testCase) {
     CactusParams *p = cactusParams_load(params_file);
 
     const char *c = cactusParams_get_string(p, 3, "blast", "lastzArguments", "default");
-    CuAssertStrEquals(testCase, "--step=1 --ambiguous=iupac,100,100 --ydrop=3000", c);
+    CuAssertStrEquals(testCase, "--step=1 --ambiguous=iupac,100,100 --ydrop=3000 --queryhsplimit=100000", c);
 
     int64_t i = cactusParams_get_int(p, 3, "bar", "pecan", "spanningTrees");
     CuAssertIntEquals(testCase, 5, i);

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -105,6 +105,16 @@
 				five="--step=2 --ambiguous=iupac,100,100 --ydrop=3000 --queryhspbest=100000"
 				default="--step=1 --ambiguous=iupac,100,100 --ydrop=3000 --queryhspbest=100000"
 		/>
+		<!-- KegAlign doesn't seem to work properly with queryhspbest -->
+		<kegalignArguments
+				one="--step=2 --ambiguous=iupac,100,100 --ydrop=3000 --notransition"
+				two="--step=5 --ambiguous=iupac,100,100 --ydrop=3000"
+				three="--step=4 --ambiguous=iupac,100,100 --ydrop=3000"
+				four="--step=3 --ambiguous=iupac,100,100 --ydrop=3000"
+				five="--step=2 --ambiguous=iupac,100,100 --ydrop=3000"
+				default="--step=1 --ambiguous=iupac,100,100 --ydrop=3000"
+		/>
+		
 	</blast>
 
 	<setup makeEventHeadersAlphaNumeric="0"/>

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -98,12 +98,12 @@
 		within a margin of 0.2% sensitivity, should be very fast for close genomes, these were tuned using the blast/blastParametersScript.py
 		We could go even faster for less than 0.05 divergence using, but want to be robust to poor branch length estimates -->
 		<lastzArguments
-				one="--step=2 --ambiguous=iupac,100,100 --ydrop=3000 --notransition --queryhsplimit=100000"
-				two="--step=5 --ambiguous=iupac,100,100 --ydrop=3000 --queryhsplimit=100000"
-				three="--step=4 --ambiguous=iupac,100,100 --ydrop=3000 --queryhsplimit=100000"
-				four="--step=3 --ambiguous=iupac,100,100 --ydrop=3000 --queryhsplimit=100000"
-				five="--step=2 --ambiguous=iupac,100,100 --ydrop=3000 --queryhsplimit=100000"
-				default="--step=1 --ambiguous=iupac,100,100 --ydrop=3000 --queryhsplimit=100000"
+				one="--step=2 --ambiguous=iupac,100,100 --ydrop=3000 --notransition --queryhspbest=100000"
+				two="--step=5 --ambiguous=iupac,100,100 --ydrop=3000 --queryhspbest=100000"
+				three="--step=4 --ambiguous=iupac,100,100 --ydrop=3000 --queryhspbest=100000"
+				four="--step=3 --ambiguous=iupac,100,100 --ydrop=3000 --queryhspbest=100000"
+				five="--step=2 --ambiguous=iupac,100,100 --ydrop=3000 --queryhspbest=100000"
+				default="--step=1 --ambiguous=iupac,100,100 --ydrop=3000 --queryhspbest=100000"
 		/>
 	</blast>
 

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -98,12 +98,12 @@
 		within a margin of 0.2% sensitivity, should be very fast for close genomes, these were tuned using the blast/blastParametersScript.py
 		We could go even faster for less than 0.05 divergence using, but want to be robust to poor branch length estimates -->
 		<lastzArguments
-				one="--step=2 --ambiguous=iupac,100,100 --ydrop=3000 --notransition"
-				two="--step=5 --ambiguous=iupac,100,100 --ydrop=3000"
-				three="--step=4 --ambiguous=iupac,100,100 --ydrop=3000"
-				four="--step=3 --ambiguous=iupac,100,100 --ydrop=3000"
-				five="--step=2 --ambiguous=iupac,100,100 --ydrop=3000"
-				default="--step=1 --ambiguous=iupac,100,100 --ydrop=3000"
+				one="--step=2 --ambiguous=iupac,100,100 --ydrop=3000 --notransition --queryhsplimit=100000"
+				two="--step=5 --ambiguous=iupac,100,100 --ydrop=3000 --queryhsplimit=100000"
+				three="--step=4 --ambiguous=iupac,100,100 --ydrop=3000 --queryhsplimit=100000"
+				four="--step=3 --ambiguous=iupac,100,100 --ydrop=3000 --queryhsplimit=100000"
+				five="--step=2 --ambiguous=iupac,100,100 --ydrop=3000 --queryhsplimit=100000"
+				default="--step=1 --ambiguous=iupac,100,100 --ydrop=3000 --queryhsplimit=100000"
 		/>
 	</blast>
 

--- a/src/cactus/paf/local_alignment.py
+++ b/src/cactus/paf/local_alignment.py
@@ -30,10 +30,12 @@ def run_lastz(job, name_A, genome_A, name_B, genome_B, distance, params):
     genome_b_file = os.path.join(work_dir, '{}.fa'.format(name_B))
     job.fileStore.readGlobalFile(genome_A, genome_a_file)
     job.fileStore.readGlobalFile(genome_B, genome_b_file)
-
+    
     # Get the params to do the alignment
     lastz_params_node = params.find("blast")
-    lastz_divergence_node = lastz_params_node.find("lastzArguments")
+    gpu = getOptionalAttrib(lastz_params_node, 'gpu', typeFn=int, default=0)
+    cpu = getOptionalAttrib(lastz_params_node, 'cpu', typeFn=int, default=None)        
+    lastz_divergence_node = lastz_params_node.find("kegalignArguments" if gpu else "lastzArguments")
     divergences = params.find("constants").find("divergences")
     for i in "one", "two", "three", "four", "five":
         if distance <= float(divergences.attrib[i]):
@@ -43,9 +45,6 @@ def run_lastz(job, name_A, genome_A, name_B, genome_B, distance, params):
         lastz_params = lastz_divergence_node.attrib["default"]
     logger.info("For distance {} for genomes {}, {} using {} lastz parameters".format(distance, genome_A,
                                                                                       genome_B, lastz_params))
-
-    gpu = getOptionalAttrib(lastz_params_node, 'gpu', typeFn=int, default=0)
-    cpu = getOptionalAttrib(lastz_params_node, 'cpu', typeFn=int, default=None)    
     if gpu:
         lastz_bin = 'run_kegalign'
         suffix_a, suffix_b = '', ''


### PR DESCRIPTION
`lastz` operates by looking up seeds then performing a series of extension and refinement steps.  In the case of of highly repetitive sequences, this process can potentially find millions of alignments.  This can 1) bog down Cactus by over-collapsing the sequence graph and, in extreme cases, 2) cause `lastz` itself to run for too long.

Normally we expect masking the input with RepeatMasker and subsequently in Cactus, Red, to work around these issues, but exceptions do arise (#1662).  

This is a quick patch to try to increase robustness by telling lastz to give up on a match after its gapless extension (HSP) phase if more that 100000 matches are found.  This seems to be, roughly, the highest number that can be used on the example from #1662 without a huge hit to runtime.  

I'll need to run some larger tests before merging - and am also curious if there are any benifits to using a much lower number... 
