### PR TITLE
rejig cactus-hal2maf output interface

### DIFF
--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -786,7 +786,7 @@ class TestCase(unittest.TestCase):
 
         # run mafComparator on the evolver output
         subprocess.check_call(['cactus-hal2maf', self._job_store('h2m'), halPath,  halPath + '.maf', '--chunkSize', '10000', '--batchCount', '2',
-                               '--refGenome', 'Anc0', '--index', '--binariesMode', binariesMode], shell=False)
+                               '--refGenome', 'Anc0', '--outType', 'norm', 'single', '--index', '--binariesMode', binariesMode], shell=False)
         self.assertGreaterEqual(os.path.getsize(halPath + '.maf.tai'), 50)        
 
         # run it with --dupeMode consensus just to make sure it doesn't crash
@@ -799,7 +799,7 @@ class TestCase(unittest.TestCase):
             pass
         if have_maf_stream:
             subprocess.check_call(['cactus-hal2maf', self._job_store('h2m'), halPath,  halPath + '.consensus.maf.gz', '--chunkSize', '10000', '--batchCount', '2',
-                                   '--refGenome', 'Anc0', '--dupeMode', 'consensus', '--binariesMode', binariesMode], shell=False)
+                                   '--refGenome', 'Anc0', '--outType', 'consensus', '--binariesMode', binariesMode], shell=False)
 
         # run it with --coverage just to make sure it doesn't crash
         subprocess.check_call(['cactus-hal2maf', self._job_store('h2m'), halPath,  halPath + '.taftest.taf.gz', '--chunkSize', '10000', '--batchCount', '2',
@@ -871,7 +871,7 @@ class TestCase(unittest.TestCase):
                 for seq, start, end in ranges:
                     bed_file.write('{}\t{}\t{}\n'.format(seq, start, end))
             subprocess.check_call(['cactus-hal2maf', self._job_store('h2m'), halPath, ranges_bed_file, '--refGenome', 'simHuman_chr6',
-                                   '--chunkSize', '699', '--bedRanges', ranges_bed_input, '--raw', '--binariesMode', binariesMode], shell=False)
+                                   '--chunkSize', '699', '--bedRanges', ranges_bed_input, '--outType', 'raw', '--binariesMode', binariesMode], shell=False)
 
             subprocess.check_call(['bin/mafComparator', '--maf1', ranges_bed_file, '--maf2', ranges_truth_file, '--samples', '100000000', '--out', halPath + 'comp_bed.xml'])
             bed_acc = parse_mafcomp_output(halPath + 'comp_bed.xml', ranges_truth_file)


### PR DESCRIPTION
I often find myself releasing two MAFs alongside Cactus alignments:
1. MAF file with paralogies (multiple rows from the same sample), normalized with `taffy`
2. Single-copy MAF, created from above with `mafDuplicateFilter -k`. 

This process is annoying, especially for huge files, since it involves either two calls to `cactus-hal2maf` (once with `--dupeMode single` and once without.  Or, more efficiently, creating thing first with `cactus-hal2maf`, then the second with `mafDuplicateFilter` directly.  

The goal of this PR is two modify `cactus-hal2maf` to be able to produce both of these outputs in the same run.  To do this I ended up generalizing the `--dupeMode` option into `--outType`, with the latter being able to accept multupe values.  

Old: 
`--raw`
`--dupeMode {single ancestral consensus all}`

New:
`--onlyOrthologs`
`--outType {raw norm single consensus}`

The rationale for the name change is that the `raw/norm` toggle doesn't have anything to do with duplications. 

The rationale for replacing `--dupeMode ancestral` with `--onlyOrthologs` is that this option happens at `hal2maf` and not in the postprocessing.  So there is no way to toggle it without rerunning `hal2maf` multiple times, which the tool doesn't do (it only reruns postporcessing multiple times). 

Hopefully the documentation update makes this all somewhat clear, but probably best not to merge this until a new release is around the corner....  