### PR TITLE
make sure HOME set somewhere writable in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,3 +98,6 @@ ENV CACTUS_INSIDE_CONTAINER 1
 RUN mkdir -p /data
 WORKDIR /data
 
+# Toil needs a writable HOME dir (which it may not have with docker run -u)
+RUN mkdir -p /home/cactus_user && chmod 777 /home/cactus_user
+ENV HOME="/home/cactus_user"

--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -183,7 +183,9 @@ class TestCase(unittest.TestCase):
 
         out_hal = self._out_hal('in_docker')
         cmd = ['docker', 'run', '--rm', '-v', '{}:{}'.format(os.path.dirname(out_hal), '/data'),
-               '-v', '{}:{}'.format(os.getcwd(), '/workdir'), 'evolvertestdocker/cactus:latest',
+               '-v', '{}:{}'.format(os.getcwd(), '/workdir'), 
+               '-u', '{}:{}'.format(os.getuid(), os.getgid()),
+               'evolvertestdocker/cactus:latest',
                'cactus /data/js /workdir/{} /data/{}'.format(seqFile, os.path.basename(out_hal))]
         sys.stderr.write('Running {}\n'.format(' '.format(cmd)))
         subprocess.check_call(' '.join(cmd), shell=True)


### PR DESCRIPTION
Running cactus via `docker run --user $(id -u):$(id -g)` as suggested in the Cactus README doesn't work.  This is because the given user almost certainly doesn't exist in the image, and the `HOME` environment variable is unset.   And Toil usees `HOME` to write a `${HOME}/.toil` directory.  So this ends up as `/.toil` which leads to a permission error. 

```
RuntimeError: Cannot create or access Toil configuration directory /.toil
```

This PR makes sure `HOME` is somewhere writable...

Resolves #1802