### PR TITLE
Update prepare replace name

### DIFF
--- a/doc/cactus-update-prepare.md
+++ b/doc/cactus-update-prepare.md
@@ -144,11 +144,13 @@ cactus-update-prepare replace ./evolverMammals.hal ./input.txt --genome simHuman
 where 
 - `replace` indicates the action of replacing a genome to the given alignment
 - `evolverMammals.hal` is the HAL-format file containing the current `evolverMammals` alignment
-- `input.txt` is the text tab-spaced file providing the genome to be replaced
+- `input.txt` is the text tab-spaced file providing the genome to be replaced, as above
 - `simHuman_chr6` is the target genome being replaced
 - `--outDir` and `--jobStore` are options inherited from [`cactus-prepare`](https://github.com/ComparativeGenomicsToolkit/cactus/blob/master/src/cactus/progressive/cactus_prepare.py)
     - `steps` is the name of the directory where assemblies and all cactus-call dependencies will be placed
     - `jobstore` is the name of the directory used by [Toil](https://toil.readthedocs.io/en/latest/) (Cactus internal scheduler) to store temporary data of job executions
+
+> **Note:** If a branch length is present in the third column of your input file (*e.g.* `input.txt`) it will be ignored in *replace* mode. The existing branch length leading to the genome you are replacing will be used instead.
 
 The output of `cactus-prepare-update` above will looks like as follows:
 


### PR DESCRIPTION
This PR has edits to `cactus_update_prepare.py` that allow the new genome to have a new name in **replace** mode. See #1727 for background.

In this version, the genome to replace is parsed from the command line option `--genome` and the new name is retrieved from the first column of the input file (_e.g._ `./input.txt` from the example in the [docs](https://github.com/ComparativeGenomicsToolkit/cactus/blob/master/doc/cactus-update-prepare.md)).

## Setup:
1. Built from source following instructions [here](https://github.com/ComparativeGenomicsToolkit/cactus/tree/3ac246f5afcdb1778079d2c4a2952a2f0c4662b6?tab=readme-ov-file#compiling-binaries-locally)
2. Ran from virtual env following instructions [here](https://github.com/ComparativeGenomicsToolkit/cactus/blob/3ac246f5afcdb1778079d2c4a2952a2f0c4662b6/BIN-INSTALL.md), but using `python3 -m pip install -e .` *after* `python3 -m pip install -U` so I could edit in place.

## Tests

I tested using the evolverMammals dataset. Here is a truncated log file showing the `halValidate` and `halStats` output of each step:

```

--- 1. Generate the hal file ---

--- 2. Copy and replace using the original script ---
File valid

hal v2.2
(((simMouse_chr6:0.084509,simRat_chr6:0.091589)mr:0.271974,simHuman_chr6:0.144018)Anc1:0.020593,(simCow_chr6:0.18908,simDog_chr6:0.16303)Anc2:0.032898)Anc0;

GenomeName, NumChildren, Length, NumSequences, NumTopSegments, NumBottomSegments
Anc0, 2, 524119, 1, 0, 13701
Anc1, 2, 557731, 1, 16090, 43051
mr, 2, 599412, 1, 41273, 45760
simMouse_chr6, 0, 636262, 1, 46751, 0
simRat_chr6, 0, 647215, 1, 46113, 0
simHuman_chr6, 0, 599081, 1, 46700, 0
Anc2, 2, 568332, 1, 16565, 51894
simCow_chr6, 0, 602619, 1, 50529, 0
simDog_chr6, 0, 593897, 1, 50997, 0

--- 3. Copy and replace using the new script ---
File valid

hal v2.2
(((simMouse_chr6:0.084509,simRat_chr6:0.091589)mr:0.271974,simGorilla_chr6:0.144018)Anc1:0.020593,(simCow_chr6:0.18908,simDog_chr6:0.16303)Anc2:0.032898)Anc0;

GenomeName, NumChildren, Length, NumSequences, NumTopSegments, NumBottomSegments
Anc0, 2, 524119, 1, 0, 13701
Anc1, 2, 557731, 1, 16090, 43086
mr, 2, 599412, 1, 41283, 45760
simMouse_chr6, 0, 636262, 1, 46751, 0
simRat_chr6, 0, 647215, 1, 46113, 0
simGorilla_chr6, 0, 599081, 1, 46720, 0
Anc2, 2, 568332, 1, 16565, 51894
simCow_chr6, 0, 602619, 1, 50529, 0
simDog_chr6, 0, 593897, 1, 50997, 0

--- 4. Copy and add by branch using the original script ---
File valid

File valid

File valid

File valid

hal v2.2
(((simMouse_chr6:0.084509,simRat_chr6:0.091589)mr:0.271974,(simHuman_chr6:0.044018,simGorilla_chr6:0.075)AncGorilla:0.1)Anc1:0.020593,(simCow_chr6:0.18908,simDog_chr6:0.16303)Anc2:0.032898)Anc0;

GenomeName, NumChildren, Length, NumSequences, NumTopSegments, NumBottomSegments
Anc0, 2, 524119, 1, 0, 13701
Anc1, 2, 557731, 1, 16090, 38853
mr, 2, 599412, 1, 37198, 45760
simMouse_chr6, 0, 636262, 1, 46751, 0
simRat_chr6, 0, 647215, 1, 46113, 0
AncGorilla, 2, 573127, 1, 40693, 47098
simHuman_chr6, 0, 601863, 1, 45562, 0
simGorilla_chr6, 0, 599081, 1, 48694, 0
Anc2, 2, 568332, 1, 16565, 51894
simCow_chr6, 0, 602619, 1, 50529, 0
simDog_chr6, 0, 593897, 1, 50997, 0

--- 5. Copy and add by branch using the new script ---
File valid

File valid

File valid

File valid

hal v2.2
(((simMouse_chr6:0.084509,simRat_chr6:0.091589)mr:0.271974,(simHuman_chr6:0.044018,simGorilla_chr6:0.075)AncGorilla:0.1)Anc1:0.020593,(simCow_chr6:0.18908,simDog_chr6:0.16303)Anc2:0.032898)Anc0;

GenomeName, NumChildren, Length, NumSequences, NumTopSegments, NumBottomSegments
Anc0, 2, 524119, 1, 0, 13701
Anc1, 2, 557731, 1, 16090, 38875
mr, 2, 599412, 1, 37222, 45760
simMouse_chr6, 0, 636262, 1, 46751, 0
simRat_chr6, 0, 647215, 1, 46113, 0
AncGorilla, 2, 573029, 1, 40703, 47129
simHuman_chr6, 0, 601863, 1, 45576, 0
simGorilla_chr6, 0, 599081, 1, 48741, 0
Anc2, 2, 568332, 1, 16565, 51894
simCow_chr6, 0, 602619, 1, 50529, 0
simDog_chr6, 0, 593897, 1, 50997, 0
``` 

I didn't test the adding to node method because of the error it throws regarding non-bifurcating trees.

As far as I can tell, the trees and outputs look essentially identical, except for slight changes in some of the `halStats` to the re-aligned sequences, which I think is normal, and the name change in step 3, which is what we wanted. But please let me know if anything looks off, and please feel free to perform your own tests.

## Notes

* Any branch length in the input file is not used when in replace mode (see function `cactus_alignment_update()`), which makes sense, but I didn't see it mentioned in the docs so I added a note about it.
* The docs should be updated again if/when this PR is included in a release to reflect the new naming options (genome to replace from command line argument, name of new genome from input file).