### PR TITLE
Better outgroups

### DIFF
--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -516,7 +516,7 @@
 		<!-- max_num_outgroups: maximum number of outgroups per alignment job-->
 		<!-- extra_chrom_outgroups: if max_num_outgroups is not sufficent to satisfy sex chromosome requirements of an ancestor while still using nearest species, allow up to this many extra (when -1 set to the number of unique sex chromosomes for the ancestor).  -->
 		<!-- topological: if 1, sort outgroup candidates by (LCA_height, distance) instead of just distance. This prefers topologically closer outgroups over those with short branch lengths. -->
-		<!-- min_novelty: minimum novelty fraction (0-1) for additional outgroups. Novelty measures how much of an outgroup's path is NOT shared with existing outgroups. Falls back to best available if no candidate meets threshold. -->
+		<!-- overlap_penalty: scale factor for branches already covered by an outgroup. After selecting an outgroup, all branches on the path from the ancestor to that outgroup are scaled by this factor for subsequent outgroup selection. Values > 1 penalize shared paths (e.g., 2.0 doubles the effective distance). 0 means disabled. -->
 		<outgroup
 			strategy="greedyLeavesPreference"
 			threshold="0"
@@ -524,7 +524,7 @@
 			max_num_outgroups="2"
 			extra_chrom_outgroups="-1"
 			topological="1"
-			min_novelty="0.2"
+			overlap_penalty="2"
 			/>
 
 		<!-- default_internal_node_prefix: internal nodes of the tree are labeled with this prefix then a BFS order number -->

--- a/src/cactus/progressive/progressive_decomposition.py
+++ b/src/cactus/progressive/progressive_decomposition.py
@@ -79,7 +79,7 @@ def compute_outgroups(mc_tree, config_wrapper, outgroup_candidates = set(), root
                         maxNumOutgroups=config_wrapper.getMaxNumOutgroups(),
                         extraChromOutgroups=config_wrapper.getExtraChromOutgroups(),
                         topological=config_wrapper.getOutgroupTopological(),
-                        minNovelty=config_wrapper.getOutgroupMinNovelty())
+                        overlapPenalty=config_wrapper.getOutgroupOverlapPenalty())
     if leaves_only:
         # use all leaves as outgroups, unless outgroup candidates are given
         outgroup.greedy(threshold=config_wrapper.getOutgroupThreshold(),
@@ -88,7 +88,7 @@ def compute_outgroups(mc_tree, config_wrapper, outgroup_candidates = set(), root
                         maxNumOutgroups=config_wrapper.getMaxNumOutgroups(),
                         extraChromOutgroups=config_wrapper.getExtraChromOutgroups(),
                         topological=config_wrapper.getOutgroupTopological(),
-                        minNovelty=config_wrapper.getOutgroupMinNovelty())
+                        overlapPenalty=config_wrapper.getOutgroupOverlapPenalty())
     elif config_wrapper.getOutgroupStrategy() != 'none':
         outgroup.greedy(threshold=config_wrapper.getOutgroupThreshold(),
                         candidateSet=None,
@@ -96,7 +96,7 @@ def compute_outgroups(mc_tree, config_wrapper, outgroup_candidates = set(), root
                         maxNumOutgroups=config_wrapper.getMaxNumOutgroups(),
                         extraChromOutgroups=config_wrapper.getExtraChromOutgroups(),
                         topological=config_wrapper.getOutgroupTopological(),
-                        minNovelty=config_wrapper.getOutgroupMinNovelty())
+                        overlapPenalty=config_wrapper.getOutgroupOverlapPenalty())
     
     if not include_dists:
         for k, v in outgroup.ogMap.items():

--- a/src/cactus/shared/configWrapper.py
+++ b/src/cactus/shared/configWrapper.py
@@ -117,14 +117,14 @@ class ConfigWrapper:
             topological = ogElem.attrib["topological"] == "1"
         return topological
 
-    def getOutgroupMinNovelty(self):
+    def getOutgroupOverlapPenalty(self):
         ogElem = self.getOutgroupElem()
-        minNovelty = 0.0
+        overlapPenalty = 0.0
         if (ogElem is not None and\
             "strategy" in ogElem.attrib and\
-            "min_novelty" in ogElem.attrib):
-            minNovelty = float(ogElem.attrib["min_novelty"])
-        return minNovelty
+            "overlap_penalty" in ogElem.attrib):
+            overlapPenalty = float(ogElem.attrib["overlap_penalty"])
+        return overlapPenalty
 
     def getDefaultInternalNodePrefix(self):
         decompElem = self.getDecompositionElem()


### PR DESCRIPTION
Right now, outgroups default to the 2 closest leaves in the tree.  This PR
1. uses LCA instead of distance.  So it will take the eligible leaf with the lowest common ancestor with the target node.  Distance only used to break ties.  This is to prevent it from choosing outgroups from outside the current clade just because there are some genomes with really short branches in another clade.  (I'm seeing this in the vgp tree where bats are outgroups for nearly everything because they have short branches).  
2. Upweights "novelty".  I thought this was implemented decades ago but it wasn't (or was lost).  Now it will factor in how close to outgroup i, the i+1st outgroup is.  If there's too much of an overlap then it will choose something else.  By default outgroups are chosen so that their paths are at least 20% novel. 

These are both on by default now, but can be toggled or adjusted in the config. 

Update: Doing the second part a bit differently:  Now branches that are already selected for outgroups get scaled by 2 (adjustable in the config) when selecting subsequent outgroups. 