### PR TITLE
Better vcfwave parallelism

### DIFF
--- a/build-tools/downloadVCFWave
+++ b/build-tools/downloadVCFWave
@@ -23,9 +23,9 @@ mkdir -p ${binDir}
 mkdir -p ${libDir}
 
 cd ${pangenomeBuildDir}
-git clone --recursive https://github.com/vcflib/vcflib.git
+git clone --recursive https://github.com/glennhickey/vcflib.git
 cd vcflib
-git checkout 8b5d4c8143ed486669f9f0f124cae0882b747fb8
+git checkout fb0c96d1917f34e0c01ce04769c318eca9607452
 mkdir build
 cd build
 cmake -DZIG=OFF -DWFA_GITMODULE=ON -DCMAKE_BUILD_TYPE=Debug ..

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -166,7 +166,7 @@ def graphmap_join_options(parser):
     parser.add_argument("--vcfReference", nargs='+', default=None, help = "If multiple references were provided with --reference, this option can be used to specify a subset for vcf creation with --vcf. By default, --vcf will create VCFs for the first reference only")
     parser.add_argument("--vcfbub", type=int, default=100000, help = "Use vcfbub to flatten nested sites (sites with reference alleles > this will be replaced by their children)). Setting to 0 will disable, only prudcing full VCF [default=100000].")
     parser.add_argument("--vcfwave", action='store_true', default=False, help = "Create a vcfwave-normalized VCF. vcfwave realigns alt alleles to the reference, and can help correct messy regions in the VCF. This option will output an additional VCF with 'wave' in its filename, other VCF outputs will not be affected")
-    parser.add_argument("--vcfwaveCores", type=int, help = "Number of cores for each vcfwave job [default=2].", default=2)
+    parser.add_argument("--vcfwaveCores", type=int, help = "Number of cores for each vcfwave job [default=4].", default=4)
     parser.add_argument("--vcfwaveMemory", type=human2bytesN, help = "Memory for reach vcfwave job [default=32Gi].", default=32000000000)
     parser.add_argument("--snarlStats", nargs='*', help = "Write a list of snarl statistics for the graph type(s). Valid types are 'full', 'clip' and 'filter'. If no type specified, 'clip' will be used ('full' used if clipping disabled). Multipe types can be provided separated by space")
         


### PR DESCRIPTION
`vcfwave` (used for vcf normalization) is a surprisingly large chunk of the runtime for some pangenome builds.  

One of the issues is that using `--vcfwaveCores` to boost the threads given to each `vcfwave` job actually makes it slower. 

This PR updates to my fork of `vcflib` where I've changed `vcfwave` to parallelize on vcf records (rather than inside the pairwise aligner).  Now `--vcfwaveCores` should give a nearly linear speedup.   I've also boosted the default value of `--vcfwaveCores` from 2 to 4 to take more advantage of this.  

See https://github.com/vcflib/vcflib/pull/449 