### PR TITLE
Ignore gpu options in cactus-preprocessor unless lastz enabled

### DIFF
--- a/src/cactus/preprocessor/cactus_preprocessor.py
+++ b/src/cactus/preprocessor/cactus_preprocessor.py
@@ -459,11 +459,11 @@ def main():
                         "rather than pulling one from quay.io")
     parser.add_argument("--binariesMode", choices=["docker", "local", "singularity"],
                         help="The way to run the Cactus binaries", default=None)
-    parser.add_argument("--gpu", nargs='?', const='all', default=None, help="toggle on GPU-enabled lastz, and specify number of GPUs (all available if no value provided)")
-    parser.add_argument("--lastzCores", type=int, default=None, help="Number of cores for each lastz/segalign job, only relevant when running with --gpu")
+    parser.add_argument("--gpu", nargs='?', const='all', default=None, help="toggle on GPU-enabled lastz, and specify number of GPUs (all available if no value provided). NOTE: lastz preprocessing is deprecated and disabled by default so this option will have no effect unless lastz is specifcally enabled in the config (no recommended).")
+    parser.add_argument("--lastzCores", type=int, default=None, help="Number of cores for each lastz/segalign job, only relevant when running with --gpu. NOTE: lastz preprocessing is deprecated and disabled by default so this option will have no effect unless lastz is specifcally enabled in the config (no recommended).")
     parser.add_argument("--lastzMemory", type=human2bytesN,
                         help="Memory in bytes for each lastz/segalign job (defaults to an estimate based on the input data size). "
-                        "Standard suffixes like K, Ki, M, Mi, G or Gi are supported (default=bytes))", default=None)
+                        "Standard suffixes like K, Ki, M, Mi, G or Gi are supported (default=bytes). NOTE: lastz preprocessing is deprecated and disabled by default so this option will have no effect unless lastz is specifcally enabled in the config (no recommended).", default=None)
 
     parser.add_argument("--pangenome", action="store_true", help='Do not mask. Just add Cactus-style unique prefixes and strip anything up to and including last #')
 
@@ -513,7 +513,8 @@ def main():
 
     # toggle on the gpu
     config_wrapper = ConfigWrapper(configNode)
-    config_wrapper.initGPU(options)
+    if config_wrapper.isLastzPreprocessorActive():
+        config_wrapper.initGPU(options)
 
     # apply pangenome overrides
     if options.pangenome:

--- a/src/cactus/preprocessor/lastzRepeatMasking/cactus_lastzRepeatMask.py
+++ b/src/cactus/preprocessor/lastzRepeatMasking/cactus_lastzRepeatMask.py
@@ -116,7 +116,7 @@ class LastzRepeatMaskJob(RoundedJob):
                 if not line.startswith("signals delivered"):
                     for keyword in ['terminate', 'error', 'fail', 'assert', 'signal', 'abort', 'segmentation', 'sigsegv', 'kill']:
                         if keyword in line and 'signals' not in line:
-                            job.fileStore.logToMaster("KegAlign offending line: " + line)  # Log the messages
+                            fileStore.logToMaster("KegAlign offending line: " + line)  # Log the messages
                             raise RuntimeError('{} exited 0 but keyword "{}" found in stderr'.format(lastz_cmd, keyword))
 
             # kegalign will write an invalid file if the output is empty.  correct it here!

--- a/src/cactus/shared/configWrapper.py
+++ b/src/cactus/shared/configWrapper.py
@@ -252,6 +252,14 @@ class ConfigWrapper:
                 return getOptionalAttrib(node, "active", default="1" if default_val else "0") == "1"
         return default_val
 
+    def isLastzPreprocessorActive(self):
+        """Determine if lastz (deprecated and disabled-by-default) preprocessing is active """
+        for node in self.xmlRoot.findall("preprocessor"):
+            if getOptionalAttrib(node, "preprocessJob") == "lastzRepeatMask":
+                if getOptionalAttrib(node, "active", default=False, typeFn=bool):
+                    return True
+        return False
+
     def initGPU(self, options):
         """ Turn on GPU and / or check options make sense """
         # first, we override the config with --gpu from the options


### PR DESCRIPTION
lastz-based preprocessing has been disabled by default for a while now in favour of RED, since RED is so much faster.

gpu-based lastz processing, efficient when it worked but not especially stable, is especially deprecated now that SegAlign has been replaced by KegAlign, with the latter not having the specialized preprocessor script.  

This means that even in the GPU-enabled cactus docker image where all gpu flags are on by default in the config, there's no reason to fail if no GPUs are detected when running `cactus-preprocess`.  

This PR changes the GPU check (`initGPU()`) to only be run if the user has manually updated the config to force lastz preprocessing (not recommonded).  

Resolves #1652