### PR TITLE
Use minigraph with the large-inversion patch

### DIFF
--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -71,9 +71,9 @@ fi
 
 # minigraph
 cd ${pangenomeBuildDir}
-git clone https://github.com/lh3/minigraph.git
+git clone https://github.com/glennhickey/minigraph.git
 pushd minigraph
-git checkout v0.21
+git checkout 4636f2d42864ee7a32c082d23097fb226acd2a67
 # hack in flags support
 sed -i Makefile -e 's/CFLAGS=/CFLAGS+=/' -e 's/LIBS=/LIBS+=/'
 LIBS="${jemallocLib}" make -j ${numcpu}


### PR DESCRIPTION
Point to minigraph fork with vibe-coded inversion scope increase.  Will see about merging it upstream but in the meantime it seems to help Cactus, both in a few little test cases as well as chm13-hg002-t2t-giab evaluation for hprc-v2.1.  brings F1 from 0.9927 to 0.9933 (with vcfwave). 