### PR TITLE
Update BCFtools to use stable sort

### DIFF
--- a/build-tools/downloadMafTools
+++ b/build-tools/downloadMafTools
@@ -34,21 +34,6 @@ fi
 
 # taffy
 cd ${mafBuildDir}
-wget -q https://github.com/samtools/samtools/releases/download/1.11/samtools-1.11.tar.bz2
-tar --no-same-owner -xf samtools-1.11.tar.bz2
-cd samtools-1.11
-SAMTOOLS_CONFIG_OPTS=""
-if [[ $STATIC_CHECK -eq 1 ]]
-then
-	 SAMTOOLS_CONFIG_OPTS="--disable-shared --enable-static"
-fi
-./configure --without-curses --disable-libcurl --enable-configure-htslib $SAMTOOLS_CONFIG_OPTS
-make -j ${numcpu}
-cd htslib-1.11
-make -j ${numcpu} libhts.a
-export HTSLIB_CFLAGS=-I$(pwd)
-export HTSLIB_LIBS="$(pwd)/libhts.a -lbz2 -ldeflate -lm -lpthread -lz -llzma -pthread -lpthread"
-cd ${mafBuildDir}
 git clone https://github.com/ComparativeGenomicsToolkit/taffy.git
 cd taffy
 git checkout 1329d999948ad4acc10116276fa7a9752a749595

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -89,9 +89,9 @@ fi
 
 #samtools
 cd ${pangenomeBuildDir}
-wget -q https://github.com/samtools/samtools/releases/download/1.11/samtools-1.11.tar.bz2
-tar --no-same-owner -xf samtools-1.11.tar.bz2
-cd samtools-1.11
+wget -q https://github.com/samtools/samtools/releases/download/1.22.1/samtools-1.22.1.tar.bz2
+tar --no-same-owner -xf samtools-1.22.1.tar.bz2
+cd samtools-1.22.1
 SAMTOOLS_CONFIG_OPTS=""
 if [[ $STATIC_CHECK -eq 1 ]]
 then
@@ -105,7 +105,7 @@ then
 else
 	 exit 1
 fi
-cd htslib-1.11
+cd htslib-1.22.1
 make -j ${numcpu} tabix
 make -j ${numcpu} bgzip
 if [[ $STATIC_CHECK -ne 1 || $(ldd tabix | grep so | wc -l) -eq 0 ]]
@@ -123,9 +123,9 @@ fi
 
 #bcftools
 cd ${pangenomeBuildDir}
-wget -q https://github.com/samtools/bcftools/releases/download/1.19/bcftools-1.19.tar.bz2
-tar --no-same-owner -xf bcftools-1.19.tar.bz2
-cd bcftools-1.19
+wget -q https://github.com/samtools/bcftools/releases/download/1.22/bcftools-1.22.tar.bz2
+tar --no-same-owner -xf bcftools-1.22.tar.bz2
+cd bcftools-1.22
 SAMTOOLS_CONFIG_OPTS=""
 if [[ $STATIC_CHECK -eq 1 ]]
 then

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -1219,7 +1219,7 @@ def vcfnorm(job, config, vcf_ref, vcf_id, vcf_path, tbi_id, fasta_ref_dict):
     cactus_call(parameters=[['bcftools', 'norm', '-m', '-any', vcf_path],
                             ['bcftools', 'norm', '-f', fa_ref_path],
                             view_cmd,
-                            ['bcftools', 'sort', '-Oz', '-T', work_dir], outfile=norm_path)
+                            ['bcftools', 'sort', '-Oz', '-T', work_dir]], outfile=norm_path)
     merge_duplicates_opts = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_join"), "mergeDuplicatesOptions", typeFn=str, default=None)
     if merge_duplicates_opts not in [None, "0"]:
         #note: merge_duplcates complains about not having a .tbi but I don't think it actually affects anything


### PR DESCRIPTION
Was looking around at some `bcftools sort` code because of the CI fail in #1809, and noticed that in bcftools v1.21 the sort function was made stable (although it doesn't appear in the release notes, see https://github.com/samtools/bcftools/pull/2252). I tested this builds in docker and am currently running it on a previous graph to see if it works, as making sure the `cactus_call` is right is a bit finickity.

As a separate note, the samtools/htslib in downloadMafTools didn't appear to do anything (although it exports HTSLIB variable), so I removed that and nothing broke (hopefully docker didn't cache anything that would stop this breaking). This seems to save a reasonable amount of build time as htslib is big.