### PR TITLE
specify memory for faffy chunk

### DIFF
--- a/src/cactus/paf/local_alignment.py
+++ b/src/cactus/paf/local_alignment.py
@@ -158,9 +158,6 @@ def merge_combined_chunks(job, combined_chunks):
 def make_chunked_alignments(job, event_a, genome_a, event_b, genome_b, distance, params):
     lastz_params_node = params.find("blast")
     gpu = getOptionalAttrib(lastz_params_node, 'gpu', typeFn=int, default=0)
-    if gpu:
-        # wga-gpu has a 6G limit, so we always override
-        lastz_params_node.attrib['chunkSize'] = '6000000000'
     lastz_cores = getOptionalAttrib(lastz_params_node, 'cpu', typeFn=int, default=None)
     lastz_memory = getOptionalAttrib(lastz_params_node, 'lastz_memory', typeFn=int, default=None)
     
@@ -227,6 +224,7 @@ def make_ingroup_to_outgroup_alignments_1(job, ingroup_event, outgroup_events, e
     alignment = root_job.addChildJobFn(make_chunked_alignments,
                                        outgroup.iD, event_names_to_sequences[outgroup.iD],
                                        ingroup_event.iD, event_names_to_sequences[ingroup_event.iD], distances[ingroup_event, outgroup], params,
+                                       memory=cactus_clamp_memory(1.2 * float(params.find("blast").attrib["chunkSize"])),
                                        disk=4*(event_names_to_sequences[ingroup_event.iD].size+event_names_to_sequences[outgroup.iD].size)).rv()
 
     #  post process the alignments and recursively generate alignments to remaining outgroups
@@ -517,6 +515,13 @@ def make_paf_alignments(job, event_tree_string, event_names_to_sequences, ancest
     # Calculate the total sequence size
     total_sequence_size = sum(event_names_to_sequences[event.iD].size for event in get_leaves(event_tree))
 
+    # override chunk size 
+    lastz_params_node = params.find("blast")
+    gpu = getOptionalAttrib(lastz_params_node, 'gpu', typeFn=int, default=0)
+    if gpu:
+        # wga-gpu has a 6G limit, so we always override
+        lastz_params_node.attrib['chunkSize'] = '6000000000'
+
     # for each pair of ingroups make alignments
     ingroup_alignments = []
     # for better logs
@@ -526,6 +531,7 @@ def make_paf_alignments(job, event_tree_string, event_names_to_sequences, ancest
         ingroup_alignments.append(root_job.addChildJobFn(make_chunked_alignments,
                                                          ingroup.iD, event_names_to_sequences[ingroup.iD],
                                                          ingroup2.iD, event_names_to_sequences[ingroup2.iD], distance_a_b, params,
+                                                         memory=cactus_clamp_memory(1.2 * float(lastz_params_node.attrib['chunkSize'])),
                                                          disk=2*total_sequence_size).rv())
         ingroup_alignment_names.append('{}-{}_vs_{}'.format(ancestor_event_string, ingroup.iD, ingroup2.iD))
 
@@ -546,6 +552,7 @@ def make_paf_alignments(job, event_tree_string, event_names_to_sequences, ancest
                                                       ingroup.iD, event_names_to_sequences[ingroup.iD],
                                                       outgroup.iD, event_names_to_sequences[outgroup.iD],
                                                       distances[ingroup, outgroup], params,
+                                                      memory=cactus_clamp_memory(1.2 * float(lastz_params_node.attrib['chunkSize'])),
                                                       disk=2*total_sequence_size).rv()
                                for ingroup in ingroup_events for outgroup in outgroup_events]
     # for better logs

--- a/src/cactus/preprocessor/checkUniqueHeaders.py
+++ b/src/cactus/preprocessor/checkUniqueHeaders.py
@@ -5,6 +5,7 @@ from Bio import SeqIO
 from Bio.SeqRecord import SeqRecord
 import os
 from cactus.shared.common import cactus_call
+from cactus.shared.common import cactus_clamp_memory
 
 def checkUniqueHeaders(inputFile, outputFile, eventName, checkAlphaNumeric=False, checkUCSC=False, checkAssemblyHub=True):
     """Check that headers are unique and meet certain requirements."""
@@ -39,6 +40,7 @@ def sanitize_fasta_headers(job, fasta_id_map, pangenome=False, log_stats=True):
     out_fasta_id_map = {}
     for event, fasta_id in fasta_id_map.items():
         out_fasta_id_map[event] = job.addChildJobFn(sanitize_fasta_header, fasta_id, event, pangenome, log_stats,
+                                                    memory=cactus_clamp_memory(fasta_id.size * 4),
                                                     disk=fasta_id.size*7).rv()
     return out_fasta_id_map
 

--- a/src/cactus/refmap/cactus_refmap.py
+++ b/src/cactus/refmap/cactus_refmap.py
@@ -41,6 +41,7 @@ from cactus.shared.common import makeURL
 from cactus.shared.common import cactus_call
 from cactus.shared.configWrapper import ConfigWrapper
 from cactus.shared.common import cactusRootPath
+from cactus.shared.common import cactus_override_toil_options
 from cactus.progressive.progressive_decomposition import compute_outgroups, parse_seqfile, get_subtree, get_spanning_subtree, get_event_set
 from cactus.preprocessor.checkUniqueHeaders import sanitize_fasta_headers
 
@@ -285,7 +286,8 @@ def get_options():
 
 def main():
     options = get_options()
-
+    cactus_override_toil_options(options)
+    
     with Toil(options) as toil:
         setupBinaries(options)
 


### PR DESCRIPTION
faffy chunk can use about a chunk size's worth of memory, which is a problem when using giant chunk sizes (ex for gpu) on slurm.  this pr fixes it so toil asks for a bit more than the chunk size in memory. 