### PR TITLE
fix singularity init bugs with preprocess and gpu

### DIFF
--- a/src/cactus/preprocessor/cactus_preprocessor.py
+++ b/src/cactus/preprocessor/cactus_preprocessor.py
@@ -576,6 +576,7 @@ def main():
     logger.info('Cactus Commit: {}'.format(cactus_commit))
     
     with Toil(options) as toil:
+        importSingularityImage(options)        
         stageWorkflow(outputSequenceDir=None,
                       configNode=configNode,
                       inputSequences=inSeqPaths,

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -317,7 +317,7 @@ def getDockerTag(gpu=False):
 
 def getDockerImage(gpu=False):
     """Get fully specified Docker image name."""
-    return "%s/cactus:%s" % (getDockerOrg(), getDockerTag())
+    return "%s/cactus:%s" % (getDockerOrg(), getDockerTag(gpu))
 
 def maxMemUsageOfContainer(containerInfo):
     """Return the max RSS usage (in bytes) of a container, or None if something failed."""


### PR DESCRIPTION
Resolves #1690

* `cactus-preprocess` corrected to run `importSingularityImage(options)`
* singularity image creation bug fixed to pull in the `-gpu` image when option specified