### PR TITLE
smaller default pangenome branch len

### DIFF
--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -528,7 +528,7 @@
 	 	<decomposition
 	 		default_internal_node_prefix="Anc"
 			default_branch_len="1"
-			default_branch_len_pangenome="0.025"
+			default_branch_len_pangenome="0.02"
 			allow_multifurcations="0"
 	 	/>
   	</multi_cactus>


### PR DESCRIPTION
This is because the current default would reduce the chaining on pangenome defaults.