### PR TITLE
CLI for scaling branches

### DIFF
--- a/doc/progressive.md
+++ b/doc/progressive.md
@@ -12,6 +12,7 @@ Please cite the [HAL paper](https://doi.org/10.1093/bioinformatics/btt128) when 
 * [Quick-start](#quick-start)
 * [Interface](#interface)
 *    * [Masking](#masking)
+*    * [Adjusting Sensitivity](#adjusting-sensitivity)
 * [Using the HAL Output](#using-the-hal-output)
      * [MAF Export](#maf-export)
 * [Using Docker](#using-docker)
@@ -109,7 +110,11 @@ The `--maskMode` option is available in `cactus`, `cactus-preprocess` and `cactu
 
 #### "Rescuing" completely-masked contigs
 
-It is possible for Cactus to reconstruct ancestral contigs that are completely masked.  These will effectively be invisible to `lastz` and will never align up the tree.  The experimental `--remask` option is added to detect these contigs, unmask them, then remask them from scratch using the cactus preprocessor.  In practice the end result is that some contigs will end up only partially masked and will have a chance at aligning further up the tree.  The details for exactly how a contig is chosen for remasking can be tuned in the config (see the "unmask" element in "blast").  Using `--remask` will likely increase sensitivity, but this could come at the cost of worse running time and/or memory usuage. 
+It is possible for Cactus to reconstruct ancestral contigs that are completely masked.  These will effectively be invisible to `lastz` and will never align up the tree.  The experimental `--remask` option is added to detect these contigs, unmask them, then remask them from scratch using the cactus preprocessor.  In practice the end result is that some contigs will end up only partially masked and will have a chance at aligning further up the tree.  The details for exactly how a contig is chosen for remasking can be tuned in the config (see the "unmask" element in "blast").  Using `--remask` will likely increase sensitivity, but this could come at the cost of worse running time and/or memory usuage.
+
+### Adjusting Sensitivity
+
+Cactus uses branch lengths in the guide tree to estimate lastz and chaining parameters.  If there is a bias in the guide tree, say all the branch lengths are too short, then Cactus's sensitivity may be unexpectedly low. You can adjust your tree or twiddle with the parameters in the [config XML]((#advanced-configuration)), but a simpler interface is to use the `--branchScale` option to scale the effective branch lengths.  For example `--branchScale 2.0` will effectively treat the branch lengths as double their actual values, making parameters more sensitive.  You can go in the other direction too:  Use `--branchScale 0.5` to use less-conservative parameters (ie if your branch lengths are too long).  Note that the final HAL output will have the original input tree embedded within it -- the scaling is only used within `cactus_consolidated` and `lastz` alignment. 
 
 ### Sex Chromosomes and Diploid Assemblies
 

--- a/src/cactus/blast/cactus_blast.py
+++ b/src/cactus/blast/cactus_blast.py
@@ -73,8 +73,10 @@ def main():
                         " at least one outgroup.")
     parser.add_argument("--remask",
                         help='Attempt to rescue completely-masked contigs by unmasking then remasking them with the preprocessor.',
-                        action='store_true')    
-    
+                        action='store_true')
+    parser.add_argument("--branchScale", type=float, default=1.0,
+                        help="Scale branch lengths by this factor to adjust alignment sensitivity (e.g., 2.0 = treat branches as 2x longer, more sensitive)")
+
     options = parser.parse_args()
 
     setupBinaries(options)
@@ -129,14 +131,19 @@ def runCactusBlastOnly(options):
                 for name, override in zip(options.pathOverrideNames, options.pathOverrides):
                     input_seq_map[name] = override
 
-            # get the spanning tree (which is what it paf aligner wants)
-            spanning_tree = get_spanning_subtree(mc_tree, options.root, config_wrapper, og_map)
-
-            if getOptionalAttrib(config_node.find('constants').find('divergences'),
-                                 'upweightAncestorDistances', typeFn=bool, default=False):
+            # apply tree scaling to reflect branch scaling and/or uncertainty in ancestor placement/sequences
+            scaled_tree = mc_tree
+            upweight_ancestors = getOptionalAttrib(config_node.find('constants').find('divergences'),
+                                                   'upweightAncestorDistances', typeFn=bool, default=False)
+            if options.branchScale != 1.0 or upweight_ancestors:
                 max_div = float(config_node.find('constants').find('divergences').attrib['five'])
-                mc_tree = get_ancestor_scaled_tree(mc_tree, spanning_tree.getRootName(), max_div)
-                    
+                scaled_tree = get_ancestor_scaled_tree(mc_tree, options.root, max_div,
+                                                       branch_scale=options.branchScale,
+                                                       upweight_ancestors=upweight_ancestors)
+
+            # get the spanning tree (which is what it paf aligner wants)
+            spanning_tree = get_spanning_subtree(scaled_tree, options.root, config_wrapper, og_map)
+
             #import the sequences
             input_seq_id_map = {}
             for (genome, seq) in input_seq_map.items():

--- a/src/cactus/progressive/progressive_decomposition.py
+++ b/src/cactus/progressive/progressive_decomposition.py
@@ -199,22 +199,39 @@ def get_spanning_subtree(mc_tree, root_name, config_wrapper, outgroup_map):
     spanning_tree.computeSubtreeRoots()
     return spanning_tree
 
-def get_ancestor_scaled_tree(mc_tree, root_name, max_div):
+def get_ancestor_scaled_tree(mc_tree, root_name, max_div, branch_scale=1.0, upweight_ancestors=False):
     """
-    add the height of each node to its branch-length to its parent.
-    we want to do this only for trees that are used to compute divergence
-    thresholds (which happens in caf and blast) and the idea behind
-    it is to add uncertainty to distances based on ancestors.
+    Scale branch lengths in the tree.
+
+    First, if branch_scale != 1.0, scale all branches by dividing by branch_scale
+    (higher branch_scale = treat branches as longer = more sensitive parameters).
+
+    Then, if upweight_ancestors is True, add the height of each node to its branch-length
+    to its parent to reflect uncertainty in ancestor placement/sequences.
+
+    This is used only for trees that compute divergence thresholds (in caf and blast).
     """
-    node_heights = get_node_heights(mc_tree, root_name)
     scaled_tree = copy.deepcopy(mc_tree)
-    for node in scaled_tree.breadthFirstTraversal(scaled_tree.getNodeId(root_name)):
-        name = scaled_tree.getName(node)
-        if name in node_heights and scaled_tree.hasParent(node):
-            parent = scaled_tree.getParent(node)
-            length = scaled_tree.getWeight(parent, node)
-            if length < max_div:
-                scaled_tree.setWeight(parent, node, min(max_div, length + node_heights[name]))
+
+    # First apply branch scaling to all branches
+    if branch_scale != 1.0:
+        for node in scaled_tree.breadthFirstTraversal(scaled_tree.getNodeId(root_name)):
+            if scaled_tree.hasParent(node):
+                parent = scaled_tree.getParent(node)
+                length = scaled_tree.getWeight(parent, node)
+                scaled_tree.setWeight(parent, node, length * branch_scale)
+
+    # Then apply ancestor height weighting if requested
+    if upweight_ancestors:
+        node_heights = get_node_heights(scaled_tree, root_name)
+        for node in scaled_tree.breadthFirstTraversal(scaled_tree.getNodeId(root_name)):
+            name = scaled_tree.getName(node)
+            if name in node_heights and scaled_tree.hasParent(node):
+                parent = scaled_tree.getParent(node)
+                length = scaled_tree.getWeight(parent, node)
+                if length < max_div:
+                    scaled_tree.setWeight(parent, node, min(max_div, length + node_heights[name]))
+    RealtimeLogger.info('Scaled Tree: {}'.format(NXNewick().writeString(scaled_tree)))
     return scaled_tree
     
 def get_node_heights(mc_tree, root_name):

--- a/src/cactus/refmap/cactus_pangenome.py
+++ b/src/cactus/refmap/cactus_pangenome.py
@@ -92,6 +92,10 @@ def main():
     # cactus-graphmap options
     parser.add_argument("--collapseRefPAF", help ="Incorporate given reference self-alignments in PAF format")
 
+    parser.add_argument("--branchScale", type=float, default=1.0,
+                        help="Scale default branch length. This option is more relevant for progressive cactus but larger values can be used here to reduce chaining thresholds in cactus_consolidated.")
+
+
     # cactus-graphmap-join options
     graphmap_join_options(parser)
 

--- a/src/cactus/shared/configWrapper.py
+++ b/src/cactus/shared/configWrapper.py
@@ -393,4 +393,15 @@ class ConfigWrapper:
                 logger.info('Scaling blast chunkSize up and dechunkBatchSize down by {} to be more cluster-friendly'.format(scale))
                 blast_node.attrib['chunkSize'] = str(scale * int(blast_node.attrib['chunkSize']))
                 blast_node.attrib['dechunkBatchSize'] = str(max(1, int(int(blast_node.attrib['dechunkBatchSize']) / scale)))
-            
+
+    def scaleBranchLengths(self, branch_scale):
+        """ Scale effective branch lengths by dividing divergence thresholds (higher scale = longer branches = more sensitive) """
+        if branch_scale != 1.0:
+            constants = findRequiredNode(self.xmlRoot, "constants")
+            divergences_node = constants.find("divergences")
+            if divergences_node is not None:
+                logger.info('Scaling branch lengths by {} (dividing divergence thresholds)'.format(branch_scale))
+                for attr_name in ['one', 'two', 'three', 'four', 'five']:
+                    if attr_name in divergences_node.attrib:
+                        divergences_node.attrib[attr_name] = str(float(divergences_node.attrib[attr_name]) / branch_scale)
+

--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -45,7 +45,7 @@ class TestCase(unittest.TestCase):
         if fastga:
             cmd += ['--fastga']
         else:
-            cmd += ['--remask']
+            cmd += ['--remask', '--branchScale', '1.25']
 
         # todo: it'd be nice to have an interface for setting tag to something not latest or commit
         if binariesMode == 'docker':
@@ -216,7 +216,7 @@ class TestCase(unittest.TestCase):
         out_seqfile = os.path.join(out_dir, 'evolverMammalsOut.txt')
         in_seqfile = './examples/evolverMammals.txt'
         cmd = ['cactus-prepare', in_seqfile, '--outDir', out_dir, '--outSeqFile', out_seqfile, '--outHal', self._out_hal(name),
-               '--jobStore', self._job_store(name), '--maskMode', 'fastan']
+               '--jobStore', self._job_store(name), '--maskMode', 'fastan', '--branchScale', '1.33']
         bm_flag = '--binariesMode {}'.format(binariesMode)
         if binariesMode == "docker":
             bm_flag += ' --latest'
@@ -255,6 +255,7 @@ class TestCase(unittest.TestCase):
                '--preprocessCores', '2',
                '--blastCores', '4',
                '--alignCores', '4',
+               '--branchScale', '1.67',
                '--remask']
 
         # specify an output directory


### PR DESCRIPTION
I've been doing a lot of testing to get around trees with branch lengths that are too short.  This PR adds the `--branchScale` option to making scaling branch lengths a little easier, without needing to keep track of configs etc.   The option scales all branches by the given factor (which can be less than 1 if the branches are too long) to trees passed to cactus-blast and cactus_consolidated.  Note that the branch lengths in the HAL output are unaffected by this option. 