### PR TITLE
Update FASTGA to latest commit

### DIFF
--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -89,7 +89,7 @@
 		   overlapSize="10000"
 		   mapper="lastz"
 		   minimap2_params="-x asm20"
-		   fastga_params="-pafs"
+		   fastga_params="-pafs -M"
 		   fastga_fill="1"
 		   fastga_stats="1"
 		   fastga_minlength="50000"


### PR DESCRIPTION
This is an attempt to fix CI errors like https://ucsc-ci.com/comparativegenomicstoolkit/cactus/-/pipelines/11916

Also, add back -M as default option since the interface seems to have flipped back to what it used to be (masking support opt-in)