### PR TITLE
Making changes to be more picky about when to allow breaks in ancestr…

### DIFF
--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -305,6 +305,10 @@
 	<!-- numberOfNs is the number of Ns to insert into an ancestral sequence when an adjacency is uncertain, think of its as the Ns in a scaffold gap -->
 	<!-- minNumberOfSequencesToSupportAdjacency is the number of sequences needed to bridge an adjacency [THIS SET TO 0, SO NO ADJACENCIES WILL BE BROKEN] -->
 	<!-- makeScaffolds is a boolean that enables the bridging of uncertain adjacencies in an ancestral sequence providing the larger scale problem (parent flower in cactus), bridges the path. -->
+	<!-- minimumNestedBasesToBreakAdjacency The minimum number of bases a flower must contain for its
+	     adjacencies to be considered for breaking. -->
+	<!-- maximumChainBasesToBreakAdjacency The maximum length, in terms of bases, of a parent chain for an
+	     adjacency in a nested flower (snarl) to be considered for breaking. -->
 	<!-- phi is the coefficient used to control how much weight to place on an adjacency given its phylogenetic distance from the reference node -->
 	<reference
 		matchingAlgorithm="blossom5"
@@ -317,7 +321,9 @@
 		ignoreUnalignedGaps="1"
 		wiggle="0.9999"
 		numberOfNs="10"
-		minNumberOfSequencesToSupportAdjacency="0"
+		minNumberOfSequencesToSupportAdjacency="1"
+		minimumNestedBasesToBreakAdjacency="1500"
+		maximumChainBasesToBreakAdjacency="3000000"
 		makeScaffolds="1"
 	>
 	</reference>


### PR DESCRIPTION
…al assemblies.

Uses nesting within a chain and size of the snarl to determine if an adjacency can be broken. On the 10-way MHC example produced by @glennhickey cuts ancestral adjacency breaks from 1467 to 980, vs 543 if no breaks are allowed.