### PR TITLE
Remove Import log messages (Toil does it now)

### DIFF
--- a/src/cactus/blast/cactus_blast.py
+++ b/src/cactus/blast/cactus_blast.py
@@ -134,7 +134,6 @@ def runCactusBlastOnly(options):
                         catFiles([os.path.join(seq, subSeq) for subSeq in os.listdir(seq)], tmpSeq)
                         seq = tmpSeq
                     seq = makeURL(seq)
-                    logger.info("Importing {}".format(seq))
                     input_seq_id_map[genome] = toil.importFile(seq)
 
             paf_id = toil.start(Job.wrapJobFn(sanitize_then_make_paf_alignments, NXNewick().writeString(spanning_tree),

--- a/src/cactus/maf/cactus_hal2chains.py
+++ b/src/cactus/maf/cactus_hal2chains.py
@@ -117,7 +117,6 @@ def main():
             config = ConfigWrapper(configNode)
             config.substituteAllPredefinedConstantsWithLiterals(options)
             
-            logger.info("Importing {}".format(options.halFile))
             hal_id = toil.importFile(options.halFile)            
             chains_id_dict = toil.start(Job.wrapJobFn(hal2chains_workflow, config, options, hal_id))
 

--- a/src/cactus/maf/cactus_hal2maf.py
+++ b/src/cactus/maf/cactus_hal2maf.py
@@ -222,7 +222,6 @@ def main():
             config.substituteAllPredefinedConstantsWithLiterals(options)
 
             bed_id = toil.importFile(options.bedRanges) if options.bedRanges else None
-            logger.info("Importing {}".format(options.halFile))
             hal_id = toil.importFile(options.halFile)
             maf_id = toil.start(Job.wrapJobFn(hal2maf_workflow, hal_id, bed_id, options, config))
         

--- a/src/cactus/maf/cactus_maf2bigmaf.py
+++ b/src/cactus/maf/cactus_maf2bigmaf.py
@@ -88,11 +88,9 @@ def main():
             config = ConfigWrapper(configNode)
             config.substituteAllPredefinedConstantsWithLiterals(options)
             
-            logger.info("Importing {}".format(options.mafFile))
             maf_id = toil.importFile(options.mafFile)
             hal_id = None
             if options.halFile:
-                logger.info("Importing {}".format(options.halFile))
                 hal_id = toil.importFile(options.halFile)
                 
             bigmaf_id_dict = toil.start(Job.wrapJobFn(maf2bigmaf_workflow, config, options, maf_id, hal_id))

--- a/src/cactus/preprocessor/cactus_preprocessor.py
+++ b/src/cactus/preprocessor/cactus_preprocessor.py
@@ -401,7 +401,6 @@ def stageWorkflow(outputSequenceDir, configNode, inputSequences, toil, restart=F
     if not restart:
         inputSequenceIDs = []
         for seq in inputSequences:
-            logger.info("Importing {}".format(seq))
             inputSequenceIDs.append(toil.importFile(makeURL(seq)))
         maskFileID = toil.importFile(makeURL(maskFile)) if maskFile else None
         unzip_job = Job.wrapJobFn(unzip_then_pp, configNode, inputSequences, inputSequenceIDs, inputEventNames,

--- a/src/cactus/progressive/cactus_progressive.py
+++ b/src/cactus/progressive/cactus_progressive.py
@@ -446,7 +446,6 @@ def main():
                         catFiles([os.path.join(seq, subSeq) for subSeq in os.listdir(seq)], tmpSeq)
                         seq = tmpSeq
                     seq = makeURL(seq)
-                    logger.info("Importing {}".format(seq))
                     input_seq_id_map[genome] = toil.importFile(seq)
                 
             # Make sure we have the dna-brnn model in the filestore if we need it

--- a/src/cactus/refmap/cactus_graphmap.py
+++ b/src/cactus/refmap/cactus_graphmap.py
@@ -179,13 +179,11 @@ def graph_map(options):
                 raise RuntimeError("{} assembly not found in seqfile so it must be specified with --outputFasta".format(graph_event))
 
             #import the graph
-            logger.info("Importing {}".format(options.minigraphGFA))
             gfa_id = toil.importFile(makeURL(options.minigraphGFA))
 
             #import the reference collapse paf
             ref_collapse_paf_id = None
             if options.collapseRefPAF:
-                logger.info("Importing {}".format(options.collapseRefPAF))
                 ref_collapse_paf_id = toil.importFile(options.collapseRefPAF)
 
             #import the sequences (that we need to align for the given event, ie leaves and outgroups)
@@ -198,7 +196,6 @@ def graph_map(options):
                         catFiles([os.path.join(seq, subSeq) for subSeq in os.listdir(seq)], tmpSeq)
                         seq = tmpSeq
                     seq = makeURL(seq)
-                    logger.info("Importing {}".format(seq))
                     seq_id_map[genome] = toil.importFile(seq)
                     fa_id_map[genome] = seq
 

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -371,13 +371,11 @@ def graphmap_join(options):
             # load up the vgs
             vg_ids = []
             for vg_path in options.vg:
-                logger.info("Importing {}".format(vg_path))
                 vg_ids.append(toil.importFile(makeURL(vg_path)))
                 
             # load up the hals
             hal_ids = []
             for hal_path in options.hal:
-                logger.info("Importing {}".format(hal_path))
                 hal_ids.append(toil.importFile(makeURL(hal_path)))
 
             # run the workflow

--- a/src/cactus/refmap/cactus_graphmap_split.py
+++ b/src/cactus/refmap/cactus_graphmap_split.py
@@ -139,11 +139,9 @@ def cactus_graphmap_split(options):
             seqFile = SeqFile(options.seqFile, defaultBranchLen=config.getDefaultBranchLen(pangenome=True))
 
             #import the graph
-            logger.info("Importing {}".format(options.minigraphGFA))
             gfa_id = toil.importFile(makeURL(options.minigraphGFA))
 
             #import the paf
-            logger.info("Importing {}".format(options.graphmapPAF))
             paf_id = toil.importFile(makeURL(options.graphmapPAF))
 
             #import the sequences (that we need to align for the given event, ie leaves and outgroups)
@@ -166,7 +164,6 @@ def cactus_graphmap_split(options):
                         catFiles([os.path.join(seq, subSeq) for subSeq in os.listdir(seq)], tmpSeq)
                         seq = tmpSeq
                     seq = makeURL(seq)
-                    logger.info("Importing {}".format(seq))
                     input_seq_id_map[genome] = toil.importFile(seq)
                     input_name_map[genome] = os.path.basename(seq)
 

--- a/src/cactus/refmap/cactus_minigraph.py
+++ b/src/cactus/refmap/cactus_minigraph.py
@@ -126,7 +126,6 @@ def main():
                         catFiles([os.path.join(seq, subSeq) for subSeq in os.listdir(seq)], tmpSeq)
                         seq = tmpSeq
                     seq = makeURL(seq)
-                    logger.info("Importing {}".format(seq))
                     input_seq_id_map[genome] = toil.importFile(seq)
                 elif genome in input_seq_order:
                     input_seq_order.remove(genome)

--- a/src/cactus/refmap/cactus_pangenome.py
+++ b/src/cactus/refmap/cactus_pangenome.py
@@ -230,7 +230,6 @@ def main():
             #import the reference collapse paf
             ref_collapse_paf_id = None
             if options.collapseRefPAF:
-                logger.info("Importing {}".format(options.collapseRefPAF))
                 ref_collapse_paf_id = toil.importFile(makeURL(options.collapseRefPAF))
                 assert options.reference
                 findRequiredNode(config_node, "graphmap").attrib["collapse"] = 'reference'
@@ -238,7 +237,6 @@ def main():
             #import the .train file
             last_scores_id = None
             if options.scoresFile:
-                logger.info("Importing {}".format(options.scoresFile))
                 last_scores_id = toil.importFile(makeURL(options.scoresFile))
 
             #import the sequences
@@ -252,7 +250,6 @@ def main():
                         catFiles([os.path.join(seq, subSeq) for subSeq in os.listdir(seq)], tmpSeq)
                         seq = tmpSeq
                     seq = makeURL(seq)
-                    logger.info("Importing {}".format(seq))
                     input_seq_id_map[genome] = toil.importFile(seq)
                     input_path_map[genome] = seq
                 elif genome in input_seq_order:

--- a/src/cactus/refmap/cactus_refmap.py
+++ b/src/cactus/refmap/cactus_refmap.py
@@ -323,7 +323,6 @@ def main():
                     catFiles([os.path.join(seq, subSeq) for subSeq in os.listdir(seq)], tmpSeq)
                     seq = tmpSeq
                 seq = makeURL(seq)
-                logger.info("Importing {}".format(seq))
                 input_seq_id_map[genome] = toil.importFile(seq)
         
         ## Perform alignments:

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -346,7 +346,6 @@ def make_align_job(options, toil, config_wrapper=None, chrom_name=None):
         poaNode.attrib["partialOrderAlignmentDisableSeeding"] = "1"
 
     # import the PAF alignments
-    logger.info("Importing {}".format(options.pafFile))
     paf_id = toil.importFile(makeURL(options.pafFile))
     
     #import the sequences
@@ -358,7 +357,6 @@ def make_align_job(options, toil, config_wrapper=None, chrom_name=None):
                 catFiles([os.path.join(seq, subSeq) for subSeq in os.listdir(seq)], tmpSeq)
                 seq = tmpSeq
             seq = makeURL(seq)
-            logger.info("Importing {}".format(seq))
             input_seq_id_map[genome] = toil.importFile(seq)
 
     # make the align job that will (optional unzip) -> consolidated -> hal export -> (optional vg/gfa)


### PR DESCRIPTION
Toil was recently changed to print a message to the log for each file import (great!).  But Cactus had also been doing this for quite some time, meaning these messages have been duplicated for the past couple of cactus releases, ex:

```
[2025-07-28T09:35:44-0400] [MainThread] [I] [toil.statsAndLogging] Importing https://raw.githubusercontent.com/ComparativeGenomicsToolkit/cactusTestData/master/evolver/mammals/loci1/simCow.chr6
[2025-07-28T09:35:45-0400] [MainThread] [I] [toil.jobStores.abstractJobStore] Importing input https://raw.githubusercontent.com/ComparativeGenomicsToolkit/cactusTestData/master/evolver/mammals/loci1/simCow.chr6...
```

This PR removes all the Cactus logs, so it should just print the Toil ones from now on..