### PR TITLE
fix outgroup parameter; change default to greedy leaves/preference

### DIFF
--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -484,13 +484,13 @@
 		 hal2vgOptions="--progress --inMemory"
 		 />
   	<multi_cactus>
-	        <!-- stategy: outgroup selection algorithm, can be one of greedy, greedyLeaves or greedyPreference -->
+	        <!-- stategy: outgroup selection algorithm, can be one of greedy, greedyPreference, greedyLeaves or greedyLeavesPreference -->
 		<!-- threshold: depth increases by at most k per outgroup -->
 		<!-- ancestor_quality_fraction: min fraction of children of ancestor in candidateSet in order for the ancestor to be an outgroup candidate -->
 		<!-- max_num_outgroups: maximum number of outgroups per alignment job-->
 		<!-- extra_chrom_outgroups: if max_num_outgroups is not sufficent to satisfy sex chromosome requirements of an ancestor while still using nearest species, allow up to this many extra (when -1 set to the number of unique sex chromosomes for the ancestor).  -->
 		<outgroup
-			strategy="greedyPreference"
+			strategy="greedyLeavesPreference"
 			threshold="0"
 			ancestor_quality_fraction="0.75"
 			max_num_outgroups="2"

--- a/src/cactus/shared/configWrapper.py
+++ b/src/cactus/shared/configWrapper.py
@@ -63,7 +63,7 @@ class ConfigWrapper:
             strategy = ogElem.attrib["strategy"]
         assert strategy == "none" or strategy == "greedy" or \
             strategy == "greedyLeaves" or strategy == "greedyPreference" or \
-            strategy == "dynamic"
+            strategy == "dynamic" or strategy == "greedyLeavesPreference"
         return strategy
 
     def getOutgroupThreshold(self):


### PR DESCRIPTION
This PR fixes the "greedyLeaevs" toggle in the config, which wasn't working.   It also adds the "greedyLeavesPreference" option which does the `greedyLeaves`, but will prioritieze starred lines in the seqfile.  And, finally, it makes this the new default.  Even though the leaf outgroups will tend to be further away from the event, we still expect them to perform better than ancestors. 