### PR TITLE
cactus_update_prepare fix and docs

### DIFF
--- a/doc/cactus-update-prepare.md
+++ b/doc/cactus-update-prepare.md
@@ -150,6 +150,8 @@ where
     - `steps` is the name of the directory where assemblies and all cactus-call dependencies will be placed
     - `jobstore` is the name of the directory used by [Toil](https://toil.readthedocs.io/en/latest/) (Cactus internal scheduler) to store temporary data of job executions
 
+**The name of the genome in the new alignment will match the label in the first column of your input file.**
+
 > **Note:** If a branch length is present in the third column of your input file (*e.g.* `input.txt`) it will be ignored in *replace* mode. The existing branch length leading to the genome you are replacing will be used instead.
 
 The output of `cactus-prepare-update` above will looks like as follows:

--- a/src/cactus/update/cactus_update_prepare.py
+++ b/src/cactus/update/cactus_update_prepare.py
@@ -397,11 +397,11 @@ def make_plan(
 
     # removing "## HAL merging" as there is no merging while performing alignment updates
     plan = re.sub("\n## HAL merging\n", "", plan, re.IGNORECASE | re.MULTILINE)
-    plan = re.sub("halAppendSubtree .*?\n", "", plan, re.IGNORECASE | re.MULTILINE)
+    plan = re.sub("cactus-halAppendSubtree .*?\n", "", plan, re.IGNORECASE | re.MULTILINE)
 
     # remove the last hal2fasta as it will
     hal2fasta_job = re.findall(
-        r"hal2fasta .*?(?=\s{0,})\n", plan, re.IGNORECASE | re.MULTILINE
+        r"cactus-hal2fasta .*?(?=\s{0,})\n", plan, re.IGNORECASE | re.MULTILINE
     )[-1]
     plan = re.sub(hal2fasta_job, "", plan, re.IGNORECASE | re.MULTILINE)
 


### PR DESCRIPTION
This PR contains a fix in cactus_update_prepare likely caused by slight changes in the names of the tools. Because of the name changes, the string "cactus-" was left when modifying the plan. For example:

```bash
cactus-update-prepare add branch --parentGenome Anc1 --childGenome simHuman_chr6 evolverMammals-add-original.hal evolverMammals-replace-gwct.txt --jobStore jobstore --outDir add-original --ancestorName AncGorilla --topBranchLength 0.10
## generated by : /home/gregg/bin/cactus/venv-cactus/bin/cactus-update-prepare add branch --parentGenome Anc1 --childGenome simHuman_chr6 evolverMammals-add-original.hal evolverMammals-replace-gwct.txt --jobStore jobstore --outDir add-original --ancestorName AncGorilla --topBranchLength 0.10
## date : 2025-10-28 10:59:36.590124
## cactus commit : 80ab744745c83587f71046c2828842b93ec07739
## wrapping : /home/gregg/bin/cactus/venv-cactus/bin/cactus-prepare add-original/seq_file.in --outDir add-original --outSeqFile add-original/seq_file.out --jobStore jobstore --preprocessBatchSize 1 --outHal add-original/Anc1.hal


## Preprocessor
$ cactus-preprocess jobstore/2 add-original/seq_file.in add-original/seq_file.out --inputNames simGorilla_chr6 --logFile add-original/logs/preprocess-simGorilla_chr6.log

## Alignment
### Round 0
cactus-blast jobstore/3 add-original/seq_file.out add-original/AncGorilla.paf --root AncGorilla   --logFile add-original/logs/blast-AncGorilla.log
cactus-align jobstore/4 add-original/seq_file.out add-original/AncGorilla.paf add-original/AncGorilla.hal --root AncGorilla   --logFile add-original/logs/align-AncGorilla.log
cactus-hal2fasta jobstore/5 add-original/AncGorilla.hal AncGorilla add-original/AncGorilla.fa.gz   --logFile add-original/logs/hal2fasta-AncGorilla.log

### Round 1
cactus-blast jobstore/6 add-original/seq_file.out add-original/Anc1.paf --root Anc1   --logFile add-original/logs/blast-Anc1.log --includeRoot
cactus-align jobstore/7 add-original/seq_file.out add-original/Anc1.paf add-original/Anc1.hal --root Anc1   --logFile add-original/logs/align-Anc1.log --includeRoot
cactus-cactus-halAppendSubtrees jobstore/9 add-original/Anc1.hal add-original/AncGorilla.hal add-original/Anc1.hal   --logFile add-original/logs/halAppend-AncGorilla.log

## Alignment update
halAddToBranch evolverMammals-add-original.hal add-original/AncGorilla.hal add-original/Anc1.hal Anc1 AncGorilla simHuman_chr6 simGorilla_chr6 0.1 0.075 --hdf5InMemory

## Alignment validation
halValidate --genome Anc1 evolverMammals-add-original.hal --hdf5InMemory
halValidate --genome AncGorilla evolverMammals-add-original.hal --hdf5InMemory
halValidate --genome simHuman_chr6 evolverMammals-add-original.hal --hdf5InMemory
halValidate --genome simGorilla_chr6 evolverMammals-add-original.hal --hdf5InMemory
```

Note "cactus-cactus-halAppendSubtrees". And another example:

```bash
$ cactus-update-prepare replace evolverMammals-replace-original.hal evolverMammals-replace-gwct.txt --genome simHuman_chr6 --outDir replace-original --jobStore jobstore
## generated by : /home/gregg/bin/cactus/venv-cactus/bin/cactus-update-prepare replace evolverMammals-replace-original.hal evolverMammals-replace-gwct.txt --genome simHuman_chr6 --outDir replace-original --jobStore jobstore
## date : 2025-10-28 11:00:36.915192
## cactus commit : 80ab744745c83587f71046c2828842b93ec07739
## wrapping : /home/gregg/bin/cactus/venv-cactus/bin/cactus-prepare replace-original/seq_file.in --outDir replace-original --outSeqFile replace-original/seq_file.out --jobStore jobstore --preprocessBatchSize 1 --outHal replace-original/Anc1.hal


## Preprocessor
cactus-preprocess jobstore/0 replace-original/seq_file.in replace-original/seq_file.out --inputNames simGorilla_chr6 --logFile replace-original/logs/preprocess-simGorilla_chr6.log

## Alignment
### Round 0
cactus-blast jobstore/2 replace-original/seq_file.out replace-original/Anc1.paf --root Anc1   --logFile replace-original/logs/blast-Anc1.log --includeRoot
cactus-align jobstore/3 replace-original/seq_file.out replace-original/Anc1.paf replace-original/Anc1.hal --root Anc1   --logFile replace-original/logs/align-Anc1.log --includeRoot
cactus-
## Alignment update
halRemoveGenome evolverMammals-replace-original.hal simHuman_chr6
halReplaceGenome --bottomAlignmentFile replace-original/Anc1.hal --topAlignmentFile evolverMammals-replace-original.hal evolverMammals-replace-original.hal Anc1 --hdf5InMemory

## Alignment validation
halValidate --genome Anc1 evolverMammals-replace-original.hal --hdf5InMemory
```

Here note the leftover "cactus-" string on the last line of Round 0.

The changes in this PR address this by adding the "cactus-" string to the pattern searched when these lines are modified.

This also contains a minor change to the update prepare documentation noting that the name of the new genome is taken from the input file when replacing a genome in a HAL file.