### PR TITLE
fix up --remask option

### DIFF
--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -134,12 +134,14 @@
 		<!-- Logic to try to rescue contigs in ingroups that would otherwise be ignored due to masking -->
 		<!-- threshold: unamask if less than this fraction of the contig is not masked -->
 		<!-- threshold_bp: unmask if fewer than this many bp of the contig are not masked -->
+		<!-- min_length: only apply to contigs at least this big (should be consistent with red prefilter) -->
 		<!-- action to apply if *either* of the above thresholds are met. Can be "none" to do nothing,
 		     "unmask" to unmaks or "remask" to remask.   -->
 		<unmask
-				threshold="0.05"
-				threshold_bp="100000"
-				action="none"
+				threshold="0.005"
+				threshold_bp="100"
+				min_length="20000"
+				action="none"				
 		    />
 	</blast>
 


### PR DESCRIPTION
This makes the logic a bit less half-baked:
* only apply to contigs big enough to get meaningfully masked by red
* run red on the whole genome instead of targeted contigs
* turn down thresholds to only run in extreme cases