### PR TITLE
fix up the useDefault divergence config option

### DIFF
--- a/caf/impl/caf.c
+++ b/caf/impl/caf.c
@@ -164,18 +164,21 @@ void caf(Flower *flower, CactusParams *params, char *alignmentsFile, char *secon
 
     // Pick the annealing round parameter based on the distance
     int64_t annealingRoundsLength;
-    int64_t *annealingRounds;
-    if(max_path_distance < cactusParams_get_float(params, 3, "constants", "divergences", "one")) {
-        annealingRounds = cactusParams_get_ints(params, &annealingRoundsLength, 3, "caf", "annealingRounds", "one");
-    } else if(max_path_distance < cactusParams_get_float(params, 3, "constants", "divergences", "two")) {
-        annealingRounds = cactusParams_get_ints(params, &annealingRoundsLength, 3, "caf", "annealingRounds", "two");
-    } else if(max_path_distance < cactusParams_get_float(params, 3, "constants", "divergences", "three")) {
-        annealingRounds = cactusParams_get_ints(params, &annealingRoundsLength, 3, "caf", "annealingRounds", "three");
-    } else if(max_path_distance < cactusParams_get_float(params, 3, "constants", "divergences", "four")) {
-        annealingRounds = cactusParams_get_ints(params, &annealingRoundsLength, 3, "caf", "annealingRounds", "four");
-    } else if(max_path_distance < cactusParams_get_float(params, 3, "constants", "divergences", "five")) {
-        annealingRounds = cactusParams_get_ints(params, &annealingRoundsLength, 3, "caf", "annealingRounds", "five");
-    } else {
+    int64_t *annealingRounds = NULL;
+    if (cactusParams_get_float(params, 3, "constants", "divergences", "useDefault") == 0) {
+        if(max_path_distance < cactusParams_get_float(params, 3, "constants", "divergences", "one")) {
+            annealingRounds = cactusParams_get_ints(params, &annealingRoundsLength, 3, "caf", "annealingRounds", "one");
+        } else if(max_path_distance < cactusParams_get_float(params, 3, "constants", "divergences", "two")) {
+            annealingRounds = cactusParams_get_ints(params, &annealingRoundsLength, 3, "caf", "annealingRounds", "two");
+        } else if(max_path_distance < cactusParams_get_float(params, 3, "constants", "divergences", "three")) {
+            annealingRounds = cactusParams_get_ints(params, &annealingRoundsLength, 3, "caf", "annealingRounds", "three");
+        } else if(max_path_distance < cactusParams_get_float(params, 3, "constants", "divergences", "four")) {
+            annealingRounds = cactusParams_get_ints(params, &annealingRoundsLength, 3, "caf", "annealingRounds", "four");
+        } else if(max_path_distance < cactusParams_get_float(params, 3, "constants", "divergences", "five")) {
+            annealingRounds = cactusParams_get_ints(params, &annealingRoundsLength, 3, "caf", "annealingRounds", "five");
+        }
+    }
+    if (annealingRounds == NULL) {
         annealingRounds = cactusParams_get_ints(params, &annealingRoundsLength, 3, "caf", "annealingRounds", "default");
     }
 

--- a/src/cactus/paf/local_alignment.py
+++ b/src/cactus/paf/local_alignment.py
@@ -42,14 +42,14 @@ def run_lastz(job, name_A, genome_A, name_B, genome_B, distance, params):
     cpu = getOptionalAttrib(lastz_params_node, 'cpu', typeFn=int, default=None)        
     lastz_divergence_node = lastz_params_node.find("kegalignArguments" if gpu else "lastzArguments")
     divergences = params.find("constants").find("divergences")
-    for i in "one", "two", "three", "four", "five":
-        if distance <= float(divergences.attrib[i]):
-            lastz_params = lastz_divergence_node.attrib[i]
-            break
-    else:
-        lastz_params = lastz_divergence_node.attrib["default"]
-    logger.info("For distance {} for genomes {}, {} using {} lastz parameters".format(distance, genome_A,
-                                                                                      genome_B, lastz_params))
+    lastz_params = lastz_divergence_node.attrib["default"]
+    if not getOptionalAttrib(divergences, 'useDefault', typeFn=bool, default=False):
+        for i in "one", "two", "three", "four", "five":
+            if distance <= float(divergences.attrib[i]):
+                lastz_params = lastz_divergence_node.attrib[i]
+                break
+        logger.info("For distance {} for genomes {}, {} using {} lastz parameters".format(distance, genome_A,
+                                                                                          genome_B, lastz_params))
     if gpu:
         lastz_bin = 'run_kegalign'
         suffix_a, suffix_b = '', ''


### PR DESCRIPTION
The `useDefault` attribute in `<divergence>` claims to override things so you use the default/most sensitive parameters.  This PR makes sure it does this 