### PR TITLE
make sure --disableProgress happens in prepare scripts

### DIFF
--- a/src/cactus/progressive/cactus_prepare.py
+++ b/src/cactus/progressive/cactus_prepare.py
@@ -178,6 +178,10 @@ def main(toil_mode=False):
     if options.wdl and options.script:
         raise RuntimeError("--wdl cannot be used with --script")
 
+    if options.script:
+        if '--disableProgress' not in options.cactusOptions:
+            options.cactusOptions += ' --disableProgress'
+
     if options.wdl and options.gpu == 'all':
         raise RuntimeError("Number of gpus N must be specified with --gpu N when using --wdl")
 


### PR DESCRIPTION
Learned this the hard way:  If you make a big cactus-prepare bash script and use it to launch a bunch of cactus commands at once, they can do a number on your terminal if they're all fighting to put up a progress bar.  This PR adds the `--skipProgress` Toil flag to disable it by default. 