### PR TITLE
prep release 3.1.2 (sigh)

### DIFF
--- a/BIN-INSTALL.md
+++ b/BIN-INSTALL.md
@@ -6,17 +6,17 @@ pre-compile binary, static linked distribution.
 ## Extracting
 If you have not already extract the distribution and cd into the cactus directory:
 ```
-tar -xzf cactus-bin-v3.1.1.tar.gz
-cd cactus-bin-v3.1.1
+tar -xzf cactus-bin-v3.1.2.tar.gz
+cd cactus-bin-v3.1.2
 ```
 
 ## Setup
 
 To build a python virtualenv and activate, do the following steps. This requires Python version >= 3.9 (so Ubuntu 18.04 users should use `-p python3.9` below):
 ```
-virtualenv -p python3 venv-cactus-v3.1.1
-printf "export PATH=$(pwd)/bin:\$PATH\nexport PYTHONPATH=$(pwd)/lib:\$PYTHONPATH\nexport LD_LIBRARY_PATH=$(pwd)/lib:\$LD_LIBRARY_PATH\n" >> venv-cactus-v3.1.1/bin/activate
-source venv-cactus-v3.1.1/bin/activate
+virtualenv -p python3 venv-cactus-v3.1.2
+printf "export PATH=$(pwd)/bin:\$PATH\nexport PYTHONPATH=$(pwd)/lib:\$PYTHONPATH\nexport LD_LIBRARY_PATH=$(pwd)/lib:\$LD_LIBRARY_PATH\n" >> venv-cactus-v3.1.2/bin/activate
+source venv-cactus-v3.1.2/bin/activate
 python3 -m pip install -U setuptools pip wheel
 python3 -m pip install -U .
 python3 -m pip install -U -r ./toil-requirement.txt

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,9 @@
+# Release 3.1.2 2025-12-10
+
+This release addresses one bug from the previous release.
+
+- Fix `cactus-prepare --script` regression that caused `cactus-blast` commands to not be run in parallel.
+
 # Release 3.1.1 2025-12-09
 
 This release fixes a number of recent bugs, especially from 3.1.0.

--- a/doc/progressive.md
+++ b/doc/progressive.md
@@ -294,12 +294,12 @@ The Cactus Docker image contains everything you need to run Cactus (python envir
 
 ```
 wget -q https://raw.githubusercontent.com/ComparativeGenomicsToolkit/cactus/master/examples/evolverMammals.txt -O evolverMammals.txt
-docker run --user $(id -u):$(id -g) -v $(pwd):/data --rm -it quay.io/comparative-genomics-toolkit/cactus:v3.1.1 cactus /data/jobStore /data/evolverMammals.txt /data/evolverMammals.hal
+docker run --user $(id -u):$(id -g) -v $(pwd):/data --rm -it quay.io/comparative-genomics-toolkit/cactus:v3.1.2 cactus /data/jobStore /data/evolverMammals.txt /data/evolverMammals.hal
 ```
 
 Or you can proceed interactively by running
 ```
-docker run -v $(pwd):/data --rm -it quay.io/comparative-genomics-toolkit/cactus:v3.1.1 bash
+docker run -v $(pwd):/data --rm -it quay.io/comparative-genomics-toolkit/cactus:v3.1.2 bash
 cactus /data/jobStore /data/evolverMammals.txt /data/evolverMammals.hal
 
 ```
@@ -516,7 +516,7 @@ cp <CACTUS-INSTALLATION-DIR>/src/cactus_progressive_config.xml ./config.xml
 If you are running cactus directly from `docker run`, then do (making sure to use the same docker image that you will use to run cactus):
 
 ```
-docker run --user $(id -u):$(id -g) -v $(pwd):/data --rm -it quay.io/comparative-genomics-toolkit/cactus:v3.1.1 cp /home/cactus/cactus_env/lib/python3.10/site-packages/cactus/cactus_progressive_config.xml /data/config.xml
+docker run --user $(id -u):$(id -g) -v $(pwd):/data --rm -it quay.io/comparative-genomics-toolkit/cactus:v3.1.2 cp /home/cactus/cactus_env/lib/python3.10/site-packages/cactus/cactus_progressive_config.xml /data/config.xml
 ```
 
 You can then edit `config.xml` and use it to override cactus's defaults by adding `--configFile config.xml` to any cactus command.  If you are using `docker run -v $(pwd):/data` then you would add `--configFile /data/config.xml` to your command instead. 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(versionFile, 'w') as versionFH:
 
 setup(
     name = "Cactus",
-    version = "3.1.1",
+    version = "3.1.2",
     author = "Benedict Paten",
     package_dir = {'': 'src'},
     packages = find_packages(where='src'),

--- a/src/cactus/shared/common.py
+++ b/src/cactus/shared/common.py
@@ -320,7 +320,7 @@ def getDockerTag(gpu=False):
         return "latest"    
     else:
         # must be manually kept current with each release        
-        return 'v3.1.1' + ('-gpu' if gpu else '')
+        return 'v3.1.2' + ('-gpu' if gpu else '')
 
 def getDockerImage(gpu=False):
     """Get fully specified Docker image name."""


### PR DESCRIPTION
Really want to pin the vgp alignment to a release, and need the prepare --script typo fixed to run the vgp...  hence 3.1.2 a day after 3.1.1....