### PR TITLE
try downgrading pysam to get around weird import errors in ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,6 +24,8 @@ test-job:
     - source venv/bin/activate
     - python3.9 -m pip install -r toil-requirement.txt
     - python3.9 -m pip install -U .
+    # downgrad pysam to work around import pysam error: "module 'pysam.libcalignedsegment' has no attribute 'CMATCH'"
+    - python3.9 -m pip install pysam==0.21.0
     # these are the old travis tests, followed by its docker push
     - git clone https://github.com/ComparativeGenomicsToolkit/cactusTestData
     - export ASAN_OPTIONS="detect_leaks=0"


### PR DESCRIPTION
See https://ucsc-ci.com/comparativegenomicstoolkit/cactus/-/jobs/92792 :+1: 

```
  File "/builds/comparativegenomicstoolkit/cactus/venv/lib/python3.9/site-packages/cactus/refmap/cactus_graphmap_join.py", line 63, in <module>
    import pysam
  File "/builds/comparativegenomicstoolkit/cactus/venv/lib/python3.9/site-packages/pysam/__init__.py", line 21, in <module>
    from pysam.libcalignedsegment import *
AttributeError: module 'pysam.libcalignedsegment' has no attribute 'CMATCH'
```