### PR TITLE
Remove --gpu option from cactus-align

### DIFF
--- a/doc/progressive.md
+++ b/doc/progressive.md
@@ -18,6 +18,7 @@ Please cite the [HAL paper](https://doi.org/10.1093/bioinformatics/btt128) when 
 * [Running on a Cluster](#running-on-a-cluster)
 * [Running Step-by-step](#running-step-by-step)
 * [Running on Terra or Cromwell](#running-on-terra-or-cromwell)
+* [Running with SnakeMake](#running-with-snakemake)
 * [Updating Alignments](#updating-alignments)
 * [GPU Acceleration](#gpu-acceleration)
 * [Pre-Alignment Checklist](#pre-alignment-checklist)
@@ -434,6 +435,10 @@ The same script can be used to download all the logs off Terra, which can be use
 ```
 gsutil ls -l -r gs://<BUCKET/PREFIX> | cactus-terra-helper scrape-logs
 ```
+
+## Running with SnakeMake](#running-with-snakemake)
+
+Please see this [Cactus Snakemake](https://github.com/harvardinformatics/cactus-snakemake) interface.  I haven't tried it yet but it seems like an extremely promising alternative to WDL for running large jobs step-by-step, including on clusters.  Credit to Gregg Thomos @gwct.
 
 ## Updating Alignments
 

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -98,8 +98,6 @@ def main():
                         "rather than pulling one from quay.io")
     parser.add_argument("--binariesMode", choices=["docker", "local", "singularity"],
                         help="The way to run the Cactus binaries", default=None)
-    parser.add_argument("--gpu", action="store_true",
-                        help="Enable GPU acceleration by using Segaling instead of lastz")
     parser.add_argument("--consCores", type=int, 
                         help="Number of cores for each cactus_consolidated job (defaults to all available / maxCores on single_machine)", default=None)
     parser.add_argument("--consMemory", type=human2bytesN,
@@ -264,7 +262,6 @@ def make_align_job(options, toil, config_wrapper=None, chrom_name=None):
         config_node = ET.parse(options.configFile).getroot()
         config_wrapper = ConfigWrapper(config_node)
         config_wrapper.substituteAllPredefinedConstantsWithLiterals(options)
-        config_wrapper.initGPU(options)
         if options.collapse:
             findRequiredNode(config_node, "graphmap").attrib["collapse"] = 'all'
     config_wrapper.setSystemMemory(options)


### PR DESCRIPTION
I'm not sure why it was ever there, and it can cause problems when trying to run `cactus-align` in gpu environments. 

Also, add little blurb about the Cactus Snakemake at https://github.com/harvardinformatics/cactus-snakemake

Note: both these things arose in #1652