### PR TITLE
add zstd compression support for hal output

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,6 +5,8 @@ variables:
 
 before_script:
   - whoami
+  - sudo apt-get -q -y update
+  - sudo apt-get -q -y install --no-upgrade liblz4-dev libzstd-dev
   - startdocker || true
   - docker info
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/comparative-genomics-toolkit/ubuntu:22.04 AS builder
 
 # apt dependencies for build
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential git python3 python3-dev python3-pip zlib1g-dev wget libbz2-dev pkg-config libhdf5-dev liblzo2-dev libtokyocabinet-dev wget liblzma-dev libxml2-dev libssl-dev libpng-dev uuid-dev libcurl4-gnutls-dev libffi-dev python3-virtualenv rsync python-is-python3 libdeflate-dev cmake libjemalloc-dev python3-distutils pybind11-dev autoconf libzstd-dev libhts-dev
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential git python3 python3-dev python3-pip zlib1g-dev wget libbz2-dev pkg-config libhdf5-dev liblzo2-dev libtokyocabinet-dev wget liblzma-dev libxml2-dev libssl-dev libpng-dev uuid-dev libcurl4-gnutls-dev libffi-dev python3-virtualenv rsync python-is-python3 libdeflate-dev cmake libjemalloc-dev python3-distutils pybind11-dev autoconf libzstd-dev liblz4-dev libhts-dev
 
 # copy cactus
 RUN mkdir -p /home/cactus
@@ -63,7 +63,7 @@ RUN rm -rf /home/cactus/hal_lib && \
 FROM quay.io/comparative-genomics-toolkit/ubuntu:22.04
 
 # apt dependencies for runtime
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends git python3 python3-pip python3-distutils zlib1g libbz2-1.0 net-tools libhdf5-103 liblzo2-2 libtokyocabinet9 libkrb5-3 libk5crypto3 time liblzma5 libcurl4 libcurl4-gnutls-dev libxml2 libgomp1 libffi7 parallel libdeflate0 libjemalloc2 libatomic1 libhts3 rsync
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends git python3 python3-pip python3-distutils zlib1g libbz2-1.0 net-tools libhdf5-103 liblzo2-2 libtokyocabinet9 libkrb5-3 libk5crypto3 time liblzma5 libcurl4 libcurl4-gnutls-dev libxml2 libgomp1 libffi7 parallel libdeflate0 libjemalloc2 libatomic1 libhts3 rsync liblz4-1 libzstd1
 
 # required for ubuntu22 but won't work anywhere else
 RUN bash -c "if ! command -v catchsegv > /dev/null; then apt-get install glibc-tools; fi"

--- a/build-tools/downloadMafTools
+++ b/build-tools/downloadMafTools
@@ -66,7 +66,7 @@ cd taffy
 git checkout 5ab000b8e12bef211352131b9891c8e2cfb94063
 git submodule update --init --recursive
 export HALDIR=${CWD}/submodules/hal
-LIBS="${jemallocLib}" make -j ${numcpu}
+LIBS="${jemallocLib} -llz4 -lzstd" make -j ${numcpu}
 if [[ $STATIC_CHECK -ne 1 || $(ldd bin/taffy | grep so | wc -l) -eq 0 ]]
 then
     mv bin/taffy ${binDir}

--- a/build-tools/makeBinRelease
+++ b/build-tools/makeBinRelease
@@ -75,7 +75,7 @@ cd libxml2-2.9.12
 ./configure --enable-static --disable-shared --prefix=${DEP_PREFIX} --with-python=no
 make -j $(nproc)
 make install
-export CACTUS_STATIC_LINK_FLAGS="-L${DEP_PREFIX}/lib -lz -lpthread -lm -llzma"
+export CACTUS_STATIC_LINK_FLAGS="-L${DEP_PREFIX}/lib -lz -lpthread -lm -llzma -llz4 -lzstd"
 export CACTUS_LIBXML2_INCLUDE_PATH=${DEP_PREFIX}/include/libxml2
 popd
 

--- a/doc/progressive.md
+++ b/doc/progressive.md
@@ -14,6 +14,7 @@ Please cite the [HAL paper](https://doi.org/10.1093/bioinformatics/btt128) when 
 *    * [Masking](#masking)
 *    * [Adjusting Sensitivity](#adjusting-sensitivity)
 * [Using the HAL Output](#using-the-hal-output)
+     * [HAL Compression](#hal-compression)
      * [MAF Export](#maf-export)
 * [Using Docker](#using-docker)
 * [Running in the Cloud](#running-on-the-cloud)
@@ -145,6 +146,10 @@ Normally, cactus greedily chooses the N (default=2, override with `cactus --maxO
 The `outputHal` file represents the multiple alignment, including all input and inferred ancestral sequences.  It is stored in HAL format, and can be accessed with [HAL tools](https://github.com/ComparativeGenomicsToolkit/Hal), which are all included in Cactus either as static binaries for the binary release, or within the Docker image for the Docker release.
 
 Please [cite HAL](https://doi.org/10.1093/bioinformatics/btt128).
+
+### HAL Compression
+
+By default, HAL files are compressed with `deflate` (gzip). The `--hdf5Codec` option can be used to select a different HDF5 compression codec. The available codecs are `deflate`, `lz4`, `zstd` and `none`. Using `zstd` is recommended for new alignments: it produces smaller files (ex. 24% smaller on a 12-mammal alignment) and is faster to read than `deflate`.  Note that HAL files written with `lz4` or `zstd` require a version of HAL that includes the corresponding codec support to read them.  The `--hdf5Codec` option is available in `cactus`, `cactus-align` and `cactus-prepare`.
 
 ### MAF Export
 

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -357,9 +357,13 @@
 	>
 	</check>
 	<!-- The hal tag controls the creation of hal and fasta files from the pipeline. -->
+	<!-- buildHal: toggle creation of output hal alignment [1=enabled] -->
+	<!-- buildFasta: toggle creation of output fasta files [1=enabled] -->
+	<!-- hdf5Codec: HDF5 compression codec for hal output: deflate, lz4, zstd, none -->
 	<hal
 		buildHal="1"
 		buildFasta="1"
+		hdf5Codec="deflate"
 	>
 	</hal>
 	<!-- cactus-graphmap options -->

--- a/src/cactus/progressive/cactus_prepare.py
+++ b/src/cactus/progressive/cactus_prepare.py
@@ -109,6 +109,8 @@ def main(toil_mode=False):
     parser.add_argument("--nvidiaDriver", default="470.82.01", help="Nvidia driver version")
     parser.add_argument("--gpuZone", default="us-central1-a", help="zone used for gpu task")
     parser.add_argument("--zone", default="us-west2-a", help="zone used for all but gpu tasks")
+    parser.add_argument("--hdf5Codec", choices=["deflate", "lz4", "zstd", "none"], default=None,
+                        help="HDF5 compression codec for HAL output (overrides config XML, default=deflate)")
 
     if not toil_mode:
         parser.add_argument("--defaultCores", type=int, help="Number of cores for each job unless otherwise specified")
@@ -392,6 +394,8 @@ def cactusPrepare(options):
     seqFile = SeqFile(options.seqFile)
     configNode = ET.parse(options.configFile).getroot()
     config = ConfigWrapper(configNode)
+    if options.hdf5Codec:
+        options.cactusOptions += ' --hdf5Codec {}'.format(options.hdf5Codec)
     options.gpu_preprocessor = options.gpu and config.getPreprocessorActive('lastzRepeatMask')
 
     if not options.wdl and not options.toil:

--- a/src/cactus/progressive/cactus_progressive.py
+++ b/src/cactus/progressive/cactus_progressive.py
@@ -207,7 +207,7 @@ def progressive_step_2(job, trimmed_outgroups_and_alignments, options, config_no
 
 
 def export_hal(job, mc_tree, config_node, seq_id_map, og_map, results, event=None, cacheBytes=None,
-               cacheMDC=None, cacheRDC=None, cacheW0=None, chunk=None, deflate=None, inMemory=False,
+               cacheMDC=None, cacheRDC=None, cacheW0=None, chunk=None, inMemory=False,
                checkpointInfo=None, acyclicEvent=None, has_resources=False, memory_override=None):
 
     # todo: going through list nonsense because (i think) it helps with promises, should at least clean up
@@ -260,8 +260,11 @@ def export_hal(job, mc_tree, config_node, seq_id_map, og_map, results, event=Non
                     args += ["--cacheW0", cacheW0]
                 if chunk is not None:
                     args += ["--chunk", chunk]
-                if deflate is not None:
-                    args += ["--deflate", deflate]
+                halElem = config_node.find("hal")
+                if halElem is not None:
+                    codec = halElem.attrib.get("hdf5Codec")
+                    if codec:
+                        args += ["--hdf5Codec", codec]
                 if inMemory is True:
                     args += ["--inMemory"]
 
@@ -275,7 +278,7 @@ def export_hal(job, mc_tree, config_node, seq_id_map, og_map, results, event=Non
             mem = memory_override
         return job.addChildJobFn(export_hal, mc_tree, config_node, seq_id_map, og_map, results, event=event,
                                  cacheBytes=cacheBytes, cacheMDC=cacheMDC, cacheRDC=cacheRDC, cacheW0=cacheW0,
-                                 chunk=chunk, deflate=deflate, inMemory=inMemory, checkpointInfo=checkpointInfo,
+                                 chunk=chunk, inMemory=inMemory, checkpointInfo=checkpointInfo,
                                  acyclicEvent=acyclicEvent, has_resources=True,
                                  disk=disk, memory=mem).rv()
 
@@ -386,6 +389,8 @@ def main():
                         action='store_true')
     parser.add_argument("--branchScale", type=float, default=1.0,
                         help="Scale branch lengths by this factor to adjust alignment sensitivity (e.g., 2.0 = treat branches as 2x longer, more sensitive)")
+    parser.add_argument("--hdf5Codec", choices=["deflate", "lz4", "zstd", "none"], default=None,
+                        help="HDF5 compression codec for HAL output (overrides config XML, default=deflate)")
 
     options = parser.parse_args()
 
@@ -452,6 +457,10 @@ def main():
             # toggle remasking
             if options.remask:
                 config_node.find("blast").find("unmask").attrib["action"] = "remask"
+
+            # override hal codec
+            if options.hdf5Codec:
+                config_node.find("hal").attrib["hdf5Codec"] = options.hdf5Codec
 
             mc_tree, input_seq_map, og_candidates = parse_seqfile(options.seqFile, config_wrapper, root_name = options.root)
             logger.info('Tree: {}'.format(NXNewick().writeString(mc_tree)))

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -111,6 +111,8 @@ def main():
                         " at least one outgroup.")
     parser.add_argument("--branchScale", type=float, default=1.0,
                         help="Scale branch lengths by this factor to adjust alignment sensitivity (e.g., 2.0 = treat branches as 2x longer, more sensitive)")
+    parser.add_argument("--hdf5Codec", choices=["deflate", "lz4", "zstd", "none"], default=None,
+                        help="HDF5 compression codec for HAL output (overrides config XML, default=deflate)")
 
     options = parser.parse_args()
 
@@ -274,6 +276,8 @@ def make_align_job(options, toil, config_wrapper=None, chrom_name=None):
         config_wrapper.substituteAllPredefinedConstantsWithLiterals(options)
         if options.collapse:
             findRequiredNode(config_node, "graphmap").attrib["collapse"] = 'all'
+    if hasattr(options, 'hdf5Codec') and options.hdf5Codec:
+        config_node.find("hal").attrib["hdf5Codec"] = options.hdf5Codec
     config_wrapper.setSystemMemory(options)
     mc_tree, input_seq_map, og_candidates = parse_seqfile(options.seqFile, config_wrapper,
                                                           pangenome=options.pangenome)


### PR DESCRIPTION
Add `--hdf5Codec` to toggle the hdf5 compression codec (https://github.com/ComparativeGenomicsToolkit/hal/pull/330) used to create the output hal.

By default it will use the same old gzip, but you can now use `--hdf5Codec zstd` to get a smaller and faster hal (but will only be readable by halTools compiled with the updated support.

Will consider changing the default to zstd in the future... 