### PR TITLE
scale cons memory a bit with cpu count

### DIFF
--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -536,10 +536,11 @@
   	</multi_cactus>
 	<!-- memory_core_scale_pct: percentage to increase memory per core above baseline (default 0.5 means 0.5% more memory per extra core) -->
 	<!-- memory_core_scale_baseline: number of cores at which scaling begins (default 32) -->
-	<!-- Note: scaled memory will never exceed the maximum value in consolidatedMemory (seq_size_10000000000) -->
+	<!-- memory_core_scale_max_pct: maximum percentage increase allowed (default 100 means memory can at most double) -->
 	<consolidated
 		 memory_core_scale_pct="0.5"
 		 memory_core_scale_baseline="32"
+		 memory_core_scale_max_pct="100"
 		 >
 	       <!-- consolidatedMemory: Specify memory requirement (in bytes) for cactus_conslidated. Each attribute corresponds to an interval start, and must be in the form seq_size_TOTAL_INPUT_SEQUENCE_SIZE=MEMORY.  So if cactus_consolidated is getting N input bytes, the first interval containing N is found, and the value of that attribute is used as the Toil memory. The idea is that it will be easier to fiddle with these than a single polynomial function while attempting to learn decent defaults by trial and error. By default, the memory requirement is linearly interpolated based on the endpoints of the interval.  If consMemory CLI option is used, then it overrides everything here.   -->
 	 	<consolidatedMemory


### PR DESCRIPTION
Nested BAR parallelism (#1833) can be way faster, but can also use more memory (since more abpoa matrices processed at the same time).

The memory Toil gives to consolidated (see the `<consolidatedMemory>` element in the config) was tuned on an earlier version of cactus.  And I've been seeing more memory limit failures, especially when running with larger cpu counts. 

This PR adds a 0.5% memory boost for each core over 32 (both parameters adjustable in the config).  It will always clamp at the maximum memory limit from `<consolidatedMemory>`  (currently 512G) or whatever comes in from max-memory. 

It's hard to ever really get this right, so it remains important to always use `--maxMemory` and `--doubleMem true` when running on slurm.  

```
  | Cores | Extra Cores | Scale Factor | Effect      |
  |-------|-------------|--------------|-------------|
  | 32    | 0           | 1.0          | No scaling  |
  | 48    | 16          | 1.08         | +8% memory  |
  | 64    | 32          | 1.16         | +16% memory |
  | 96    | 64          | 1.32         | +32% memory |
  | 128   | 96          | 1.48         | +48% memory |
```

