### PR TITLE
fix naming bug in .sv.gfa.gz output

### DIFF
--- a/src/cactus/refmap/cactus_minigraph.py
+++ b/src/cactus/refmap/cactus_minigraph.py
@@ -459,8 +459,12 @@ def minigraph_gfa_to_pansn(names, gfa_path, out_gfa_path):
                     name = tok[8:barpos]
                     assert name in names
                     dotpos = name.rfind('.')
-                    # add #0 to names without haplotype to make valid PAN-SN
-                    hap = '0' if dotpos < 0 else name[dotpos+1:]
+                    if dotpos > 0:
+                        hap = name[dotpos+1:]
+                        name = name[:dotpos]
+                    else:
+                        # add #0 to names without haplotype to make valid PAN-SN
+                        hap = '0'
                     toks[4+i] = 'SN:Z:{}#{}#{}'.format(name, hap, tok[barpos+1:])
                     break
             out_file.write(('\t'.join(toks) + '\n').encode())


### PR DESCRIPTION
There was a name munging bug in the minigraph output (.sv.gfa.gz) produced by mc:  non-reference input genomes with haplotypes (ex `human.1`) in the seqfile, would end up as `human.1#1` in the output.   This PR fixes this.  (note only the .sv.gfa.gz output was affected by this)