### PR TITLE
Fatal error as soon as empty input FASTA detected

### DIFF
--- a/preprocessor/cactus_sanitizeFastaHeaders.c
+++ b/preprocessor/cactus_sanitizeFastaHeaders.c
@@ -196,7 +196,11 @@ int main(int argc, char *argv[]) {
     if (fileHandle != stdin) {
         fclose(fileHandle);
     }
-    fflush(stdout);
+    if (stSet_size(header_set) == 0) {
+        fprintf(stderr, "Error: No fasta sequences found in input FASTA file %s for %s\n", argv[1], argv[2]);
+        exit(1);
+    }
+    fflush(stdout);    
     stSet_destruct(header_set);
 
     return 0;


### PR DESCRIPTION
`cactus_sanitizeFastaHeaders` gets run at the outset of most cactus tools.  In addition to adding header prefixes etc, it detects various formatting issuesf in FASTA files that may cause downstream issues, such as empty or duplicate sequences and invalid characters.  

But apparently it will work just fine on completely empty files (see #1693).  Completely empty inputs will eventually lead to crashes in `cactus_consolidated`, and until then cause massive under-alignment.  What's worse, is that the pipeline will continue to run as normal before eventually failing, potentially wasting tons of time. 

I don't think there's a use case for empty sequence, so this PR modifies `cactus_sanitizeFastaHeaders` to abort with an error as soon as one is seen.  