### PR TITLE
add --delEdgeFilter option to do edge clipping with vg clip

### DIFF
--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -432,6 +432,7 @@
 	<!-- clipNonMinigraph: clip out regions if the don't align to minigraph (if disabled, clip if they don't align to anything) -->
 	<!-- minimizerOptions: options for vg minimizer -->
 	<!-- minFilterFragment: discard fragments that result from the vg clip frequency filter if they are smaller than this -->
+	<!-- clipContext: use this many context steps when doing edge clipping (activated via delEdgeFilter cli option) -->	
 	<!-- removeStubs: remove any nodes dangling off reference paths (ie softclips) -->
 	<!-- odgiVizOptions: options to odgi viz, used for 1d viz -->
 	<!-- odgiLayoutOptions: options to odgi layout, used for 2d viz -->
@@ -450,6 +451,7 @@
 		 clipNonMinigraph="1"		 
 		 minimizerOptions="-k 29 -w 11"
 		 minFilterFragment="1000"
+		 clipContext="1000"
 		 removeStubs="1"
 		 odgiVizOptions="-x 1500 -y 500 -a 10"
 		 odgiLayoutOptions="-x 50"


### PR DESCRIPTION
Some errors found using recent HPRC graphs for variant calling benchmarks seem to be due to large snarls.  In particular how the haplotpe sampling logic we use doesn't necessarily work well with them (in addition to issues that may arise when mapping or surjecting in big snarls in the first place).  

After looking at a variety of filters, the one that worked best was `vg clip -D 1000000 -m 1000 -c 1000` that tries to greedily remove edges that span more than 1MB along the reference genome.  

This PR adds an option to bake this process into the clipping phase.  Turn it on with `--delEdgeFilter 1000000` in `cactus-pangenome` or `cactus-graphmap-join`.  