### PR TITLE
relax gaf/paf filtering on first stage of mgSplit pipeline

### DIFF
--- a/doc/pangenome.md
+++ b/doc/pangenome.md
@@ -164,8 +164,8 @@ By default, minigraph construction and mapping are performed at the whole-genome
 
 ```
 cactus-minigraph js examples/evolverPrimates.txt ep.sv.gfa.gz --refOnly --reference simChimp 
-cactus-graphmap js examples/evolverPrimates.txt ep.sv.gfa.gz ep.paf --reference simChimp  --outputFasta ep.sv.fa.gz
-cactus-graphmap-split js examples/evolverPrimates.txt ep.sv.gfa.gz ep.paf --reference simChimp  --outDir out-split
+cactus-graphmap js examples/evolverPrimates.txt ep.sv.gfa.gz ep.paf --reference simChimp --mgSplit --outputFasta ep.sv.fa.gz
+cactus-graphmap-split js examples/evolverPrimates.txt ep.sv.gfa.gz ep.paf --reference simChimp --mgSplit --outDir out-split
 cactus-minigraph js ./out-split/chromfile.txt out-construct --reference simChimp --batch
 cactus-graphmap js ./out-construct/chromfile.mg.txt out-map --reference simChimp --batch
 cactus-align js ./out-map/chromfile.gm.txt out-align --reference simChimp --outVG --pangenome --batch

--- a/src/cactus/refmap/cactus_graphmap.py
+++ b/src/cactus/refmap/cactus_graphmap.py
@@ -59,6 +59,8 @@ def main():
 
     parser.add_argument("--batch", action="store_true",
                         help="Run independently on set of chromosomea inputs (chromfile as from cactus-minigraph --batch). Note that the output will be a directory and not a PAF")
+    parser.add_argument("--mgSplit", action="store_true", default=False,
+                        help="Relax block-length, overlap and deletion filters because this PAF will only feed cactus-graphmap-split for chromosome binning (matches the cactus-pangenome --mgSplit / cactus-minigraph --refOnly pipeline). Do not use on per-chromosome (--batch) runs.")
 
     #Progressive Cactus Options
     parser.add_argument("--configFile", dest="configFile",
@@ -102,6 +104,9 @@ def main():
 
     if options.batch and options.outputFasta:
         raise RuntimeError("--outputFasta cannot be used with --batch")
+
+    if options.mgSplit and options.batch:
+        raise RuntimeError("--mgSplit is for the whole-genome splitting pass and cannot be used with --batch")
     
     # Mess with some toil options to create useful defaults.
     cactus_override_toil_options(options)
@@ -141,6 +146,10 @@ def graph_map(options):
         else:
             # load the config
             config_wrapper.substituteAllPredefinedConstantsWithLiterals(options)
+
+            # relax splitting-stage filters first; explicit --delFilter / --maskFilter below override
+            if options.mgSplit:
+                apply_mgsplit_filter_overrides(config_node)
 
             #apply the maskfilter override
             if options.maskFilter is not None:
@@ -382,6 +391,7 @@ def minigraph_workflow(job, options, config, seq_id_map, gfa_id, graph_event, sa
     # apply the optional deletion filter
     unfiltered_paf_id = None
     filtered_paf_log = None
+    paf_was_filtered = False
     del_filter = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap"), "delFilter", int, default=-1)
     if del_filter > 0:
         del_filter_threshold = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap"), "delFilterThreshold", float, default=None)
@@ -618,8 +628,21 @@ def self_align(job, config, seq_name, seq_id):
         cactus_call(parameters=cmd, outfile=paf_path, outappend=True)
     return job.fileStore.writeGlobalFile(paf_path)        
 
+def apply_mgsplit_filter_overrides(config_node):
+    """ Disable the overlap/block-length/deletion filters in the <graphmap> config.
+        These filters tidy up alignment blocks but mangle the signal rgfa-split needs
+        when the splitting graph contains only the reference (eg --mgSplit / --refOnly):
+        palindromic mappings against a single-haplotype chrY all look similarly sized
+        and gaffilter axes them.  rgfa-split has its own interval merging.
+        Caller deep-copies the config first if it must be preserved for other branches. """
+    graphmap_node = findRequiredNode(config_node, "graphmap")
+    graphmap_node.attrib["GAFOverlapFilterRatio"] = "0"
+    graphmap_node.attrib["PAFOverlapFilterRatio"] = "0"
+    graphmap_node.attrib["minGAFBlockLength"] = "0"
+    graphmap_node.attrib["delFilter"] = "-1"
+
 def filter_paf(job, paf_id, config, reference=None):
-    """ run basic paf-filtering.  these are quick filters that are best to do on-the-fly when reading the paf and 
+    """ run basic paf-filtering.  these are quick filters that are best to do on-the-fly when reading the paf and
         as such, they are called by cactus-graphmap-split and cactus-align, not here """
     work_dir = job.fileStore.getLocalTempDir()
     paf_path = os.path.join(work_dir, 'mg.paf')

--- a/src/cactus/refmap/cactus_graphmap_split.py
+++ b/src/cactus/refmap/cactus_graphmap_split.py
@@ -28,7 +28,7 @@ from cactus.shared.common import cactus_clamp_memory
 from cactus.shared.version import cactus_commit
 from cactus.preprocessor.fileMasking import get_mask_bed_from_fasta
 from cactus.preprocessor.checkUniqueHeaders import sanitize_fasta_headers
-from cactus.refmap.cactus_graphmap import filter_paf
+from cactus.refmap.cactus_graphmap import filter_paf, apply_mgsplit_filter_overrides
 from cactus.refmap.cactus_minigraph import check_sample_names, minigraph_gfa_from_pansn
 from toil.job import Job
 from toil.common import Toil
@@ -54,6 +54,8 @@ def main():
     parser.add_argument("--maskFilter", type=int, help = "Ignore softmasked sequence intervals > Nbp")
     parser.add_argument("--minIdentity", type=float, help = "Ignore PAF lines with identity (column 10/11) < this (overrides minIdentity in <graphmap_split> in config)")
     parser.add_argument("--permissiveContigFilter", nargs='?', const='0.25', default=None, type=float, help = "If specified, override the configuration to accept contigs so long as they have at least given fraction of coverage (0.25 if no fraction specified). This can increase sensitivity of very small, fragmented and/or diverse assemblies.")
+    parser.add_argument("--mgSplit", action="store_true", default=False,
+                        help="Use this when the input PAF was produced against a reference-only minigraph (cactus-pangenome --mgSplit / cactus-minigraph --refOnly): relaxes the block-length and overlap filters so palindromic mappings don't get axed before rgfa-split.")
 
     parser.add_argument("--collapse", help = "Incorporate minimap2 self-alignments.", action='store_true', default=False)
     
@@ -106,6 +108,9 @@ def cactus_graphmap_split(options):
 
         if options.collapse:
             findRequiredNode(config_node, "graphmap").attrib["collapse"] = 'all'
+
+        if options.mgSplit:
+            apply_mgsplit_filter_overrides(config_node)
 
         #Run the workflow
         if options.restart:

--- a/src/cactus/refmap/cactus_pangenome.py
+++ b/src/cactus/refmap/cactus_pangenome.py
@@ -44,6 +44,7 @@ from cactus.refmap.cactus_minigraph import minigraph_construct_workflow, minigra
 from cactus.refmap.cactus_minigraph import check_sample_names, read_chromfile
 from cactus.refmap.cactus_minigraph import minigraph_construct_import_sequences, export_minigraph_construct_output
 from cactus.refmap.cactus_graphmap import minigraph_workflow, minigraph_batch_workflow, export_graphmap_output
+from cactus.refmap.cactus_graphmap import apply_mgsplit_filter_overrides
 from cactus.refmap.cactus_graphmap_split import graphmap_split_workflow, export_split_data
 from cactus.setup.cactus_align import make_batch_align_jobs, batch_align_jobs
 from cactus.refmap.cactus_graphmap_join import graphmap_join_workflow, export_join_data, graphmap_join_options, graphmap_join_validate_options, vcflib_checks
@@ -472,8 +473,19 @@ def pangenome_end_to_end_workflow(job, options, config_wrapper, seq_id_map, seq_
     mg_options = copy.deepcopy(options)
     mg_options.refOnly = options.mgSplit
     if mg_options.refOnly:
-        mg_options.lastTrain = False        
-    minigraph_job = sanitize_job.addFollowOnJobFn(minigraph_construct_workflow, mg_options, config_node, seq_id_map, seq_order, sv_gfa_path, sanitize=False)
+        mg_options.lastTrain = False
+    # With --mgSplit, the whole-genome graphmap only feeds rgfa-split for chromosome
+    # binning; the per-chrom graphmap/align below produce the real alignments and
+    # apply default filters.  Deep-copy and relax the splitting-stage config so
+    # the per-chrom branch still sees defaults.
+    if options.mgSplit:
+        split_config_node = copy.deepcopy(config_node)
+        apply_mgsplit_filter_overrides(split_config_node)
+        split_config_wrapper = ConfigWrapper(split_config_node)
+    else:
+        split_config_node = config_node
+        split_config_wrapper = config_wrapper
+    minigraph_job = sanitize_job.addFollowOnJobFn(minigraph_construct_workflow, mg_options, split_config_node, seq_id_map, seq_order, sv_gfa_path, sanitize=False)
     sv_gfa_id = minigraph_job.rv(0)
     pansn_sv_gfa_id = minigraph_job.rv(1)
     if not last_scores_id:
@@ -490,7 +502,7 @@ def pangenome_end_to_end_workflow(job, options, config_wrapper, seq_id_map, seq_
     gm_options = copy.deepcopy(options)
     if options.mgSplit:
         gm_options.collapse = False
-    graphmap_job = minigraph_wrapper_job.addFollowOnJobFn(minigraph_workflow, gm_options, config_wrapper, seq_id_map, sv_gfa_id, graph_event, False, ref_collapse_paf_id, pansn_gfa_input=False)
+    graphmap_job = minigraph_wrapper_job.addFollowOnJobFn(minigraph_workflow, gm_options, split_config_wrapper, seq_id_map, sv_gfa_id, graph_event, False, ref_collapse_paf_id, pansn_gfa_input=False)
     paf_id, gfa_fa_id, gaf_id, unfiltered_paf_id, paf_filter_log = graphmap_job.rv(0), graphmap_job.rv(1), graphmap_job.rv(2), graphmap_job.rv(3), graphmap_job.rv(4)
     graphmap_export_job = graphmap_job.addFollowOnJobFn(export_graphmap_wrapper, options, paf_id, paf_path, gaf_id, unfiltered_paf_id, paf_filter_log)
 
@@ -503,13 +515,13 @@ def pangenome_end_to_end_workflow(job, options, config_wrapper, seq_id_map, seq_
         phony_chromfile_job = update_seqfile_job.addFollowOnJobFn(phony_chromfile, options, paf_path)
         chromfile_path = phony_chromfile_job.rv()
         split_export_job = phony_chromfile_job
-    else:        
+    else:
         # cactus_graphmap_split
-        split_job = update_seqfile_job.addFollowOnJobFn(graphmap_split_workflow, options, config_wrapper, seq_id_map, seq_name_map, sv_gfa_id,
+        split_job = update_seqfile_job.addFollowOnJobFn(graphmap_split_workflow, options, split_config_wrapper, seq_id_map, seq_name_map, sv_gfa_id,
                                                         sv_gfa_path, paf_id, paf_path, sanitize=False, pansn_gfa_input=False)
         wf_output = split_job.rv()
-        split_out_path = os.path.join(options.outDir, 'chrom-subproblems')    
-        split_export_job = split_job.addFollowOnJobFn(export_split_wrapper, wf_output, split_out_path, config_wrapper)        
+        split_out_path = os.path.join(options.outDir, 'chrom-subproblems')
+        split_export_job = split_job.addFollowOnJobFn(export_split_wrapper, wf_output, split_out_path, split_config_wrapper)
         chromfile_path = os.path.join(split_out_path, 'chromfile.txt')
 
     # clean out some jobstore files we no longer need


### PR DESCRIPTION
@Sagorikanag found a bug where `chrY` would get dropped when running `cactus-pagnenome --mgSplit` on a 3-genome graph.  The root issue seems to be that the `--mgSplit` workflow first builds a reference only graph (just CHM13 in this case), then runs the usual splitting pipeline on that.  But this also triggers a bunch of the gaf/paf filtering that normally happens in this stage.  In particular, the paf overlap filter gobbles up the linear chrY alignment because of large ambiguous blocks.  

This patch just turns off all these filters for the reference-only graph stages of `--mgSplit`.  

By virtue of having 2 references (CHM13 and GRCh38), the v2.1 HPRC graphs seem to avoid this issue (and probably why I never ran into it).  But I think it's a pretty serious once that could cause contigs to be dropped by `--mgSplit` with a single `--reference` in many cases...
