### PR TITLE
revert post-zoonomia outgroup changes

### DIFF
--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -516,10 +516,10 @@
 		<!-- max_num_outgroups: maximum number of outgroups per alignment job-->
 		<!-- extra_chrom_outgroups: if max_num_outgroups is not sufficent to satisfy sex chromosome requirements of an ancestor while still using nearest species, allow up to this many extra (when -1 set to the number of unique sex chromosomes for the ancestor).  -->
 		<outgroup
-			strategy="greedyLeavesPreference"
+			strategy="greedyPreference"
 			threshold="0"
 			ancestor_quality_fraction="0.75"
-			max_num_outgroups="2"
+			max_num_outgroups="3"
 			extra_chrom_outgroups="-1"
 			/>
 


### PR DESCRIPTION
og-selection is impactful high up in deep, large trees.  the 10-way test i've been using doesn't really cover it, nor do recent projects like primates or apes.

even with some new machinery (#1875), any errors in the tree can wildly swing outgroups between clades.  going back to:

* allowing ancestral outgroups should mitigate this, as each outgroup can potentially cover far more of the tree)
* and using 3 outgroups further reduces the odds of missing anything important. 

(pending a few focused tests to merge this or #1875)  
