### PR TITLE
boost pairwise divergences involving ancestors by their height

### DIFF
--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -76,6 +76,7 @@
 	     other ingroups without outgroups, then get the outgroups to pick their primary alignment to the ingroups. If 0
 	     get every sequence to pick its primary alignment without regard to if the other sequence is an ingroup or outgroup -->
 	<!-- slurmChunkScale Multiply chunkSize and divide dechunkBatchSize by this value when running slurm in order to decrease job count -->
+	<!-- upweightAncestorDistances Add the ancestor's height in the tree to any pairwise distance computed with it -->
 	<blast chunkSize="30000000"
 	       bigChunkSize="6000000000"
 		   overlapSize="10000"
@@ -107,6 +108,7 @@
 		   dechunkBatchSize="1000"
 		   pickIngroupPrimaryAlignmentsSeparatelyToOutgroups="1"
 		   slurmChunkScale="3"
+		   upweightAncestorDistances="1"
 		   >
 
 		<!-- The following are parametrised to produce the same results as the default settings,

--- a/src/cactus/paf/local_alignment.py
+++ b/src/cactus/paf/local_alignment.py
@@ -719,13 +719,16 @@ def tile_alignments(job, alignment_files, reference_event_name, params, has_reso
     return job.fileStore.writeGlobalFile(output_alignments_file)  # Copy back
         
 
-def sanitize_then_make_paf_alignments(job, event_tree_string, event_names_to_sequences, ancestor_event_string, params):
+def sanitize_then_make_paf_alignments(job, event_tree_string, event_names_to_sequences, ancestor_event_string, params,
+                                      height_map=None):
     sanitize_job = job.addChildJobFn(sanitize_fasta_headers, event_names_to_sequences)
-    paf_job = sanitize_job.addFollowOnJobFn(make_paf_alignments, event_tree_string, sanitize_job.rv(), ancestor_event_string, params)
+    paf_job = sanitize_job.addFollowOnJobFn(make_paf_alignments, event_tree_string, sanitize_job.rv(),
+                                            ancestor_event_string, params, height_map)
     return paf_job.rv()
 
 
-def make_paf_alignments(job, event_tree_string, event_names_to_sequences, ancestor_event_string, params):
+def make_paf_alignments(job, event_tree_string, event_names_to_sequences, ancestor_event_string, params,
+                        height_map=None):
     # a job should never set its own follow-on, so we hang everything off the root_job here to encapsulate
     root_job = Job()
     job.addChild(root_job)
@@ -765,8 +768,14 @@ def make_paf_alignments(job, event_tree_string, event_names_to_sequences, ancest
                                                          disk=2*total_sequence_size).rv())
         ingroup_alignment_names.append('{}-{}_vs_{}'.format(ancestor_event_string, ingroup.iD, ingroup2.iD))
 
-    # Get the outgroup events
     distances = get_distances(event_tree)  # Distances between all pairs of nodes
+
+    if height_map:
+        # upweight ancestors by their heights
+        for distance in distances:
+            distances[distance] += height_map[distance[0].iD] + height_map[distance[1].iD]
+                                                                       
+    # Get the outgroup events
     outgroup_events.sort(key=lambda outgroup: distances[ancestor_event, outgroup])  # Sort from closest to furthest
     logger.info("Got outgroup events: {} for ancestor event: {}".format(" ".join([i.iD for i in outgroup_events]),
                                                                         ancestor_event.iD))

--- a/src/cactus/progressive/cactus_progressive.py
+++ b/src/cactus/progressive/cactus_progressive.py
@@ -38,7 +38,7 @@ from cactus.shared.common import write_s3
 from cactus.shared.common import cactus_clamp_memory
 from cactus.shared.common import clean_jobstore_files
 from cactus.pipeline.cactus_workflow import cactus_cons_with_resources
-from cactus.progressive.progressive_decomposition import compute_outgroups, parse_seqfile, get_subtree, get_spanning_subtree, get_event_set
+from cactus.progressive.progressive_decomposition import compute_outgroups, parse_seqfile, get_subtree, get_spanning_subtree, get_event_set, get_node_heights
 from cactus.preprocessor.cactus_preprocessor import CactusPreprocessor
 from cactus.preprocessor.dnabrnnMasking import loadDnaBrnnModel
 from cactus.preprocessor.checkUniqueHeaders import sanitize_fasta_headers
@@ -172,9 +172,14 @@ def progressive_step(job, options, config_node, seq_id_map, tree, og_map, event)
     # get the spanning tree (which is what consolidated wants)
     spanning_tree = get_spanning_subtree(tree, event, ConfigWrapper(config_node), og_map)
 
+    height_map = None
+    if getOptionalAttrib(config_node.find('blast'), 'upweightAncestorDistances', typeFn=bool, default=False):
+        # get the heights of each node, to add ancestor divergences
+        height_map = get_node_heights(tree, spanning_tree.getRootName())
+    
     # do the blast
     paf_job = job.addChildJobFn(make_paf_alignments, NXNewick().writeString(spanning_tree),
-                                subtree_eventmap, event, config_node).encapsulate()
+                                subtree_eventmap, event, config_node, height_map=height_map).encapsulate()
 
     outgroups = og_map[event] if event in og_map else []
     # trim the outgroups


### PR DESCRIPTION
Let's say I have two ancestors that are very close in the tree.  But each has a couple really long branches below them.  As it stands, the ancestors will be aligned with the least sensitive parameters, but it's not a stretch to imagine that, due to uncertainty in the tree and/or alignments, the ancestors may not be that close after all.   

This PR adds an option in the config (and set on by default) to help boost sensitivity deep in the tree by adding the Ancestor's height in the tree to any distance between it and other nodes that are computed for the purposes of lastz parameters.  This means that for deep trees, ancestors will get sensitive parameters no matter how close they are to each other. 