### PR TITLE
Better pangenome stats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,8 @@ testModules = \
     progressive/outgroupTest.py \
     preprocessor/cactus_preprocessorTest.py \
     preprocessor/lastzRepeatMasking/cactus_lastzRepeatMaskTest.py \
-    progressive/multiCactusTreeTest.py
+    progressive/multiCactusTreeTest.py \
+    refmap/cactus_panpatchTest.py
 
 # Unit tests (just collecting everything in bin/ with "test" in the name)
 unitTests = \

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,8 @@ testModules = \
     preprocessor/cactus_preprocessorTest.py \
     preprocessor/lastzRepeatMasking/cactus_lastzRepeatMaskTest.py \
     progressive/multiCactusTreeTest.py \
-    refmap/cactus_panpatchTest.py
+    refmap/cactus_panpatchTest.py \
+    refmap/pangenome_exclusionsTest.py
 
 # Unit tests (just collecting everything in bin/ with "test" in the name)
 unitTests = \

--- a/doc/pangenome.md
+++ b/doc/pangenome.md
@@ -294,9 +294,134 @@ Further reading:
 * `dist`: Snarl distance index required for `vg giraffe`.
 * `min`: Minimizer index required for `vg giraffe`.
 * `hapl` : Haplotype sampling index. Created with `--haplo` (new alternative to `--filter`) and used for new best practice `vg giraffe` pipeline.
-* `stats.tgz`: Some stats about how much sequence was clipped, including a BED file of the removed sequence.
+* `stats/`: Tables describing the graph and a complete accounting of input sequence that did *not* make it in. See [Statistics and Clipping Reports](#statistics-and-clipping-reports).
 * `og`: [odgi](https://github.com/pangenome/odgi)'s native format, can be read and written by `odgi`. Very useful for [visualization](#visualization).
 * `snarl-stats.tsv.gz`: Table with one row per snarl (bubble) in the graph, sorted in decreasing order of the distance they span on the (first) reference sample.  See the table header for a description of each column, and note that snarls can be nested in eachother.  This table is produced with the `--snarlStats` option.  
+#### Statistics and Clipping Reports
+
+Every run writes a `<outName>.stats/` directory describing what went into the graph and what did
+not, plus two files at the top level:
+
+```
+<outName>.WARNING                    only exists if something looks wrong -- see below
+<outName>.input-contig-sizes.tsv.gz  input contig lengths, as cactus saw them
+<outName>.stats/
+    clipped-by-genome.tsv               one row per input genome and reason
+    clipped-by-reference-contig.tsv     one row per genome per reference contig
+    clipped-by-input-contig.tsv.gz      one row per input contig
+    clipped.beds.tar.gz                 the intervals themselves, for the clipped graph
+    clipped.full.beds.tar.gz            ...for the full graph
+    clipped.d2.beds.tar.gz              ...for the frequency-filtered graph
+    graph-stats.tsv                     one row per reference contig: nodes, edges, length
+    path-stats.tsv.gz                   one row per path in the clipped graph
+    refgaps.bed.gz                      reference regions no other assembly aligns to
+```
+
+##### What "clipped" means here
+
+Any input base that is **not in the output graph**, whatever removed it. That is broader than the
+`--clip` phase alone, and the `reason` column says which stage was responsible:
+
+| reason | meaning |
+|-|-|
+| `ambiguous` | contig binned to `_AMBIGUOUS_` during chromosome splitting |
+| `unassigned` | contig that splitting made no decision about at all |
+| `no_chromosome_graph` | contig assigned to a reference contig no graph was built for (e.g. one left out of `--refContigs`) |
+| `unaligned` | contig reached its chromosome graph, but some of its sequence is not in the `full` graph |
+| `clip` | removed by the clip phase (`--clip`) |
+| `filter` | removed by the allele-frequency filter (`--filter`) |
+
+The first four mean the sequence is absent from **every** graph. Only phases that actually ran are
+reported: with the default options there is no frequency-filtered graph, so there are no `filter`
+rows and no `.d2` files. The report never causes a phase to run.
+
+##### The three tables
+
+They are the same accounting at three zoom levels, and all reconcile with each other.
+`clipped-by-genome.tsv` is the headline:
+
+```
+genome        reason      intervals  bp        pct_of_input
+UWOPS034614   ambiguous   4          3255663   27.714
+UWOPS034614   clip        15         389645    3.317
+UWOPS034614   TOTAL       25390      4067475   34.625
+```
+
+Every reason the run could measure gets a row for every genome, so a `0` means
+measured-and-nothing-lost, while a reason with no rows at all means that phase never ran.
+
+The other two say how much of the input survived into each graph, rather than what was lost, so the
+columns decrease left to right and the loss at any stage is the drop between adjacent `_bp` columns:
+
+```
+#ref_chrom  genome  contigs  input_bp  full_bp  full_frags  clip_bp  clip_frags  filter_bp  filter_frags
+chrI        SK1     1        228861    228861   1           214802   1           191745     869
+```
+
+`_frags` is how many contiguous pieces the sequence is broken into in that graph, so the example
+above shows clipping removing 14,059 bp while leaving one piece, then the frequency filter removing
+another 23,057 and shattering it into 869. A `ref_chrom` of `_NONE_` means the contig reached no
+chromosome graph at all.
+
+`clipped-by-input-contig.tsv.gz` is the same thing one level down, one row per input contig. It is
+most useful for fragmented assemblies, where a genome contributes many contigs to one reference
+contig; where each contig maps to its own reference contig it adds little over the rollup.
+
+##### The BED archives
+
+Each `clipped*.beds.tar.gz` unpacks to a directory of one plain 4-column BED per input genome, in
+input contig coordinates, usable with `bedtools` as-is:
+
+```
+chrVI      0        290867    unassigned
+chrI       0        17071     clip
+```
+
+They are cumulative, since each graph is built from the previous one: everything missing from the
+full graph is also missing from the clipped graph. So `clipped.beds.tar.gz` is what is not in the
+clipped graph -- the default output, and what most people want.
+
+The accounting is measured, not estimated: path coverage is read back out of each graph that was
+built and subtracted from the input contig lengths, so for every genome `bases in the graph + bases
+in that graph's BED == input bases`, exactly.
+
+##### Graph statistics
+
+`graph-stats.tsv` and `path-stats.tsv.gz` describe the clipped graph rather than what was clipped
+from it. `graph-stats.tsv` gives the size and complexity of each chromosome graph, where `length`
+is the total sequence in the graph -- much less than the sum of the inputs, because shared sequence
+is stored once. `path-stats.tsv.gz` has one row per path; a `[start-end]` suffix on a path name
+means it is a fragment of a longer input contig.
+
+##### Reference gaps
+
+`refgaps.bed.gz` is different in kind: the reference is never clipped, so it loses nothing. These
+are instead regions of the reference that **no other assembly aligns to** (runs of at least
+`refGapMinLength`, 10kb by default). This sequence is present in the graph and is never counted as
+clipped.
+
+##### `<outName>.WARNING`
+
+A run can finish successfully and still have gone badly wrong. If the accounting shows one of the
+shapes that usually means something is off, cactus writes `<outName>.WARNING` -- **the file only
+exists when there is something to say**, so its absence is the all-clear. It looks for a genome with
+a large fraction of itself in no graph at all, whole input contigs absent from every graph, one
+genome losing far more than the rest of the panel, a reference little of the panel aligns to, and an
+accounting that fails to add up.
+
+It deliberately stays quiet on losses that are uniform across the panel, since those reflect how the
+run was configured rather than a problem: dropping whole chromosomes with `--refContigs` and removing
+rare alleles with `--filter` both do that. Each note is a heuristic, so check it against your data --
+a genuinely rearranged assembly will trip the first one, correctly.
+
+##### Running `cactus-graphmap-join` on its own
+
+Pass `--inputContigSizes <outName>.input-contig-sizes.tsv.gz` from the `cactus-pangenome` run that
+produced the graphs. It is the only record of how much input sequence there was, so **without it no
+clipping report is written** -- only `refgaps.bed.gz` and the graph statistics, which do not depend
+on it. Measuring the graphs against each other instead would produce the same filenames and column
+names meaning something different, which is worse than producing nothing.
+
 #### Node Chopping
 
 As of [v2.9.1](https://github.com/ComparativeGenomicsToolkit/cactus/releases/tag/v2.9.1), all output graphs will have node IDs of at most 1024bp. This is because the `gbz` and `dist` indexes require this (they use 10bits for node offsets), and as a result so do an increasing number of `vg` tools. There is also a major benefit from the simplicity of having all output files sharing the same ID space.
@@ -586,7 +711,8 @@ ls -hs yeast-pg/yeast-pg*
  21M yeast-pg/yeast-pg.dist      103M yeast-pg/yeast-pg.min             4.3M yeast-pg/yeast-pg.vcf.gz
  38M yeast-pg/yeast-pg.full.hal  4.6M yeast-pg/yeast-pg.raw.vcf.gz      8.0K yeast-pg/yeast-pg.vcf.gz.tbi
  16M yeast-pg/yeast-pg.gbz       8.0K yeast-pg/yeast-pg.raw.vcf.gz.tbi
- 14M yeast-pg/yeast-pg.gfa.gz     16K yeast-pg/yeast-pg.stats.tgz
+ 14M yeast-pg/yeast-pg.gfa.gz     12K yeast-pg/yeast-pg.input-contig-sizes.tsv.gz
+4.0K yeast-pg/yeast-pg.stats
 
 zcat yeast-pg/yeast-pg.gfa.gz | grep '^W' | awk '{print $1 "\t" $2 "\t" $3 "\t" $4 "\t" $5 "\t" $6 }' | grep S288C
 W	S288C	0	chrIII	0	341580

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -480,6 +480,7 @@
 	<!-- minFilterFragment: discard fragments that result from the vg clip frequency filter if they are smaller than this -->
 	<!-- clipContext: use this many context steps when doing edge clipping (activated via delEdgeFilter cli option) -->	
 	<!-- removeStubs: remove any nodes dangling off reference paths (ie softclips) -->
+	<!-- refGapMinLength: minimum length of a reference gap (run of reference with no other assembly aligned) to report in the exclusion report. set to 0 to skip the reference gap scan entirely -->
 	<!-- odgiVizOptions: options to odgi viz, used for 1d viz -->
 	<!-- odgiLayoutOptions: options to odgi layout, used for 2d viz -->
 	<!-- odgiDrawOptions: options to odgi draw, used for 2d viz -->
@@ -501,6 +502,7 @@
 		 minFilterFragment="1000"
 		 clipContext="1000"
 		 removeStubs="1"
+		 refGapMinLength="10000"
 		 odgiVizOptions="-x 1500 -y 500 -a 10"
 		 odgiLayoutOptions="-x 50"
 		 odgiDrawOptions="-H 1000"

--- a/src/cactus/refmap/cactus_graphmap.py
+++ b/src/cactus/refmap/cactus_graphmap.py
@@ -655,10 +655,17 @@ def filter_paf(job, paf_id, config, reference=None):
     min_score = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap"), "minScore", typeFn=float, default=0)
     max_collapse_ratio = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap"), "maxCollapseDistanceRatio", typeFn=float, default=-1)
     RealtimeLogger.info("Running PAF filter with minBlock={} minMAPQ={} minIdentity={} minScore={} maxCollapseDistanceRatio={}".format(min_block, min_mapq, min_ident, min_score, max_collapse_ratio))
+    # a contig whose alignments are all filtered out here vanishes from everything downstream: it
+    # reaches neither rgfa-split's coverage map nor any chromosome, so it is never assigned, never
+    # binned ambiguous, and never logged.  count what goes in and what survives so it can be said
+    # out loud rather than inferred from a missing output fasta at the end of the run.
+    query_line_counts = {}
+    query_kept_counts = {}
     with open(paf_path, 'r') as paf_file, open(filter_paf_path, 'w') as filter_paf_file:
         for line in paf_file:
             toks = line.split('\t')
             query_name = toks[0]
+            query_line_counts[query_name] = query_line_counts.get(query_name, 0) + 1
             target_name = toks[5]
             is_ref = reference and query_name.startswith('id={}|'.format(reference)) and query_name != target_name
             mapq = int(toks[11])
@@ -689,6 +696,16 @@ def filter_paf(job, paf_id, config, reference=None):
             if is_ref or (mapq >= min_mapq and (bl is None or query_len <= min_block or bl >= min_block) and ident >= min_ident and \
                           (score is None or score >= min_score) and (collapse_ratio is None or collapse_ratio <= max_collapse_ratio)):
                 filter_paf_file.write(line)
+                query_kept_counts[query_name] = query_kept_counts.get(query_name, 0) + 1
+
+    eliminated = sorted(q for q, n in query_line_counts.items() if not query_kept_counts.get(q))
+    if eliminated:
+        RealtimeLogger.warning(
+            'PAF filter removed every alignment of {} query contig(s), which will therefore be '
+            'absent from all output graphs without appearing in any chromosome or in the ambiguous '
+            'bin. The usual cause is minGAFBlockLength={} exceeding the contig\'s longest alignment '
+            'block (contigs shorter than that are exempt). Contigs: {}'.format(
+                len(eliminated), min_block, ', '.join(eliminated[:20])))
 
     overlap_ratio = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap"), "PAFOverlapFilterRatio", typeFn=float, default=0)
     length_ratio = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap"), "PAFOverlapFilterMinLengthRatio", typeFn=float, default=0)

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -55,6 +55,8 @@ from toil.statsAndLogging import set_logging_from_options
 from toil.realtimeLogger import RealtimeLogger
 from cactus.shared.common import cactus_cpu_count
 from cactus.refmap.cactus_minigraph import check_sample_names
+from cactus.refmap.pangenome_exclusions import path_coverage_job, ref_gaps_job, compute_exclusions_job
+from cactus.refmap.pangenome_exclusions import check_baseline_header
 from cactus.progressive.cactus_prepare import human2bytesN
 
 from sonLib.nxnewick import NXNewick
@@ -130,6 +132,16 @@ def main():
     # Mess with some toil options to create useful defaults.
     cactus_override_toil_options(options)
 
+    # say this up front rather than at the end of the join, when it is too late to add the option.
+    # only reachable here: cactus-pangenome computes the sizes itself and never comes through main()
+    if not options.inputContigSizes:
+        logger.warning(
+            'No --inputContigSizes given, so NO CLIPPING REPORT will be written: measuring how much '
+            'input sequence is missing from the graphs needs the input contig lengths, and the '
+            'graphs alone do not carry them. Pass --inputContigSizes '
+            '<outDir>/<outName>.input-contig-sizes.tsv.gz from the cactus-pangenome run that '
+            'produced these graphs. Reference gaps and the graph statistics are written either way.')
+
     logger.info('Cactus Command: {}'.format(' '.join(sys.argv)))
     logger.info('Cactus Commit: {}'.format(cactus_commit))
     start_time = timeit.default_timer()
@@ -183,6 +195,16 @@ def graphmap_join_options(parser):
                         help="Memory in bytes for each indexing and vcf construction job (defaults to an estimate based on the input data size). If specified will also be used to upper-bound per-chromosome memory estimates -- ie no job will request more than this much memory."
                         "Standard suffixes like K, Ki, M, Mi, G or Gi are supported (default=bytes))", default=None)   
     
+    parser.add_argument("--inputContigSizes", type=str, default=None,
+                        help="Contig size table written by cactus-pangenome as "
+                        "<outDir>/<outName>.input-contig-sizes.tsv.gz. Only needed when running "
+                        "cactus-graphmap-join standalone, where it is the only way to know how much "
+                        "input sequence there was: without it no exclusion report is produced (only "
+                        "the reference gaps, which do not depend on it). Has no effect with "
+                        "--vgFull/--vgClip/--vgFilter, which produce no exclusion report either way. "
+                        "NOTE: this is not the same file as "
+                        "<outDir>/chrom-subproblems/contig_sizes.tsv.")
+
     parser.add_argument("--collapse", help = "Incorporate minimap2 self-alignments.", action='store_true', default=False)
 
     parser.add_argument("--delEdgeFilter", type=int, default=None, help = "Remove edges that span more than Nbp on the reference genome (vg clip -D). Applied during clipping.")
@@ -214,6 +236,12 @@ def graphmap_join_defaults(options):
 
 def graphmap_join_validate_options(options):
     """ make sure the options make sense and fill in sensible defaults """
+
+    # the exclusion report only reads this table in its very last job, so check it here instead:
+    # the easy mistake is passing chrom-subproblems/contig_sizes.tsv, which lives in the same output
+    # tree, and finding out about it after the whole join has run
+    if getattr(options, 'inputContigSizes', None) and not options.inputContigSizes.startswith('s3://'):
+        check_baseline_header(options.inputContigSizes)
 
     # detect bypass mode
     vg_full = getattr(options, 'vgFull', None)
@@ -576,6 +604,11 @@ def graphmap_join(options):
             for sv_gfa_path in options.sv_gfa:
                 sv_gfa_ids.append(toil.importFile(makeURL(sv_gfa_path)))
 
+            # optional baseline for the exclusion report
+            contig_sizes_id = None
+            if options.inputContigSizes:
+                contig_sizes_id = toil.importFile(makeURL(options.inputContigSizes))
+
             if options.bypass:
                 bypass_full_ids = [toil.importFile(makeURL(p)) for p in options._vgFull_paths]
                 bypass_clip_ids = [toil.importFile(makeURL(p)) for p in options._vgClip_paths]
@@ -583,7 +616,8 @@ def graphmap_join(options):
                 vg_ids = bypass_full_ids or bypass_clip_ids or bypass_filter_ids
                 wf_output = toil.start(Job.wrapJobFn(graphmap_join_workflow, options, config,
                                                       vg_ids, hal_ids, sv_gfa_ids,
-                                                      bypass_full_ids, bypass_clip_ids, bypass_filter_ids))
+                                                      bypass_full_ids, bypass_clip_ids, bypass_filter_ids,
+                                                      contig_sizes_id=contig_sizes_id))
             else:
                 # load up the vgs
                 vg_ids = []
@@ -591,10 +625,13 @@ def graphmap_join(options):
                     vg_ids.append(toil.importFile(makeURL(vg_path)))
 
                 # run the workflow
-                wf_output = toil.start(Job.wrapJobFn(graphmap_join_workflow, options, config, vg_ids, hal_ids, sv_gfa_ids))
-                
+                wf_output = toil.start(Job.wrapJobFn(graphmap_join_workflow, options, config, vg_ids,
+                                                     hal_ids, sv_gfa_ids,
+                                                     contig_sizes_id=contig_sizes_id))
+
         #export the split data
-        export_join_data(toil, options, wf_output[0], wf_output[1], wf_output[2], wf_output[3], wf_output[4], wf_output[5])
+        export_join_data(toil, options, wf_output[0], wf_output[1], wf_output[2], wf_output[3], wf_output[4], wf_output[5],
+                         wf_output[6])
 
 def vcflib_checks(job, options, config_node):
     """ run the vcflib checks"""
@@ -613,7 +650,8 @@ def vcflib_checks(job, options, config_node):
     return job
         
 def graphmap_join_workflow(job, options, config, vg_ids, hal_ids, sv_gfa_ids,
-                           bypass_full_ids=None, bypass_clip_ids=None, bypass_filter_ids=None):
+                           bypass_full_ids=None, bypass_clip_ids=None, bypass_filter_ids=None,
+                           contig_sizes_id=None, split_log_id=None):
 
     root_job = Job()
     job.addChild(root_job)
@@ -794,10 +832,22 @@ def graphmap_join_workflow(job, options, config, vg_ids, hal_ids, sv_gfa_ids,
             workflow_phases.append(('clip', clip_vg_ids, clip_root_job))
         if options.filter:
             workflow_phases.append(('filter', filter_vg_ids, filter_root_job))
+    # Account for input sequence that isn't in the output graphs.  This only ever measures the
+    # phases that were actually built -- it never causes a phase to run.
+    #
+    # Skipped entirely in two cases.  cactus-panpatch throws the join output away, so there is
+    # nothing to measure.  And bypass mode starts from graphs that were already clipped elsewhere:
+    # with no earlier phase to difference against, every class is unmeasurable, and a report saying
+    # so with empty BED files is worse than no report -- it reads as "nothing was excluded" on runs
+    # where megabases were.
+    exclusion_coverage = {}
+    exclusion_refgap_ids = {}
+    do_exclusions = not getattr(options, 'noJoinExport', False) and not options.bypass
+
     for workflow_phase, phase_vg_ids, phase_root_job in workflow_phases:
-            
+
         # make a gfa for each
-        gfa_root_job = Job()        
+        gfa_root_job = Job()
         phase_root_job.addFollowOn(gfa_root_job)
         gfa_ids = []
         current_out_dict = None
@@ -986,7 +1036,60 @@ def graphmap_join_workflow(job, options, config, vg_ids, hal_ids, sv_gfa_ids,
                                                             disk=sum(f.size for f in vg_ids))
         out_dicts.append(gref_segs_merge_job.rv())
 
-    return output_full_vg_ids, clip_vg_ids, clipped_stats, filter_vg_ids, out_dicts, og_chrom_ids
+    # All of the exclusion work hangs off one barrier, and that barrier is a descendant of
+    # root_job -- which is a child of `job`.  That placement is load-bearing: export_join_data is
+    # invoked from a follow-on of `job` (cactus_pangenome.py), and a job's follow-ons only run once
+    # its entire child subtree is done.  Hanging this off `job` directly instead would make the two
+    # siblings in the same phase, and the export would deserialise an unresolved promise and fail.
+    exclusion_ids = None
+    if do_exclusions and workflow_phases:
+        deepest_phase, deepest_vg_ids, deepest_root_job = workflow_phases[-1]
+        excl_root_job = Job()
+        deepest_root_job.addFollowOn(excl_root_job)
+
+        exclusion_coverage = {}
+        for workflow_phase, phase_vg_ids, _phase_root_job in workflow_phases:
+            phase_coverage = []
+            assert len(options.vg) == len(phase_vg_ids)
+            for vg_path, phase_vg_id, input_vg_id in zip(options.vg, phase_vg_ids, vg_ids):
+                chrom_name = os.path.splitext(os.path.basename(vg_path))[0]
+                cov_job = excl_root_job.addChildJobFn(
+                    path_coverage_job, config, vg_path, phase_vg_id, chrom_name, workflow_phase,
+                    disk=input_vg_id.size * 3,
+                    memory=cactus_clamp_memory(min(max(2**31, input_vg_id.size * 6), max_mem)))
+                phase_coverage.append((cov_job.rv(0), cov_job.rv(1), cov_job.rv(2), cov_job.rv(3)))
+            exclusion_coverage[workflow_phase] = phase_coverage
+
+        # the reference is never clipped, so its exclusions can't be measured by absence.  They're
+        # inferred instead as runs with no other assembly aligned, on the deepest graph built.
+        ref_gap_min = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_join"),
+                                        "refGapMinLength", typeFn=int, default=10000)
+        if ref_gap_min > 0 and options.reference:
+            ref_event = options.reference[0]
+            gap_ids = []
+            for vg_path, phase_vg_id, input_vg_id in zip(options.vg, deepest_vg_ids, vg_ids):
+                chrom_name = os.path.splitext(os.path.basename(vg_path))[0]
+                gap_job = excl_root_job.addChildJobFn(
+                    ref_gaps_job, config, options, vg_path, phase_vg_id, chrom_name, ref_event,
+                    deepest_phase == 'full',
+                    disk=input_vg_id.size * 4,
+                    memory=cactus_clamp_memory(min(max(2**31, input_vg_id.size * 8), max_mem)))
+                gap_ids.append(gap_job.rv())
+            exclusion_refgap_ids[ref_event] = gap_ids
+
+        chrom_names = [os.path.splitext(os.path.basename(p))[0] for p in options.vg]
+        # this job streams one chromosome at a time, so its peak memory tracks the largest
+        # chromosome rather than the whole panel.  the frequency filter can still fragment a
+        # chromosome into ~10^3 intervals per Mbp of reference, hence the generous multiple.
+        exclusion_job = excl_root_job.addFollowOnJobFn(
+            compute_exclusions_job, config, options, exclusion_coverage, contig_sizes_id,
+            split_log_id, exclusion_refgap_ids, chrom_names,
+            disk=sum(f.size for f in vg_ids) * 2,
+            memory=cactus_clamp_memory(min(max(2**31, max(f.size for f in vg_ids) * 16), max_mem)))
+        exclusion_ids = exclusion_job.rv()
+
+    return (output_full_vg_ids, clip_vg_ids, clipped_stats, filter_vg_ids, out_dicts, og_chrom_ids,
+            exclusion_ids)
 
 def clip_vg(job, options, config, vg_path, vg_id, phase):
     """ run clip-vg 
@@ -998,7 +1101,6 @@ def clip_vg(job, options, config, vg_path, vg_id, phase):
     job.fileStore.readGlobalFile(vg_id, vg_path)
 
     clipped_path = vg_path + '.clip'
-    clipped_bed_path = vg_path + '.clip.bed'
 
     join_xml_node = findRequiredNode(config.xmlRoot, "graphmap_join")
     graph_event = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap"), "assemblyName", default="_MINIGRAPH_")
@@ -1041,7 +1143,6 @@ def clip_vg(job, options, config, vg_path, vg_id, phase):
             clip_vg_cmd += ['-u', str(options.clip)]
             if getOptionalAttrib(join_xml_node, "clipNonMinigraph", typeFn=bool, default=True):
                 clip_vg_cmd += ['-a', graph_event]
-            clip_vg_cmd += ['-o', clipped_bed_path]
 
     # disable reference cycle check if desiired
     if getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap"), "collapse", typeFn=str, default="none") in ["all", "reference"]:
@@ -1079,8 +1180,11 @@ def clip_vg(job, options, config, vg_path, vg_id, phase):
             # todo: do we want to add the minigraph prefix to keep stubs from minigraph? but I don't think it makes stubs....
             cmd.append(stub_cmd)
 
-        # Optional deletion-edge filter to go after huge snarls that may negatively impact giraffe
-        if options.delEdgeFilter:
+        # Optional deletion-edge filter to go after huge snarls that may negatively impact giraffe.
+        # clip-phase only: the clip graph is built from the full graph, so running it in both phases
+        # just repeats the same work, and removals made in "full" would be indistinguishable from
+        # sequence that never aligned at all in the exclusion report.
+        if phase == 'clip' and options.delEdgeFilter:
             clip_context = getOptionalAttrib(join_xml_node, "clipContext", typeFn=int, default=0)
             min_fragment = getOptionalAttrib(join_xml_node, "minFilterFragment", typeFn=int, default=0)
             del_clip_cmd = ['vg', 'clip', '-', '-D', str(options.delEdgeFilter), '-P', options.reference[0]]
@@ -1110,35 +1214,23 @@ def clip_vg(job, options, config, vg_path, vg_id, phase):
         cactus_call(parameters=[['vg', 'paths', '-E', '-v', clipped_path],
                                 ['awk', '{{print "{}\t" $0}}'.format(chr_name)]],
                     outfile=path_stats_path)
-        # Nodes, edges and total length
+        # Nodes, edges and total length.  vg prints these one per line; transpose to a single row
+        # per chromosome so the table can be read as a table
         graph_stats_path = vg_path + '.graph-stats.tsv'
-        cactus_call(parameters=[['vg', 'stats', '-l', '-z', clipped_path],
-                                ['awk', '{{print "{}\t" $0}}'.format(chr_name)]],
-                    outfile=graph_stats_path)
-        # Stick the contig identifier onto the clipped regions bed
-        clipped_bed_chr_path = clipped_bed_path + '.named'
-        cactus_call(parameters=['awk',  '{{print $0 "\t{}"}}'.format(chr_name), clipped_bed_path],
-                    outfile=clipped_bed_chr_path)
-        sample_stats_path = vg_path + '.sample-stats.tsv'
-        sample_stats = {}
-        with open(path_stats_path, 'r') as path_stats_file:
-            for line in path_stats_file:
-                toks = line.split()
-                contig_name = toks[1]
-                contig_length = int(toks[2])
-                sample_name = contig_name if '#' not in contig_name else '#'.join(contig_name.split('#')[:2])
-                if sample_name not in sample_stats:
-                    sample_stats[sample_name] = contig_length
-                else:
-                    sample_stats[sample_name] += contig_length
-        with open(sample_stats_path, 'w') as sample_stats_file:
-            for sample in sorted(sample_stats.keys()):
-                sample_stats_file.write("{}\t{}\t{}\n".format(chr_name, sample, sample_stats[sample]))
-
-        out_stats = { 'clip-stats.bed' : job.fileStore.writeGlobalFile(clipped_bed_chr_path),
-                      'path-stats.tsv' : job.fileStore.writeGlobalFile(path_stats_path),
-                      'graph-stats.tsv' : job.fileStore.writeGlobalFile(graph_stats_path),
-                      'sample-stats.tsv' : job.fileStore.writeGlobalFile(sample_stats_path) }
+        vg_stats = cactus_call(parameters=['vg', 'stats', '-l', '-z', clipped_path], check_output=True)
+        stat_of = {}
+        for stat_line in vg_stats.split('\n'):
+            toks = stat_line.split()
+            if len(toks) == 2:
+                stat_of[toks[0]] = toks[1]
+        with open(graph_stats_path, 'w') as graph_stats_file:
+            graph_stats_file.write('{}\t{}\t{}\t{}\n'.format(
+                chr_name, stat_of.get('nodes', 'NA'), stat_of.get('edges', 'NA'),
+                stat_of.get('length', 'NA')))
+        # sample-stats and contig-stats are written by the exclusion report instead: they need the
+        # input contig lengths, which are not available here
+        out_stats = { 'path-stats.tsv' : job.fileStore.writeGlobalFile(path_stats_path),
+                      'graph-stats.tsv' : job.fileStore.writeGlobalFile(graph_stats_path) }
     else:
         out_stats = None
     return job.fileStore.writeGlobalFile(clipped_path), out_stats
@@ -2292,23 +2384,71 @@ def cat_bed_files(job, bed_ids):
             ofile.write(line)    
     return job.fileStore.writeGlobalFile(renamed_bed_path)
 
-def cat_stats(job, stats_dict_list, zip_stats=True):
+# the per-chromosome stats tables have no self-describing columns otherwise, and the tables are
+# concatenated from one file per chromosome, so the header can only be added once at the end
+STATS_HEADERS = {
+    'path-stats.tsv': '#ref_chrom\tpath\tlength',
+    'graph-stats.tsv': '#ref_chrom\tnodes\tedges\tlength',
+}
+
+# path-stats has a row per surviving path fragment, which runs to millions on a filtered graph.
+# graph-stats is one row per chromosome and is handier left readable
+STATS_GZIP = {'path-stats.tsv'}
+
+
+def cat_stats(job, stats_dict_list):
     work_dir = job.fileStore.getLocalTempDir()
+    stats_dir = os.path.join(work_dir, 'stats')
+    os.makedirs(stats_dir, exist_ok=True)
     merged_dict = {}
     for key in stats_dict_list[0].keys():
-        merged_dict[key] = os.path.join(work_dir, key)
+        merged_dict[key] = os.path.join(stats_dir, key)
         catFiles([job.fileStore.readGlobalFile(sd[key]) for sd in stats_dict_list], merged_dict[key])
-    if zip_stats:
-        cactus_call(parameters=['tar', 'czf', os.path.join(work_dir, 'stats.tgz')] + list(merged_dict.values()))
-        return { 'stats.tgz': job.fileStore.writeGlobalFile(os.path.join(work_dir, 'stats.tgz')) }
-    else:
-        for key in stats_dict_list[0].keys():
-            merged_dict[key] = job.fileStore.writeGlobalFile(merged_dict[key])
-        return merged_dict
+        if key in STATS_HEADERS:
+            with open(merged_dict[key], 'r') as body_file:
+                body = body_file.read()
+            with open(merged_dict[key], 'w') as out_file:
+                out_file.write(STATS_HEADERS[key] + '\n')
+                out_file.write(body)
+    out_dict = {}
+    for key in stats_dict_list[0].keys():
+        if key in STATS_GZIP:
+            cactus_call(parameters=['gzip', '-f', merged_dict[key]])
+            out_dict[key + '.gz'] = job.fileStore.writeGlobalFile(merged_dict[key] + '.gz')
+        else:
+            out_dict[key] = job.fileStore.writeGlobalFile(merged_dict[key])
+    return out_dict
 
-def export_join_data(toil, options, full_ids, clip_ids, clip_stats, filter_ids, idx_maps, og_chrom_ids):
+def export_join_data(toil, options, full_ids, clip_ids, clip_stats, filter_ids, idx_maps, og_chrom_ids,
+                     exclusion_ids=None):
     """ download all the output data
     """
+
+    # everything that describes the run rather than being part of the graph goes in one directory.
+    # the per-genome BED archives are the exception: they stay whole at the top level so that "what
+    # is missing from the graph I am using" is a single file to download or pass on.
+    stats_dir = os.path.join(options.outDir, '{}.stats'.format(options.outName))
+    if (clip_stats or exclusion_ids) and not stats_dir.startswith('s3://') \
+       and not os.path.isdir(stats_dir):
+        os.makedirs(stats_dir)
+
+    if exclusion_ids:
+        for name, file_id in exclusion_ids['missing'].items():
+            toil.exportFile(file_id, makeURL(os.path.join(stats_dir, name)))
+        for name, file_id in exclusion_ids['refgaps'].items():
+            toil.exportFile(file_id, makeURL(os.path.join(stats_dir, name)))
+        for name in ['clipped-by-input-contig.tsv.gz', 'clipped-by-reference-contig.tsv']:
+            if exclusion_ids.get(name):
+                toil.exportFile(exclusion_ids[name], makeURL(os.path.join(stats_dir, name)))
+        # absent when there was no input contig-size table to measure the graphs against
+        if exclusion_ids.get('summary.tsv'):
+            toil.exportFile(exclusion_ids['summary.tsv'],
+                            makeURL(os.path.join(stats_dir, 'clipped-by-genome.tsv')))
+        # this one goes at the top level: its whole job is to be impossible to miss, and it only
+        # exists when something in the accounting looks wrong
+        if exclusion_ids.get('WARNING'):
+            toil.exportFile(exclusion_ids['WARNING'],
+                            makeURL(os.path.join(options.outDir, '{}.WARNING'.format(options.outName))))
 
     # make a directory for the chromosomal vgs
     if options.chrom_vg:
@@ -2376,10 +2516,10 @@ def export_join_data(toil, options, full_ids, clip_ids, clip_stats, filter_ids, 
                     draw_name = os.path.splitext(vg_path)[0] + '{}.draw.png'.format('.' + tag if tag != 'clip' else '')
                     toil.exportFile(draw_id, makeURL(os.path.join(viz_base, os.path.basename(draw_name))))
                 
-    # download the stats files
+    # the per-chromosome graph tables join them there
     if clip_stats:
         for stats_file in clip_stats.keys():
-            toil.exportFile(clip_stats[stats_file], makeURL(os.path.join(options.outDir, '{}.{}'.format(options.outName, stats_file))))
+            toil.exportFile(clip_stats[stats_file], makeURL(os.path.join(stats_dir, stats_file)))
         
     # download everything else
     for idx_map in idx_maps:

--- a/src/cactus/refmap/cactus_pangenome.py
+++ b/src/cactus/refmap/cactus_pangenome.py
@@ -48,6 +48,7 @@ from cactus.refmap.cactus_graphmap import apply_mgsplit_filter_overrides
 from cactus.refmap.cactus_graphmap_split import graphmap_split_workflow, export_split_data
 from cactus.setup.cactus_align import make_batch_align_jobs, batch_align_jobs
 from cactus.refmap.cactus_graphmap_join import graphmap_join_workflow, export_join_data, graphmap_join_options, graphmap_join_validate_options, vcflib_checks
+from cactus.refmap.pangenome_exclusions import contig_sizes_job
 
 def pangenome_options(parser):
     """ the options that drive the end-to-end pangenome workflow, everything except the
@@ -474,9 +475,17 @@ def export_align_wrapper(job, options, results_dict):
 
     return join_options, vg_ids, hal_ids
 
-def export_join_wrapper(job, options, wf_output):
+def export_join_wrapper(job, options, wf_output, contig_sizes_id=None):
     """ toil join wrapper for cactus_graphmap_join """
-    export_join_data(job.fileStore, options, wf_output[0], wf_output[1], wf_output[2], wf_output[3], wf_output[4], wf_output[5])
+    export_join_data(job.fileStore, options, wf_output[0], wf_output[1], wf_output[2], wf_output[3], wf_output[4], wf_output[5],
+                     wf_output[6])
+    # the baseline table is exported alongside the report so that a later standalone
+    # cactus-graphmap-join can be given it with --inputContigSizes
+    if contig_sizes_id:
+        # top level rather than in stats/: it is an intermediate of the pipeline, not a report,
+        # and it is what --inputContigSizes wants handed back to it
+        sizes_path = os.path.join(options.outDir, '{}.input-contig-sizes.tsv.gz'.format(options.outName))
+        job.fileStore.exportFile(contig_sizes_id, makeURL(sizes_path))
 
 def pangenome_end_to_end_workflow(job, options, config_wrapper, seq_id_map, seq_path_map, seq_order, ref_collapse_paf_id,
                                   last_scores_id):
@@ -491,6 +500,21 @@ def pangenome_end_to_end_workflow(job, options, config_wrapper, seq_id_map, seq_
     # sanitize headers (once here, skip in all workflows below)
     sanitize_job = root_job.addFollowOnJobFn(sanitize_fasta_headers, seq_id_map, pangenome=True)
     seq_id_map = sanitize_job.rv()
+
+    # snapshot the input contig sizes while the sanitized fastas still exist: they are the baseline
+    # the exclusion report measures the output graphs against, and they are cleaned out of the
+    # jobstore once splitting is done.  chained (rather than run alongside) so it cannot race that
+    # cleanup.  the graph event isn't in seq_id_map yet -- update_seqfile adds it further down.
+    # skipped when the join output is discarded (cactus-panpatch), where no report is written and
+    # this would be one faidx per genome for nothing.
+    contig_sizes_id = None
+    prev_job = sanitize_job
+    if not options.noJoinExport:
+        prev_job = sanitize_job.addFollowOnJobFn(
+            contig_sizes_job, seq_id_map,
+            getOptionalAttrib(findRequiredNode(config_node, "graphmap"), "assemblyName",
+                              default="_MINIGRAPH_"))
+        contig_sizes_id = prev_job.rv()
 
     assert type(options.reference) == list
 
@@ -514,7 +538,7 @@ def pangenome_end_to_end_workflow(job, options, config_wrapper, seq_id_map, seq_
     else:
         split_config_node = config_node
         split_config_wrapper = config_wrapper
-    minigraph_job = sanitize_job.addFollowOnJobFn(minigraph_construct_workflow, mg_options, split_config_node, seq_id_map, seq_order, sv_gfa_path, sanitize=False)
+    minigraph_job = prev_job.addFollowOnJobFn(minigraph_construct_workflow, mg_options, split_config_node, seq_id_map, seq_order, sv_gfa_path, sanitize=False)
     sv_gfa_id = minigraph_job.rv(0)
     pansn_sv_gfa_id = minigraph_job.rv(1)
     if not last_scores_id:
@@ -544,11 +568,15 @@ def pangenome_end_to_end_workflow(job, options, config_wrapper, seq_id_map, seq_
         phony_chromfile_job = update_seqfile_job.addFollowOnJobFn(phony_chromfile, options, paf_path)
         chromfile_path = phony_chromfile_job.rv()
         split_export_job = phony_chromfile_job
+        # nothing is binned or dropped without a split, so the exclusion report has no split log
+        # to attribute causes with
+        split_log_id = None
     else:
         # cactus_graphmap_split
         split_job = update_seqfile_job.addFollowOnJobFn(graphmap_split_workflow, options, split_config_wrapper, seq_id_map, seq_name_map, sv_gfa_id,
                                                         sv_gfa_path, paf_id, paf_path, sanitize=False, pansn_gfa_input=False)
         wf_output = split_job.rv()
+        split_log_id = split_job.rv(2)
         split_out_path = os.path.join(options.outDir, 'chrom-subproblems')
         split_export_job = split_job.addFollowOnJobFn(export_split_wrapper, wf_output, split_out_path, split_config_wrapper)
         chromfile_path = os.path.join(split_out_path, 'chromfile.txt')
@@ -608,7 +636,9 @@ def pangenome_end_to_end_workflow(job, options, config_wrapper, seq_id_map, seq_
     # hal_ids, and it's also the only thing that frees the chromosome hals from the jobstore, so we
     # need to do that ourselves here or they'd leak for the rest of the run
     join_job = align_export_job.addFollowOnJobFn(graphmap_join_workflow, join_options, config_wrapper, vg_ids,
-                                                 [] if options.noHal else hal_ids, minigraph_pansn_sv_gfa_ids)
+                                                 [] if options.noHal else hal_ids, minigraph_pansn_sv_gfa_ids,
+                                                 contig_sizes_id=contig_sizes_id,
+                                                 split_log_id=split_log_id)
     join_wf_output = join_job.rv()
     if options.noHal:
         join_job.addFollowOnJobFn(clean_jobstore_files, file_ids=hal_ids)
@@ -617,7 +647,8 @@ def pangenome_end_to_end_workflow(job, options, config_wrapper, seq_id_map, seq_
     # would write, given it turns every other output off), so let it skip this to avoid writing
     # the biggest output twice
     if not options.noJoinExport:
-        join_job.addFollowOnJobFn(export_join_wrapper, join_options, join_wf_output)
+        join_job.addFollowOnJobFn(export_join_wrapper, join_options, join_wf_output,
+                                  contig_sizes_id=contig_sizes_id)
 
     return join_options, join_wf_output, seq_id_map
         

--- a/src/cactus/refmap/pangenome_exclusions.py
+++ b/src/cactus/refmap/pangenome_exclusions.py
@@ -1,0 +1,1157 @@
+#!/usr/bin/env python3
+
+"""
+Accounting for input sequence that does not make it into the output pangenome graphs.
+
+Sequence goes missing between the input FASTAs and the output graphs in several ways: whole contigs
+binned to _AMBIGUOUS_ (or dropped without any log record) during chromosome splitting, fragments
+removed by clip-vg and the vg clip stages that follow it, and fragments removed by the allele
+frequency (depth) filter.  None of these were reported completely, and clip-vg's own --out-bed is
+wrong whenever paths carry subranges, which in cactus they always do after the "full" phase.
+
+The method here does not trust any of those tools' self-reports.  For every phase graph the workflow
+actually produced, path coverage is read back with `vg paths -E`, projected into input-contig
+coordinates, and subtracted from a baseline built from the sanitized input FASTAs.  Because the
+phases are strictly nested (filter subset of clip subset of full subset of input), each lost base is
+attributed to the phase boundary at which it disappeared, by set subtraction alone -- no heuristics.
+
+This module holds the pure, Toil-free half: name parsing, interval algebra and file parsing.  The
+job functions that drive it live alongside in cactus_graphmap_join.py.
+"""
+
+import gzip
+import logging
+import os
+import re
+import shutil
+
+from cactus.shared.common import cactus_call, getOptionalAttrib, findRequiredNode
+from toil.realtimeLogger import RealtimeLogger
+
+logger = logging.getLogger(__name__)
+
+# every baseline table starts with exactly this line.  it is checked on read because
+# <outDir>/chrom-subproblems/contig_sizes.tsv is a completely different (chromosome x sample matrix)
+# file living in the same output tree, and feeding it to this parser would otherwise silently
+# produce a nonsense baseline and a 100%-loss report
+BASELINE_HEADER = '#event\tpansn_prefix\tbase_contig\toffset\tlength'
+
+# written above the header so the table explains itself
+BASELINE_PREAMBLE = [
+    '# input contig lengths, as cactus saw them after sanitizing the fasta headers.',
+    '# pansn_prefix    SAMPLE#HAP, the prefix this genome carries in the graph',
+    '# base_contig     contig name in the graph, and in the exclusion BED files',
+    '# offset, length  where this piece sits in base_contig. a contig that arrived whole is one',
+    '#                 row at offset 0; one that arrived in fragments is several rows',
+]
+
+
+def open_maybe_gzip(path, mode='rt'):
+    """ the baseline table is written gzipped, but accept it either way: users hand this file back
+    with --inputContigSizes and may well have decompressed it """
+    with open(path, 'rb') as probe:
+        gzipped = probe.read(2) == b'\x1f\x8b'
+    return gzip.open(path, mode) if gzipped else open(path, mode)
+
+# reason tokens used in column 4 of the emitted BED files.  bare tokens, no whitespace, so that
+# column 4 remains a legal BED name field
+REASON_AMBIGUOUS = 'ambiguous'
+REASON_UNASSIGNED = 'unassigned'
+REASON_NO_CHROM_GRAPH = 'no_chromosome_graph'
+REASON_UNALIGNED = 'unaligned'
+REASON_CLIP = 'clip'
+REASON_FILTER = 'filter'
+REASON_REFGAP = 'refgap'
+
+# stand-in chromosome for contigs that reached no chromosome graph at all, so that per-chromosome
+# tables still sum to the per-genome totals
+NO_CHROMOSOME = '_NONE_'
+
+# a phase's name doubles as the reason token for sequence it removed.  spelled out rather than left
+# implicit so that renaming a phase cannot silently rename a column-4 value users filter on
+PHASE_REASON = {'clip': REASON_CLIP, 'filter': REASON_FILTER}
+
+# sequence lost before any graph was built.  absent from every graph, whichever one you look at
+DROPPED_REASONS = (REASON_AMBIGUOUS, REASON_UNASSIGNED, REASON_NO_CHROM_GRAPH, REASON_UNALIGNED)
+
+# each graph is built from the previous one, so exclusions accumulate: what is missing from the
+# clipped graph is everything missing from the full graph plus what clipping took, and so on
+PHASE_REASONS = {'full': frozenset(DROPPED_REASONS),
+                 'clip': frozenset(DROPPED_REASONS) | {REASON_CLIP},
+                 'filter': frozenset(DROPPED_REASONS) | {REASON_CLIP, REASON_FILTER}}
+
+
+def phase_tag(phase, filter_threshold=None):
+    """ the infix cactus uses for a phase's output files: clip is the unsuffixed default, the full
+    graph gets .full, and the frequency-filtered graph gets .dN """
+    if phase == 'clip':
+        return ''
+    if phase == 'full':
+        return '.full'
+    return '.d{}'.format(filter_threshold)
+
+# vg depth prints one line per reference base as `path <TAB> 1-based-pos <TAB> depth`, which is far
+# too much to hand to python for a whole genome.  this reduces it to the zero-depth positions in the
+# pipe, as refgaps.sh does, and converts 1-based positions to 0-based half-open BED in the same
+# step: base p becomes [p-1, p), so a run p..q merges to [p-1, q) -- width preserved, and it can
+# never extend past the end of the contig
+DEPTH_TO_BED_AWK = '$3==0 {print $1 "\t" ($2-1) "\t" $2}'
+
+_SUBRANGE_RE = re.compile(r'^(.*)\[(\d+)-(\d+)\]$')
+_SPLIT_ASSIGNED_RE = re.compile(r'^Assigned (?:ref-)?contig to (\S+): id=([^|]+)\|(\S+)\s')
+_SPLIT_AMBIGUOUS_RE = re.compile(r'^Query contig is ambiguous: id=([^|]+)\|(\S+)\s')
+
+
+def resolve_subpath_naming(name):
+    """ python port of hal2vg's resolve_subpath_naming (hal2vg.cpp).  cactus encodes a contig
+    fragment as <CONTIG>_sub_<START>_<END>, and hal2vg turns that back into a path on <CONTIG> with
+    subrange [START-END].  the encoding nests, in which case the offsets sum and the length is the
+    innermost (first-parsed) one.
+
+    returns (base_name, offset, length) with length None when there was no _sub_ suffix at all """
+    first_length = None
+    start_offset = 0
+    while True:
+        sp = name.rfind('_sub_')
+        if sp == -1:
+            break
+        up = name.rfind('_')
+        if up <= sp + 1:
+            break
+        start_tok, end_tok = name[sp + 5:up], name[up + 1:]
+        if not start_tok.isdigit() or not end_tok.isdigit():
+            # not a coordinate suffix -- a contig genuinely called e.g. "scaf_sub_unit".  hal2vg
+            # would abort on such a name, so it cannot reach a graph; treat it as an opaque name
+            break
+        start, end = int(start_tok), int(end_tok)
+        start_offset += start
+        if first_length is None:
+            first_length = end - start
+        name = name[:sp]
+    return name, (start_offset if first_length is not None else 0), first_length
+
+
+def event_to_pansn_prefix(event):
+    """ the SAMPLE#HAP prefix that graph paths for a given seqfile event carry.  mirrors hal2vg's
+    resolve_haplotype_naming: a trailing .N with N all digits is the haplotype, otherwise 0 """
+    dot = event.rfind('.')
+    if dot != -1 and event[dot + 1:].isdigit():
+        return '{}#{}'.format(event[:dot], int(event[dot + 1:]))
+    return '{}#0'.format(event)
+
+
+def pansn_prefix_to_event(pansn_prefix):
+    """ inverse of event_to_pansn_prefix, for the degraded mode where the seqfile event names are
+    not available.  SAMPLE#0 -> SAMPLE, SAMPLE#1 -> SAMPLE.1, so the two haplotypes of a diploid
+    still land in separate files instead of being merged """
+    toks = pansn_prefix.split('#')
+    if len(toks) != 2:
+        return pansn_prefix.replace('#', '.')
+    return toks[0] if toks[1] == '0' else '{}.{}'.format(toks[0], toks[1])
+
+
+def parse_path_name(name, path_length=None):
+    """ split a vg path name into (pansn_prefix, base_contig, start, end).
+
+    the grammar, verified against real cactus output:
+        SAMPLE#HAP#CONTIG                 reference-sense    S288C#0#chrI
+        SAMPLE#HAP#CONTIG#PHASEBLOCK      haplotype-sense    Y12#0#chrI#0
+        ...either, with an optional [START-END] subrange   SK1#0#chrI#0[14059-228861]
+
+    contig names contain no '#' (the sanitizer strips through the last one) and hal2vg has already
+    resolved any _sub_ encoding into the subrange, so the third field is always a base contig.  the
+    phase block, when present, is discarded.
+
+    returns None for anything that is not PanSN, which the caller counts as an orphan """
+    m = _SUBRANGE_RE.match(name)
+    if m:
+        base, start, end = m.group(1), int(m.group(2)), int(m.group(3))
+    else:
+        base, start, end = name, 0, None
+    toks = base.split('#')
+    if len(toks) < 3:
+        return None
+    if end is None:
+        end = start + path_length if path_length is not None else None
+    return '#'.join(toks[:2]), toks[2], start, end
+
+
+def merge_intervals(intervals):
+    """ sort and merge, returning non-overlapping half-open [start, end) tuples """
+    out = []
+    for start, end in sorted(intervals):
+        if start >= end:
+            continue
+        if out and start <= out[-1][1]:
+            if end > out[-1][1]:
+                out[-1][1] = end
+        else:
+            out.append([start, end])
+    return [(s, e) for s, e in out]
+
+
+def subtract_intervals(a, b):
+    """ a \\ b, both merged on the way in """
+    a, b = merge_intervals(a), merge_intervals(b)
+    out = []
+    j = 0
+    for start, end in a:
+        cur = start
+        while j < len(b) and b[j][1] <= cur:
+            j += 1
+        k = j
+        while k < len(b) and b[k][0] < end:
+            if b[k][0] > cur:
+                out.append((cur, min(b[k][0], end)))
+            cur = max(cur, b[k][1])
+            if cur >= end:
+                break
+            k += 1
+        if cur < end:
+            out.append((cur, end))
+    return out
+
+
+def intersect_intervals(a, b):
+    a, b = merge_intervals(a), merge_intervals(b)
+    out = []
+    i = j = 0
+    while i < len(a) and j < len(b):
+        start, end = max(a[i][0], b[j][0]), min(a[i][1], b[j][1])
+        if start < end:
+            out.append((start, end))
+        if a[i][1] < b[j][1]:
+            i += 1
+        else:
+            j += 1
+    return out
+
+
+def total_bp(intervals):
+    return sum(end - start for start, end in intervals)
+
+
+def merge_sorted_bed_stream(line_iter, min_length, path_offsets=None):
+    """ merge an already-sorted stream of `name <TAB> start <TAB> end` BED lines into maximal runs,
+    keeping only those at least min_length long.  streaming, so a reference with no alignment at all
+    costs O(1) memory instead of one tuple per base.
+
+    yields (name, start, end), with any subrange offset of the named path added to both ends """
+    path_offsets = path_offsets or {}
+    cur_name, cur_start, cur_end = None, None, None
+
+    def emit():
+        if cur_name is None or cur_end - cur_start < min_length:
+            return None
+        offset = path_offsets.get(cur_name, 0)
+        return (cur_name, cur_start + offset, cur_end + offset)
+
+    for line in line_iter:
+        toks = line.split('\t')
+        if len(toks) < 3:
+            continue
+        name, start, end = toks[0], int(toks[1]), int(toks[2])
+        if name == cur_name and start <= cur_end:
+            cur_end = max(cur_end, end)
+            continue
+        got = emit()
+        if got:
+            yield got
+        cur_name, cur_start, cur_end = name, start, end
+    got = emit()
+    if got:
+        yield got
+
+
+def contig_sizes_from_fai(fai_path, event):
+    """ read a samtools faidx index of a *sanitized* cactus fasta into baseline rows.
+
+    returns a list of (event, pansn_prefix, base_contig, offset, length) """
+    pansn_prefix = event_to_pansn_prefix(event)
+    rows = []
+    with open(fai_path, 'r') as fai_file:
+        for line in fai_file:
+            toks = line.split('\t')
+            if len(toks) < 2:
+                continue
+            name, length = toks[0], int(toks[1])
+            # the sanitizer passes through a pre-existing id=X| prefix even when X is not the event,
+            # so cut at the first '|' generically rather than matching id=<event>|
+            if name.startswith('id='):
+                bar = name.find('|')
+                if bar > 0:
+                    name = name[bar + 1:]
+            base_contig, offset, sub_length = resolve_subpath_naming(name)
+            if sub_length is not None and sub_length != length:
+                logger.warning('subpath name %s in %s implies length %d but the fasta has %d; '
+                               'using the fasta length', name, fai_path, sub_length, length)
+            rows.append((event, pansn_prefix, base_contig, offset, length))
+    return rows
+
+
+def write_baseline_tsv(rows, out_path):
+    opener = gzip.open if out_path.endswith('.gz') else open
+    with opener(out_path, 'wt') as out_file:
+        for line in BASELINE_PREAMBLE:
+            out_file.write(line + '\n')
+        out_file.write(BASELINE_HEADER + '\n')
+        for row in rows:
+            out_file.write('{}\t{}\t{}\t{}\t{}\n'.format(*row))
+
+
+def check_baseline_header(path):
+    """ raise unless path looks like a baseline contig-size table.  cheap enough to call during
+    option validation, so a wrong file fails immediately rather than after the whole join has run """
+    try:
+        with open_maybe_gzip(path) as in_file:
+            header = in_file.readline().rstrip('\n')
+            while header.startswith('#') and header != BASELINE_HEADER:
+                header = in_file.readline().rstrip('\n')
+    except OSError as e:
+        raise RuntimeError('could not read --inputContigSizes {}: {}'.format(path, e))
+    if header != BASELINE_HEADER:
+        raise RuntimeError(
+            '{} is not a cactus baseline contig-size table: expected the header line\n  {}\n'
+            'but found\n  {}\nThis file is written by cactus-pangenome as '
+            '<outDir>/<outName>.input-contig-sizes.tsv.gz. Note it is NOT the same file as '
+            '<outDir>/chrom-subproblems/contig_sizes.tsv, which is a chromosome-by-sample '
+            'matrix and cannot be used here.'.format(path, BASELINE_HEADER, header))
+
+
+def read_baseline_tsv(path):
+    """ inverse of write_baseline_tsv.  hard-fails on a wrong header rather than silently parsing
+    some other tsv (chrom-subproblems/contig_sizes.tsv is the one that would otherwise get passed) """
+    rows = []
+    check_baseline_header(path)
+    with open_maybe_gzip(path) as in_file:
+        for line in in_file:
+            if not line.strip() or line.startswith('#'):
+                continue
+            toks = line.rstrip('\n').split('\t')
+            if len(toks) != 5:
+                raise RuntimeError('malformed line in {}: {}'.format(path, line.rstrip('\n')))
+            rows.append((toks[0], toks[1], toks[2], int(toks[3]), int(toks[4])))
+    return rows
+
+
+def parse_split_log(path):
+    """ read minigraph.split.log, which rgfa-split writes one line per contig it made a decision
+    about.  returns (assigned, ambiguous) where assigned maps (event, contig, offset) -> chromosome
+    and ambiguous is the set of (event, contig, offset) binned to _AMBIGUOUS_.
+
+    the log names contigs the way cactus named them internally, so a contig that arrived as a
+    fragment appears as e.g. chr1_sub_1000_2000.  those are resolved here into the same
+    (contig, offset) space the graph and the input contig sizes use, so the three can be joined
+    without anything having to carry the internal name around.
+
+    contigs rgfa-split made no decision about appear in neither -- that silence is exactly the case
+    this feature exists to surface, so it must not be conflated with either bucket """
+    assigned, ambiguous = {}, set()
+    with open(path, 'r') as log_file:
+        for line in log_file:
+            m = _SPLIT_ASSIGNED_RE.match(line)
+            if m:
+                contig, offset, _length = resolve_subpath_naming(m.group(3))
+                assigned[(m.group(2), contig, offset)] = m.group(1)
+                continue
+            m = _SPLIT_AMBIGUOUS_RE.match(line)
+            if m:
+                contig, offset, _length = resolve_subpath_naming(m.group(2))
+                ambiguous.add((m.group(1), contig, offset))
+    return assigned, ambiguous
+
+
+def baseline_by_key(rows):
+    """ group baseline rows into {(pansn_prefix, base_contig): merged intervals}, which is the key
+    graph coverage joins on """
+    by_key = {}
+    for _event, pansn_prefix, base_contig, offset, length in rows:
+        by_key.setdefault((pansn_prefix, base_contig), []).append((offset, offset + length))
+    return {key: merge_intervals(ivs) for key, ivs in by_key.items()}
+
+
+def event_by_pansn_prefix(rows):
+    """ {pansn_prefix: event}, so a graph path can be routed to the right output file """
+    return {pansn_prefix: event for event, pansn_prefix, _c, _o, _l in rows}
+
+
+def safe_event_filename(event):
+    """ event names become file basenames; check_sample_names only constrains a leading '.' and a
+    numeric suffix, so guard against a name that would escape the output directory """
+    if os.sep in event or '/' in event or event in ('.', '..'):
+        raise RuntimeError('genome name {} cannot be used as a file name'.format(event))
+    return event
+
+
+def synthetic_samples(config):
+    """ the sample names that exist only inside the graph and have no input fasta: the minigraph
+    "assembly" and, if ancestors are ever included, the cactus ancestral genomes.  read from the
+    config rather than hardcoded -- assemblyName is a config attribute, and includeAncestor is
+    shipped as 0 today but flipping it would otherwise silently reintroduce the same bug """
+    graph_event = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap"),
+                                    "assemblyName", default="_MINIGRAPH_")
+    return {graph_event, config.getDefaultInternalNodePrefix() + '0'}
+
+
+###############################################################################
+# toil job functions
+###############################################################################
+
+def path_coverage_job(job, config, vg_path, vg_id, chrom_name, phase):
+    """ read back what a phase graph actually contains, as intervals in input-contig coordinates.
+
+    returns (file_id, key_list, fragment_count) where file_id is a sorted, merged TSV of
+    pansn_prefix / base_contig / start / end.  merging here keeps the bytes crossing the jobstore
+    proportional to the number of surviving fragments rather than to the number of paths """
+    work_dir = job.fileStore.getLocalTempDir()
+    local_vg_path = os.path.join(work_dir, os.path.basename(vg_path))
+    job.fileStore.readGlobalFile(vg_id, local_vg_path)
+
+    synthetic = synthetic_samples(config)
+    coverage = {}
+    orphan_names = []
+    lines = cactus_call(parameters=['vg', 'paths', '-E', '-v', local_vg_path],
+                        check_output=True, job_memory=job.memory)
+    for line in lines.split('\n'):
+        toks = line.split('\t')
+        if len(toks) < 2:
+            continue
+        path_name, path_length = toks[0], int(toks[1])
+        parsed = parse_path_name(path_name, path_length)
+        if parsed is None:
+            orphan_names.append(path_name)
+            continue
+        pansn_prefix, base_contig, start, end = parsed
+        # drop synthetic events at parse time, not on the output: the degraded (no baseline table)
+        # mode derives its baseline *from* this coverage, so a _MINIGRAPH_ path left in here would
+        # become its own "input genome"
+        if pansn_prefix.split('#')[0] in synthetic:
+            continue
+        if end - start != path_length:
+            raise RuntimeError(
+                'path {} in {} has subrange width {} but length {}; the assumption that a vg '
+                'subrange spans exactly the path it names no longer holds'.format(
+                    path_name, vg_path, end - start, path_length))
+        coverage.setdefault((pansn_prefix, base_contig), []).append((start, end))
+
+    if orphan_names:
+        RealtimeLogger.warning('{} {}: {} path(s) are not PanSN and were skipped, e.g. {}'.format(
+            chrom_name, phase, len(orphan_names), orphan_names[:3]))
+
+    out_path = os.path.join(work_dir, '{}.{}.coverage.tsv'.format(chrom_name, phase))
+    fragment_count = 0
+    with open(out_path, 'w') as out_file:
+        for (pansn_prefix, base_contig) in sorted(coverage.keys()):
+            for start, end in merge_intervals(coverage[(pansn_prefix, base_contig)]):
+                out_file.write('{}\t{}\t{}\t{}\n'.format(pansn_prefix, base_contig, start, end))
+                fragment_count += 1
+
+    return (job.fileStore.writeGlobalFile(out_path), sorted(coverage.keys()),
+            fragment_count, len(orphan_names))
+
+
+def read_coverage_tsv(path):
+    """ inverse of path_coverage_job's output """
+    coverage = {}
+    with open(path, 'r') as in_file:
+        for line in in_file:
+            toks = line.rstrip('\n').split('\t')
+            if len(toks) != 4:
+                continue
+            coverage.setdefault((toks[0], toks[1]), []).append((int(toks[2]), int(toks[3])))
+    return coverage
+
+
+def ref_gaps_job(job, config, options, vg_path, vg_id, chrom_name, ref_event, drop_graph_event):
+    """ the reference is never clipped, so its exclusions cannot be measured by absence.  measure
+    them the way refgaps.sh does instead: runs along the reference with no other assembly aligned.
+
+    `vg depth -m0 -P <ref>#` prints one line per reference base as `path <TAB> 1-based-pos <TAB>
+    depth`, where depth excludes the reference path itself.  It is streamed, never materialised """
+    work_dir = job.fileStore.getLocalTempDir()
+    local_vg_path = os.path.join(work_dir, os.path.basename(vg_path))
+    job.fileStore.readGlobalFile(vg_id, local_vg_path)
+
+    min_length = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_join"),
+                                   "refGapMinLength", typeFn=int, default=10000)
+    if min_length <= 0:
+        return None
+
+    depth_input_path = local_vg_path
+    if drop_graph_event:
+        # falling back to the full graph, which still carries minigraph fragments.  they would
+        # count towards depth and mask real gaps, so take them out first
+        graph_event = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap"),
+                                        "assemblyName", default="_MINIGRAPH_")
+        depth_input_path = local_vg_path + '.nomg'
+        cactus_call(parameters=['vg', 'paths', '-d', '-S', graph_event, '-x', local_vg_path],
+                    outfile=depth_input_path, job_memory=job.memory)
+
+    # note: vg depth already reports positions in original contig coordinates -- it strips the
+    # subrange from the path name and adds subrange.first to the offset itself (vg's
+    # algorithms/coverage_depth.cpp path_depths).  So nothing here may add the offset a second time.
+    # vg depth emits one line per reference base, so it is filtered down to the zero-depth
+    # positions in the pipe (exactly as refgaps.sh does) before anything touches disk.  awk also
+    # does the 1-based -> 0-based half-open conversion, emitting one [pos-1, pos) singleton per
+    # zero base, which merge_sorted_bed_stream then joins back into runs
+    zeros_path = os.path.join(work_dir, '{}.zeros.bed'.format(chrom_name))
+    cactus_call(parameters=[['vg', 'depth', depth_input_path, '-m0', '-P', ref_event + '#'],
+                            ['awk', DEPTH_TO_BED_AWK]],
+                outfile=zeros_path, job_memory=job.memory)
+
+    out_path = os.path.join(work_dir, '{}.refgaps.bed'.format(chrom_name))
+    rows = 0
+    with open(zeros_path, 'r') as zeros_file, open(out_path, 'w') as out_file:
+        for path_name, start, end in merge_sorted_bed_stream(zeros_file, min_length):
+            parsed = parse_path_name(path_name)
+            contig = parsed[1] if parsed else path_name
+            out_file.write('{}\t{}\t{}\t{}\n'.format(contig, start, end, REASON_REFGAP))
+            rows += 1
+    os.remove(zeros_path)
+
+    if not rows:
+        return None
+    return job.fileStore.writeGlobalFile(out_path)
+
+
+def _strip_subrange(name):
+    m = _SUBRANGE_RE.match(name)
+    return m.group(1) if m else name
+
+
+PHASE_ORDER = ('full', 'clip', 'filter')
+
+
+def resolve_assigned_graph(where, chrom_names, other_contig):
+    """ the graph a split-log assignment actually landed in.  rgfa-split logs the fine-grained
+    reference contig (e.g. chr14_GL000009v2_random), but cactus then folds every reference contig
+    not given its own graph into the otherContig graph (chrOther by default).  So an assignment
+    naming a contig with no graph of its own resolves to otherContig when that was built, and to
+    None only when the sequence really reached no graph at all.  Returns the graph name or None """
+    if where in chrom_names:
+        return where
+    if other_contig and other_contig in chrom_names:
+        return other_contig
+    return None
+
+
+def assigned_chromosome(key_event, base_contig, offsets, split_log, chrom_names, other_contig):
+    """ the graph the splitting stage put this contig in, if any """
+    if split_log is None:
+        return None
+    assigned, _ambiguous = split_log
+    for offset in offsets:
+        key = (key_event, base_contig, offset)
+        if key in assigned:
+            return resolve_assigned_graph(assigned[key], chrom_names, other_contig)
+    return None
+
+
+def sublabel_dropped(key_event, base_contig, offsets, full_cov_bp, split_log, chrom_names,
+                     other_contig):
+    """ which of the four split-stage fates a wholly-or-partly absent contig met.
+
+    the three split-level labels are gated on *zero* full-phase coverage: a contig with any
+    coverage demonstrably reached a chromosome graph, so whatever it lost there is alignment-level,
+    not split-level, no matter what the log says about it """
+    if full_cov_bp > 0 or split_log is None:
+        return REASON_UNALIGNED
+    assigned, ambiguous = split_log
+    for offset in offsets:
+        if (key_event, base_contig, offset) in ambiguous:
+            return REASON_AMBIGUOUS
+    for offset in offsets:
+        key = (key_event, base_contig, offset)
+        if key in assigned:
+            return (REASON_UNALIGNED
+                    if resolve_assigned_graph(assigned[key], chrom_names, other_contig)
+                    else REASON_NO_CHROM_GRAPH)
+    return REASON_UNASSIGNED
+
+
+def compute_exclusions(baseline_rows, coverage_paths_by_phase, phases_present, split_log,
+                       chrom_names, out_dir, filter_threshold=None, other_contig=None):
+    # chrom_names is order-significant: entry i names the chromosome whose coverage file is at
+    # index i in each phase's list
+    """ the pure core of the exclusion report: turn per-phase coverage into per-genome BED files
+    plus a summary, and return the counters.
+
+    baseline_rows is None in degraded mode (no --inputContigSizes), in which case the baseline is
+    taken from the widest present phase and the 'dropped' class cannot be reported at all.
+
+    processing is chromosome by chromosome.  each input contig lives in exactly one chromosome
+    subproblem, so peak memory scales with the largest chromosome rather than the whole panel """
+    order = [p for p in PHASE_ORDER if p in phases_present]
+    if not order:
+        raise RuntimeError('exclusion report needs at least one phase graph')
+    widest = order[0]
+    explicit = baseline_rows is not None
+
+
+    if explicit:
+        baseline = baseline_by_key(baseline_rows)
+        event_of = event_by_pansn_prefix(baseline_rows)
+        offsets_of = {}
+        for event, pansn_prefix, base_contig, offset, _l in baseline_rows:
+            offsets_of.setdefault((pansn_prefix, base_contig), []).append(offset)
+        input_bp = {}
+        for event, _p, _c, _o, length in baseline_rows:
+            input_bp[event] = input_bp.get(event, 0) + length
+    else:
+        baseline, event_of, offsets_of, input_bp = {}, {}, {}, {}
+        for path in coverage_paths_by_phase[widest]:
+            for key, ivs in read_coverage_tsv(path).items():
+                baseline.setdefault(key, []).extend(ivs)
+        baseline = {k: merge_intervals(v) for k, v in baseline.items()}
+        for pansn_prefix, _contig in baseline:
+            event_of.setdefault(pansn_prefix, pansn_prefix_to_event(pansn_prefix))
+        for key, ivs in baseline.items():
+            event = event_of[key[0]]
+            input_bp[event] = input_bp.get(event, 0) + total_bp(ivs)
+
+    # sequence missing from every graph can only be seen against a real input baseline: without one
+    # the baseline IS the widest graph, so that class would measure zero by construction
+    report_dropped = explicit and 'full' in phases_present
+
+    # one BED per (graph, genome).  writing them in one pass would need phases x genomes open
+    # handles, which overruns the usual 1024 limit on a big panel, so a single reason-tagged file
+    # per genome is written here and split per graph afterwards
+    work_dir = os.path.join(out_dir, '.by-reason')
+    os.makedirs(work_dir, exist_ok=True)
+    writers = {}
+
+    def writer_for(event):
+        if event not in writers:
+            writers[event] = open(
+                os.path.join(work_dir, '{}.bed'.format(safe_event_filename(event))), 'w')
+        return writers[event]
+
+    counts = {}            # (event, reason) -> [intervals, bp]
+    whole_dropped = {}     # event -> [(contig, bp, reason)] absent from every graph
+    # one row per (chromosome, genome, contig): how much of that contig survived into each graph
+    contig_rows = []
+    outside_baseline_bp = 0
+    orphan_keys = []
+    orphan_bp = 0
+    seen_keys = set()
+
+    def tally(event, reason, intervals):
+        if not intervals:
+            return
+        slot = counts.setdefault((event, reason), [0, 0])
+        slot[0] += len(intervals)
+        slot[1] += total_bp(intervals)
+
+    def emit(event, contig, intervals, reason):
+        if not intervals:
+            return
+        out_file = writer_for(event)
+        for start, end in intervals:
+            out_file.write('{}\t{}\t{}\t{}\n'.format(contig, start, end, reason))
+        tally(event, reason, intervals)
+
+    n_chroms = len(coverage_paths_by_phase[widest])
+    for i in range(n_chroms):
+        cov = {}
+        for phase in order:
+            cov[phase] = read_coverage_tsv(coverage_paths_by_phase[phase][i])
+        keys = set()
+        for phase in order:
+            keys.update(cov[phase].keys())
+
+        for key in sorted(keys):
+            pansn_prefix, base_contig = key
+            if key not in baseline:
+                bp = total_bp(merge_intervals(cov[widest].get(key, [])))
+                orphan_keys.append(key)
+                orphan_bp += bp
+                continue
+            seen_keys.add(key)
+            base_ivs = baseline[key]
+            event = event_of[pansn_prefix]
+
+            clamped = {}
+            for phase in order:
+                raw = merge_intervals(cov[phase].get(key, []))
+                clamped[phase] = intersect_intervals(raw, base_ivs)
+                outside_baseline_bp += total_bp(raw) - total_bp(clamped[phase])
+
+            missing = {p: subtract_intervals(base_ivs, clamped[p]) for p in order}
+
+            if report_dropped:
+                reason = sublabel_dropped(event, base_contig, offsets_of.get(key, [0]),
+                                          total_bp(clamped['full']), split_log, chrom_names,
+                                          other_contig)
+                emit(event, base_contig, missing['full'], reason)
+                if reason != REASON_NO_CHROM_GRAPH and not total_bp(clamped['full']):
+                    whole_dropped.setdefault(event, []).append(
+                        (base_contig, total_bp(base_ivs), reason))
+            for prev, cur in zip(order, order[1:]):
+                gained = subtract_intervals(missing[cur], missing[prev])
+                emit(event, base_contig, gained, PHASE_REASON[cur])
+
+            contig_rows.append((chrom_names[i], event, base_contig, total_bp(base_ivs),
+                                dict((p, total_bp(clamped[p])) for p in order),
+                                dict((p, len(clamped[p])) for p in order)))
+
+    # contigs that reached no chromosome graph at all never appear in any coverage file
+    if report_dropped:
+        for key, base_ivs in sorted(baseline.items()):
+            if key in seen_keys:
+                continue
+            pansn_prefix, base_contig = key
+            event = event_of[pansn_prefix]
+            reason = sublabel_dropped(event, base_contig, offsets_of.get(key, [0]), 0,
+                                      split_log, chrom_names, other_contig)
+            emit(event, base_contig, base_ivs, reason)
+            if reason != REASON_NO_CHROM_GRAPH:
+                whole_dropped.setdefault(event, []).append(
+                    (base_contig, total_bp(base_ivs), reason))
+            # in no chromosome graph, so it gets the synthetic chromosome _NONE_ rather than being
+            # left out -- otherwise the per-chromosome rows would not sum to the genome total
+            # a contig assigned to a chromosome nobody built still belongs to that chromosome:
+            # attributing it keeps the per-chromosome view complete under --refContigs
+            where = assigned_chromosome(event, base_contig, offsets_of.get(key, [0]),
+                                        split_log, chrom_names, other_contig) or NO_CHROMOSOME
+            contig_rows.append((where, event, base_contig, total_bp(base_ivs),
+                                dict((p, 0) for p in order), dict((p, 0) for p in order)))
+
+    for out_file in writers.values():
+        out_file.close()
+
+    # split into one directory per graph.  every input genome gets a file in every directory,
+    # including the genomes that lost nothing
+    phase_dirs = {}
+    for phase in order:
+        keep = PHASE_REASONS[phase]
+        phase_dir = os.path.join(out_dir, 'clipped' + phase_tag(phase, filter_threshold) + '.beds')
+        os.makedirs(phase_dir, exist_ok=True)
+        phase_dirs[phase] = phase_dir
+        for event in sorted(input_bp):
+            src = os.path.join(work_dir, '{}.bed'.format(safe_event_filename(event)))
+            dest = os.path.join(phase_dir, '{}.bed'.format(safe_event_filename(event)))
+            with open(dest, 'w') as out_file:
+                if os.path.exists(src):
+                    with open(src, 'r') as in_file:
+                        for line in in_file:
+                            if line.rstrip('\n').split('\t')[3] in keep:
+                                out_file.write(line)
+    shutil.rmtree(work_dir)
+
+    return {'counts': counts, 'input_bp': input_bp, 'phase_dirs': phase_dirs,
+            'whole_dropped': whole_dropped, 'contig_rows': contig_rows,
+            'phases': order, 'explicit_baseline': explicit, 'report_dropped': report_dropped,
+            'outside_baseline_bp': outside_baseline_bp, 'orphan_paths': len(orphan_keys),
+            'orphan_bp': orphan_bp, 'orphan_keys': orphan_keys[:10]}
+
+
+# a sample losing this much of itself to sequence that reached no graph at all is not normal
+# divergence, it is a sign the assembly did not fit the reference's chromosome structure
+WARN_DROPPED_FRACTION = 0.05
+# ...and a sample losing this much more than the rest of the panel stands out even if the cause
+# is spread across classes.  both must hold, so a uniformly lossy run does not flag every sample
+WARN_OUTLIER_RATIO = 3.0
+WARN_OUTLIER_FRACTION = 0.10
+# a reference with this much of itself unaligned to anything means the panel barely agrees with it
+WARN_REFGAP_FRACTION = 0.20
+
+
+def detect_problems(result, refgap_bp=None, ref_input_bp=None):
+    """ look over the finished accounting for the shapes that mean something went wrong, as opposed
+    to sequence being legitimately clipped or filtered.
+
+    the two things that separate a real problem from a configuration choice are *which* class the
+    loss falls into and whether it is *uniform*.  sequence dropped before any graph was built is
+    always worth knowing about; sequence lost to a chromosome nobody asked to build
+    (no_chromosome_graph, what --refContigs does on purpose) is not, and neither is a panel where
+    everything loses about the same amount.
+
+    returns a list of human-readable warnings, empty when nothing looks wrong """
+    warnings = []
+    counts, input_bp = result['counts'], result['input_bp']
+
+    # 1. sequence that reached no graph at all.  no_chromosome_graph is deliberately excluded: it
+    #    is what --refContigs does, and it applies uniformly to every sample
+    never_placed = (REASON_AMBIGUOUS, REASON_UNASSIGNED, REASON_UNALIGNED)
+    for event in sorted(input_bp):
+        total_in = input_bp[event]
+        if not total_in:
+            continue
+        bp = sum(counts.get((event, r), [0, 0])[1] for r in never_placed)
+        if bp > total_in * WARN_DROPPED_FRACTION:
+            by_reason = ', '.join('{}={} bp'.format(r, counts[(event, r)][1])
+                                  for r in never_placed if (event, r) in counts)
+            warnings.append(
+                '{}: {:.1f}% of its input ({} bp) is in no graph at all ({}). Sequence in these '
+                'classes never reached a chromosome graph, so it was lost during chromosome '
+                'splitting rather than by clipping. A large fraction usually means the assembly '
+                'disagrees with the reference chromosome structure -- inter-chromosomal '
+                'rearrangements, a mis-joined scaffold, or the wrong reference.'.format(
+                    event, 100.0 * bp / total_in, bp, by_reason))
+
+    # 2. whole input contigs absent from every graph
+    for event in sorted(result.get('whole_dropped', {})):
+        contigs = result['whole_dropped'][event]
+        bp = sum(c[1] for c in contigs)
+        shown = ', '.join('{} ({} bp, {})'.format(*c) for c in contigs[:5])
+        warnings.append(
+            '{}: {} whole contig(s) totalling {} bp are absent from every graph: {}{}'.format(
+                event, len(contigs), bp, shown, ', ...' if len(contigs) > 5 else ''))
+
+    # 3. one sample much worse than the rest.  needs both a ratio and a floor so that a panel which
+    #    is uniformly lossy (or uniformly fine) does not flag anything
+    fractions = {}
+    for event, total_in in input_bp.items():
+        if total_in:
+            lost = sum(bp for (ev, _r), (_n, bp) in counts.items() if ev == event)
+            fractions[event] = lost / total_in
+    if len(fractions) > 2:
+        ordered = sorted(fractions.values())
+        median = ordered[len(ordered) // 2]
+        for event in sorted(fractions):
+            frac = fractions[event]
+            if frac > WARN_OUTLIER_FRACTION and median > 0 and frac > median * WARN_OUTLIER_RATIO:
+                warnings.append(
+                    '{}: loses {:.1f}% of its input, against {:.1f}% for the typical genome in this '
+                    'panel. One genome behaving very differently from the rest usually means a '
+                    'problem with that assembly rather than with the alignment.'.format(
+                        event, 100.0 * frac, 100.0 * median))
+
+    # 4. the reference barely agrees with the panel
+    for ref_event, (_n, bp) in (refgap_bp or {}).items():
+        if ref_input_bp and bp > ref_input_bp * WARN_REFGAP_FRACTION:
+            warnings.append(
+                '{}: {:.1f}% of the reference has no other assembly aligned to it. Either the '
+                'panel is very distant from this reference, or the alignment largely '
+                'failed.'.format(ref_event, 100.0 * bp / ref_input_bp))
+
+    # 5. the accounting did not add up, which means a bug rather than a data problem
+    if result['outside_baseline_bp']:
+        warnings.append(
+            'INTERNAL: {} bp of graph path coverage falls outside the input contig bounds. The '
+            'exclusion report may be wrong; please report this.'.format(result['outside_baseline_bp']))
+    if result['orphan_paths']:
+        warnings.append(
+            'INTERNAL: {} graph path group(s) have no matching input contig (e.g. {}). The '
+            'exclusion report may be wrong; please report this.'.format(
+                result['orphan_paths'], result['orphan_keys']))
+
+    return warnings
+
+
+def write_summary(result, out_path, refgap_bp=None, notes=None):
+    """ the concise view: one block per input genome, always, including zero-loss ones """
+    refgap_bp = refgap_bp or {}
+    counts, input_bp = result['counts'], result['input_bp']
+    with open(out_path, 'w') as out_file:
+        out_file.write('# input sequence that is not in the output graph, by genome.\n')
+        out_file.write('# NOTE "clipped" in these filenames means any input base absent from the '
+                       'graph, whatever removed it.\n')
+        out_file.write('#      the reason column below says which stage did, and one of its values '
+                       "is the narrower 'clip'\n")
+        out_file.write('# phases: {}\n'.format(','.join(result['phases'])))
+        out_file.write('# baseline: {}\n'.format(
+            '--inputContigSizes' if result['explicit_baseline'] else
+            'derived from {}-phase coverage; the dropped class is unavailable'.format(
+                result['phases'][0])))
+        out_file.write('# TOTAL = input bp absent from the deepest graph that was built. refgap '
+                       'is not counted in it\n')
+        out_file.write('# every reason measured for this run gets a row for every genome, so a 0 '
+                       'means measured-and-nothing-lost\n')
+        out_file.write('# lost at chromosome assignment, so absent from EVERY graph:\n')
+        out_file.write('#   ambiguous           = contig binned to _AMBIGUOUS_ during splitting\n')
+        out_file.write('#   unassigned          = contig that splitting made no decision about\n')
+        out_file.write('#   no_chromosome_graph = contig assigned to a chromosome no graph was '
+                       'built for (e.g. left out of --refContigs)\n')
+        out_file.write('#   unaligned           = contig reached its chromosome graph, but some of '
+                       'its sequence did not make the full graph\n')
+        out_file.write('# lost later, so present in the earlier graphs:\n')
+        out_file.write('#   clip   = removed by the clip phase (clip-vg -u/-a, vg clip -d1/-sS'
+                       ', vg clip -D with --delEdgeFilter)\n')
+        out_file.write('#   filter = removed by the filter phase (vg clip -d <filter> -m, vg clip -sS)\n')
+        out_file.write('# refgap = reference bp with zero non-reference depth. PRESENT in the graph.'
+                       ' NOT lost. Excluded from TOTAL lost.\n')
+        out_file.write('# outside_baseline_bp: {}\n'.format(result['outside_baseline_bp']))
+        out_file.write('# orphan_paths: {}\n'.format(result['orphan_paths']))
+        for note in (notes or []):
+            out_file.write('# NOTE: {}\n'.format(note))
+        out_file.write('#genome\treason\tintervals\tbp\tpct_of_input\n')
+
+        def pct(bp, total):
+            return 'NA' if not total else '{:.3f}'.format(100.0 * bp / total)
+
+        # the reasons this run could measure at all: the dropped classes only when there is a
+        # baseline and a full graph, and each later phase only when it ran
+        measured = []
+        if result['report_dropped']:
+            measured += list(DROPPED_REASONS)
+        for phase in result['phases'][1:]:
+            measured.append(PHASE_REASON[phase])
+
+        grand_lost = grand_refgap = 0
+        for event in sorted(input_bp):
+            total_in = input_bp[event]
+            lost_n = lost_bp = 0
+            for reason in measured:
+                n, bp = counts.get((event, reason), (0, 0))
+                out_file.write('{}\t{}\t{}\t{}\t{}\n'.format(event, reason, n, bp,
+                                                                pct(bp, total_in)))
+                lost_n += n
+                lost_bp += bp
+            if not result['report_dropped']:
+                out_file.write('{}\tdropped\tNA\tNA\tNA\n'.format(event))
+            out_file.write('{}\tTOTAL\t{}\t{}\t{}\n'.format(event, lost_n, lost_bp,
+                                                             pct(lost_bp, total_in)))
+            if event in refgap_bp:
+                n, bp = refgap_bp[event]
+                out_file.write('{}\trefgap\t{}\t{}\t{}\n'.format(event, n, bp,
+                                                                   pct(bp, total_in)))
+                grand_refgap += bp
+            grand_lost += lost_bp
+        total_in = sum(input_bp.values())
+        out_file.write('TOTAL\tTOTAL\t\t{}\t{}\n'.format(grand_lost, pct(grand_lost, total_in)))
+        if refgap_bp:
+            out_file.write('TOTAL\trefgap\t\t{}\t{}\n'.format(grand_refgap,
+                                                                pct(grand_refgap, total_in)))
+
+
+def write_per_contig_stats(result, contig_path, chrom_path):
+    """ the same accounting as the exclusion report, rolled up two ways: one row per input contig,
+    and one row per genome per reference contig.  both answer "how much of this survived", at the
+    two zoom levels people actually ask about """
+    phases = result['phases']
+    pairs = []
+    for phase in phases:
+        pairs += ['{}_bp'.format(phase), '{}_frags'.format(phase)]
+    preamble = [
+        '# how much of the input survived into each graph that was built.',
+        '# NOTE "clipped" in these filenames means any input base absent from the graph, whatever',
+        '#      removed it -- chromosome splitting, the clip phase, or the frequency filter.',
+        '# ref_chrom   the reference contig whose graph it landed in, or {} if it reached none'.format(
+            NO_CHROMOSOME),
+        '# genome      the input genome, as named in the seqfile',
+        '# input_bp    its length in the input fasta',
+        '# <graph>_bp    bases of it present in that graph',
+        '# <graph>_frags contiguous pieces it is broken into in that graph',
+        '# bases lost at a stage are the drop between two adjacent _bp columns; everything lost',
+        '# overall is input_bp - {}_bp'.format(phases[-1]),
+    ]
+
+    def row(prefix, in_bp, in_frags):
+        cells = []
+        for phase in phases:
+            cells += [str(in_bp[phase]), str(in_frags[phase])]
+        return prefix + '\t' + '\t'.join(cells) + '\n'
+
+    with gzip.open(contig_path, 'wt') as out_file:
+        for line in preamble:
+            out_file.write(line + '\n')
+        out_file.write('#genome\tcontig\tref_chrom\tinput_bp\t{}\n'.format('\t'.join(pairs)))
+        for chrom, event, contig, input_bp, in_bp, in_frags in sorted(
+                result['contig_rows'], key=lambda r: (r[1], r[2], r[0])):
+            out_file.write(row('{}\t{}\t{}\t{}'.format(event, contig, chrom, input_bp),
+                               in_bp, in_frags))
+
+    rolled = {}
+    for chrom, event, _contig, input_bp, in_bp, in_frags in result['contig_rows']:
+        slot = rolled.setdefault((chrom, event),
+                                 [0, 0, dict((p, 0) for p in phases), dict((p, 0) for p in phases)])
+        slot[0] += 1
+        slot[1] += input_bp
+        for phase in phases:
+            slot[2][phase] += in_bp[phase]
+            slot[3][phase] += in_frags[phase]
+
+    chrom_opener = gzip.open if chrom_path.endswith('.gz') else open
+    with chrom_opener(chrom_path, 'wt') as out_file:
+        for line in preamble[:1] + preamble[2:]:
+            out_file.write(line + '\n')
+        out_file.write('#ref_chrom\tgenome\tcontigs\tinput_bp\t{}\n'.format('\t'.join(pairs)))
+        for (chrom, event) in sorted(rolled):
+            contigs, input_bp, in_bp, in_frags = rolled[(chrom, event)]
+            out_file.write(row('{}\t{}\t{}\t{}'.format(chrom, event, contigs, input_bp),
+                               in_bp, in_frags))
+
+
+def compute_exclusions_job(job, config, options, phase_coverage, baseline_id, split_log_id,
+                           refgap_ids, chrom_names):
+    """ join every phase's coverage against the baseline and write the report.
+
+    phase_coverage is {phase: [(file_id, key_list, fragment_count, orphan_count), ...]} covering
+    only the phases that actually ran -- a phase that did not run contributes no rows at all, rather
+    than being charged its predecessor's survivors """
+    work_dir = job.fileStore.getLocalTempDir()
+    out_dir = os.path.join(work_dir, 'exclusions')
+    os.makedirs(out_dir, exist_ok=True)
+
+    coverage_paths = {}
+    for phase, results in phase_coverage.items():
+        coverage_paths[phase] = []
+        for i, (file_id, _keys, _frags, _orphans) in enumerate(results):
+            local = os.path.join(work_dir, '{}.{}.cov'.format(i, phase))
+            job.fileStore.readGlobalFile(file_id, local)
+            coverage_paths[phase].append(local)
+
+    notes = []
+    # without the input contig lengths there is nothing to measure the graphs against.  the graphs
+    # could be measured against each other, but the result would carry the same filenames and column
+    # names while meaning something else -- missing.full would be empty by construction rather than
+    # by measurement, and pct_of_input would be a fraction of the graph rather than of the input.
+    # Reference gaps do not depend on the baseline, so those are still produced.
+    baseline_rows = None
+    if baseline_id:
+        baseline_path = os.path.join(work_dir, 'input-contig-sizes.tsv')
+        job.fileStore.readGlobalFile(baseline_id, baseline_path)
+        baseline_rows = read_baseline_tsv(baseline_path)
+    else:
+        RealtimeLogger.warning(
+            'No exclusion report: it needs the input contig lengths, which are only available when '
+            'the whole pipeline runs. Pass --inputContigSizes <outName>.input-contig-sizes.tsv.gz from '
+            'the cactus-pangenome run that produced these graphs to get one.')
+
+    split_log = None
+    if split_log_id:
+        split_log_path = os.path.join(work_dir, 'minigraph.split.log')
+        job.fileStore.readGlobalFile(split_log_id, split_log_path)
+        split_log = parse_split_log(split_log_path)
+    elif baseline_id:
+        notes.append('no split log was available, so sequence missing from every graph is reported '
+                     'as {} without distinguishing the split-stage causes.'.format(REASON_UNALIGNED))
+
+    other_contig = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap_split"),
+                                     "otherContigName", typeFn=str, default="chrOther")
+    result = None
+    if baseline_rows is not None:
+        result = compute_exclusions(baseline_rows, coverage_paths, list(phase_coverage.keys()),
+                                    split_log, chrom_names, out_dir,
+                                    filter_threshold=getattr(options, 'filter', None),
+                                    other_contig=other_contig)
+
+    # reference gaps: concatenated per reference genome, kept well away from the loss totals
+    refgap_bp = {}
+    refgap_out = {}
+    for ref_event, ids in (refgap_ids or {}).items():
+        ids = [i for i in ids if i]
+        if not ids:
+            continue
+        name = 'refgaps.bed.gz' if len(refgap_ids) == 1 else 'refgaps.{}.bed.gz'.format(
+            safe_event_filename(ref_event))
+        path = os.path.join(out_dir, name)
+        rows = bp = 0
+        with gzip.open(path, 'wt') as out_file:
+            for file_id in ids:
+                local = job.fileStore.readGlobalFile(file_id)
+                with open(local, 'r') as in_file:
+                    for line in in_file:
+                        toks = line.split('\t')
+                        if len(toks) < 3:
+                            continue
+                        out_file.write(line)
+                        rows += 1
+                        bp += int(toks[2]) - int(toks[1])
+        refgap_bp[ref_event] = (rows, bp)
+        refgap_out[name] = job.fileStore.writeGlobalFile(path)
+
+    if result is None:
+        return {'summary.tsv': None, 'missing': {}, 'refgaps': refgap_out, 'WARNING': None}
+
+    summary_path = os.path.join(out_dir, 'summary.tsv')
+    write_summary(result, summary_path, refgap_bp=refgap_bp, notes=notes)
+
+    contig_stats_path = os.path.join(out_dir, 'clipped-by-input-contig.tsv.gz')
+    chrom_stats_path = os.path.join(out_dir, 'clipped-by-reference-contig.tsv')
+    write_per_contig_stats(result, contig_stats_path, chrom_stats_path)
+
+    # a run can succeed and still have gone badly wrong.  surface the shapes that mean that, in a
+    # file that only exists when there is something to say
+    ref_input_bp = None
+    if refgap_bp:
+        ref_input_bp = result['input_bp'].get(sorted(refgap_bp)[0])
+    problems = detect_problems(result, refgap_bp=refgap_bp, ref_input_bp=ref_input_bp)
+    warning_id = None
+    if problems:
+        warning_path = os.path.join(out_dir, 'WARNING')
+        with open(warning_path, 'w') as warning_file:
+            warning_file.write('cactus-pangenome finished, but the exclusion accounting looks '
+                               'wrong. Each note below is a heuristic, not a failure -- check it '
+                               'against your data before acting.\n\n')
+            for problem in problems:
+                warning_file.write('* ' + problem + '\n\n')
+            warning_file.write('Full detail: the clipped-by-*.tsv tables and clipped*.tar.gz '
+                               'archives in <outName>.stats/.\n')
+        warning_id = job.fileStore.writeGlobalFile(warning_path)
+        # logged from inside the job: RealtimeLogger is the only channel that reaches the console
+        # both here and under cactus-pangenome, where export runs in a worker
+        for problem in problems:
+            RealtimeLogger.warning('exclusion report: ' + problem)
+        RealtimeLogger.warning(
+            'The above means {}.WARNING was written. This run finished, but its exclusion '
+            'accounting looks wrong -- please read that file.'.format(
+                getattr(options, 'outName', '<outName>')))
+
+    if result['orphan_paths']:
+        RealtimeLogger.warning(
+            'exclusion report: {} graph path group(s) have no input contig, e.g. {}'.format(
+                result['orphan_paths'], result['orphan_keys']))
+    if result['outside_baseline_bp']:
+        RealtimeLogger.warning('exclusion report: {} bp of graph coverage fall outside the input '
+                               'contig bounds'.format(result['outside_baseline_bp']))
+    with open(summary_path, 'r') as summary_file:
+        RealtimeLogger.info('Exclusion report:\n' + summary_file.read())
+
+    # one tarball per graph, so the common case -- "give me what is missing from the graph I am
+    # using" -- is a single download with no post-processing
+    missing_out = {}
+    for phase, phase_dir in result['phase_dirs'].items():
+        base = os.path.basename(phase_dir)
+        tar_path = os.path.join(work_dir, base + '.tar.gz')
+        cactus_call(parameters=['tar', 'czf', tar_path, '-C', out_dir, base])
+        missing_out[base + '.tar.gz'] = job.fileStore.writeGlobalFile(tar_path)
+
+    return {'summary.tsv': job.fileStore.writeGlobalFile(summary_path),
+            'clipped-by-input-contig.tsv.gz': job.fileStore.writeGlobalFile(contig_stats_path),
+            'clipped-by-reference-contig.tsv': job.fileStore.writeGlobalFile(chrom_stats_path),
+            'missing': missing_out,
+            'refgaps': refgap_out,
+            'WARNING': warning_id}
+
+
+def contig_sizes_job(job, seq_id_map, graph_event):
+    """ build the exclusion report's baseline from the *sanitized* input fastas, whose contig names
+    are already in the namespace the graph paths and the split log use.
+
+    this has to run early, right after sanitization, because the fastas do not survive to the join:
+    sanitize_fasta_header deletes its input from the jobstore, and the sanitized copies are cleaned
+    up once splitting is done.  only this small table is carried forward.
+
+    one child per genome, then a follow-on to concatenate """
+    per_event = {}
+    for event in sorted(seq_id_map.keys()):
+        if event == graph_event:
+            continue
+        safe_event_filename(event)
+        fa_id = seq_id_map[event]
+        per_event[event] = job.addChildJobFn(contig_sizes_for_event, fa_id, event,
+                                             disk=fa_id.size * 3).rv()
+    return job.addFollowOnJobFn(merge_contig_sizes, per_event).rv()
+
+
+def contig_sizes_for_event(job, fa_id, event):
+    """ faidx one sanitized genome and return its baseline rows """
+    work_dir = job.fileStore.getLocalTempDir()
+    fa_path = os.path.join(work_dir, '{}.fa'.format(event))
+    job.fileStore.readGlobalFile(fa_id, fa_path)
+    cactus_call(parameters=['samtools', 'faidx', fa_path])
+    return contig_sizes_from_fai(fa_path + '.fai', event)
+
+
+def merge_contig_sizes(job, per_event_rows):
+    work_dir = job.fileStore.getLocalTempDir()
+    rows = []
+    for event in sorted(per_event_rows.keys()):
+        rows += per_event_rows[event]
+    out_path = os.path.join(work_dir, 'input-contig-sizes.tsv.gz')
+    write_baseline_tsv(rows, out_path)
+    RealtimeLogger.info('exclusion report baseline: {} contigs over {} genomes, {} bp'.format(
+        len(rows), len(set(r[0] for r in rows)), sum(r[4] for r in rows)))
+    return job.fileStore.writeGlobalFile(out_path)

--- a/src/cactus/refmap/pangenome_exclusionsTest.py
+++ b/src/cactus/refmap/pangenome_exclusionsTest.py
@@ -1,0 +1,575 @@
+#!/usr/bin/env python3
+
+"""
+Unit tests for the pure (non-Toil) logic behind the pangenome exclusion report: the hal2vg name
+resolution that has to match hal2vg.cpp, PanSN path parsing, interval algebra, and the parsers for
+the baseline table, the split log and vg depth output.
+
+These are fast and offline.  The end-to-end report is covered by evolverTest.py.
+"""
+
+import gzip
+import subprocess
+import os
+import shutil
+import tempfile
+import unittest
+
+from cactus.refmap.pangenome_exclusions import (
+    compute_exclusions, sublabel_dropped, write_summary, merge_sorted_bed_stream, pansn_prefix_to_event,
+    DEPTH_TO_BED_AWK, PHASE_REASON, check_baseline_header, detect_problems,
+    BASELINE_HEADER, baseline_by_key, contig_sizes_from_fai,
+    event_by_pansn_prefix, event_to_pansn_prefix, intersect_intervals, merge_intervals,
+    parse_path_name, parse_split_log, read_baseline_tsv, resolve_subpath_naming,
+    safe_event_filename, subtract_intervals, total_bp, write_baseline_tsv)
+
+
+class TestSubpathNaming(unittest.TestCase):
+
+    def test_plain_contig(self):
+        self.assertEqual(resolve_subpath_naming('chr1'), ('chr1', 0, None))
+
+    def test_single_subpath(self):
+        self.assertEqual(resolve_subpath_naming('chr1_sub_999_2000'), ('chr1', 999, 1001))
+
+    def test_nested_subpath(self):
+        # offsets sum; the length is the innermost (first-parsed) one
+        self.assertEqual(resolve_subpath_naming('a_sub_10_20_sub_2_5'), ('a', 12, 3))
+
+    def test_non_numeric_suffix_is_opaque(self):
+        # a contig genuinely called "scaf_sub_unit" is not a coordinate encoding
+        self.assertEqual(resolve_subpath_naming('scaf_sub_unit'), ('scaf_sub_unit', 0, None))
+
+    def test_zero_offset_subpath(self):
+        self.assertEqual(resolve_subpath_naming('chrI_sub_0_219929'), ('chrI', 0, 219929))
+
+
+class TestEventToPansn(unittest.TestCase):
+
+    def test_haploid(self):
+        self.assertEqual(event_to_pansn_prefix('S288C'), 'S288C#0')
+
+    def test_diploid(self):
+        self.assertEqual(event_to_pansn_prefix('HG002.1'), 'HG002#1')
+        self.assertEqual(event_to_pansn_prefix('HG002.2'), 'HG002#2')
+
+    def test_non_numeric_suffix_is_not_a_haplotype(self):
+        self.assertEqual(event_to_pansn_prefix('HG002.verkko'), 'HG002.verkko#0')
+
+    def test_numeric_suffix_after_dotted_name(self):
+        self.assertEqual(event_to_pansn_prefix('HG002.verkko.1'), 'HG002.verkko#1')
+
+
+class TestParsePathName(unittest.TestCase):
+
+    def test_reference_sense(self):
+        self.assertEqual(parse_path_name('S288C#0#chrI', 219929), ('S288C#0', 'chrI', 0, 219929))
+
+    def test_haplotype_sense(self):
+        self.assertEqual(parse_path_name('Y12#0#chrI#0', 197190), ('Y12#0', 'chrI', 0, 197190))
+
+    def test_subrange(self):
+        self.assertEqual(parse_path_name('SK1#0#chrI#0[14059-228861]', 214802),
+                         ('SK1#0', 'chrI', 14059, 228861))
+
+    def test_subrange_width_equals_path_length(self):
+        # the invariant the coverage job asserts on every line
+        _p, _c, start, end = parse_path_name('SK1#0#chrI#0[14059-228861]', 214802)
+        self.assertEqual(end - start, 214802)
+
+    def test_minigraph_path_still_parses(self):
+        self.assertEqual(parse_path_name('_MINIGRAPH_#0#s113[0-405]', 405),
+                         ('_MINIGRAPH_#0', 's113', 0, 405))
+
+    def test_non_pansn_is_orphan(self):
+        self.assertIsNone(parse_path_name('chrI', 100))
+        self.assertIsNone(parse_path_name('sample#0', 100))
+
+
+class TestIntervals(unittest.TestCase):
+
+    def test_merge(self):
+        self.assertEqual(merge_intervals([(5, 10), (0, 3), (2, 6)]), [(0, 10)])
+        self.assertEqual(merge_intervals([(0, 3), (3, 6)]), [(0, 6)])
+        self.assertEqual(merge_intervals([(0, 3), (4, 6)]), [(0, 3), (4, 6)])
+        self.assertEqual(merge_intervals([]), [])
+        self.assertEqual(merge_intervals([(5, 5)]), [])
+
+    def test_subtract(self):
+        self.assertEqual(subtract_intervals([(0, 100)], [(10, 20)]), [(0, 10), (20, 100)])
+        self.assertEqual(subtract_intervals([(0, 100)], [(0, 100)]), [])
+        self.assertEqual(subtract_intervals([(0, 100)], []), [(0, 100)])
+        self.assertEqual(subtract_intervals([], [(0, 10)]), [])
+        self.assertEqual(subtract_intervals([(0, 10), (20, 30)], [(5, 25)]), [(0, 5), (25, 30)])
+        self.assertEqual(subtract_intervals([(0, 100)], [(0, 10), (90, 100)]), [(10, 90)])
+
+    def test_intersect(self):
+        self.assertEqual(intersect_intervals([(0, 100)], [(10, 20)]), [(10, 20)])
+        self.assertEqual(intersect_intervals([(0, 10)], [(20, 30)]), [])
+        self.assertEqual(intersect_intervals([(0, 10), (20, 30)], [(5, 25)]), [(5, 10), (20, 25)])
+
+    def test_total_bp(self):
+        self.assertEqual(total_bp([(0, 10), (20, 25)]), 15)
+
+    def test_phase_subtraction_is_nested(self):
+        # the core of the report: missing_clip - missing_full is what the clip phase removed
+        baseline = [(0, 1000)]
+        cov_full = [(0, 1000)]
+        cov_clip = [(100, 900)]
+        missing_full = subtract_intervals(baseline, cov_full)
+        missing_clip = subtract_intervals(baseline, cov_clip)
+        self.assertEqual(missing_full, [])
+        self.assertEqual(subtract_intervals(missing_clip, missing_full),
+                         [(0, 100), (900, 1000)])
+
+
+class TestHprcTwoFragmentClosure(unittest.TestCase):
+    """ an input contig split into two _sub_ fragments must close to zero missing.  without the
+    hal2vg name resolution this reports the whole contig lost AND the whole contig as orphan
+    coverage, which is the single most damaging way this feature could be wrong """
+
+    def test_two_fragments_close_to_zero(self):
+        rows = [('HG02080.1', 'HG02080#1', 'JAHEOW010000073.1', 0, 7238466),
+                ('HG02080.1', 'HG02080#1', 'JAHEOW010000073.1', 7238466, 5630658)]
+        baseline = baseline_by_key(rows)
+        key = ('HG02080#1', 'JAHEOW010000073.1')
+        self.assertEqual(baseline[key], [(0, 12869124)])
+
+        coverage = []
+        for name, length in [('HG02080#1#JAHEOW010000073.1#0[0-7238466]', 7238466),
+                             ('HG02080#1#JAHEOW010000073.1#0[7238466-12869124]', 5630658)]:
+            pansn, contig, start, end = parse_path_name(name, length)
+            self.assertEqual((pansn, contig), key)
+            self.assertEqual(end - start, length)
+            coverage.append((start, end))
+
+        self.assertEqual(subtract_intervals(baseline[key], coverage), [])
+
+    def test_fai_round_trip(self):
+        tmp_dir = tempfile.mkdtemp()
+        try:
+            fai_path = os.path.join(tmp_dir, 'x.fa.fai')
+            with open(fai_path, 'w') as fai_file:
+                fai_file.write('id=HG02080.1|JAHEOW010000073.1_sub_0_7238466\t7238466\t0\t60\t61\n')
+                fai_file.write('id=HG02080.1|JAHEOW010000073.1_sub_7238466_12869124\t5630658\t0\t60\t61\n')
+            rows = contig_sizes_from_fai(fai_path, 'HG02080.1')
+            self.assertEqual(len(rows), 2)
+            self.assertEqual(baseline_by_key(rows)[('HG02080#1', 'JAHEOW010000073.1')],
+                             [(0, 12869124)])
+        finally:
+            shutil.rmtree(tmp_dir)
+
+    def test_fai_strips_foreign_id_prefix(self):
+        # the sanitizer passes through a pre-existing id=X| even when X is not the event
+        tmp_dir = tempfile.mkdtemp()
+        try:
+            fai_path = os.path.join(tmp_dir, 'x.fa.fai')
+            with open(fai_path, 'w') as fai_file:
+                fai_file.write('id=SOMETHINGELSE|chrI\t219929\t0\t60\t61\n')
+            rows = contig_sizes_from_fai(fai_path, 'S288C')
+            self.assertEqual(rows[0][1], 'S288C#0')
+            self.assertEqual(rows[0][2], 'chrI')
+        finally:
+            shutil.rmtree(tmp_dir)
+
+
+class TestBaselineTsv(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp_dir)
+
+    def test_round_trip(self):
+        rows = [('S288C', 'S288C#0', 'chrI', 0, 219929)]
+        path = os.path.join(self.tmp_dir, 'sizes.tsv')
+        write_baseline_tsv(rows, path)
+        self.assertEqual(read_baseline_tsv(path), rows)
+
+    def test_rejects_contig_sizes_matrix(self):
+        """ chrom-subproblems/contig_sizes.tsv lives in the same output tree and has 10 columns of
+        completely different meaning.  parsing it would yield a silent 100%-loss report """
+        path = os.path.join(self.tmp_dir, 'contig_sizes.tsv')
+        with open(path, 'w') as out_file:
+            out_file.write('Contig\tDBVPG6044\tS288C\tSK1\tUWOPS034614\tY12\tYPS128\t'
+                           '_MINIGRAPH_\tmin\tmax\tavg\n')
+            out_file.write('chrXV\t1062383\t1091343\t1053869\t1062502\t1048295\t1072763\t'
+                           '1091343\t1048295\t1091343\t1068928\n')
+        with self.assertRaises(RuntimeError) as caught:
+            read_baseline_tsv(path)
+        message = str(caught.exception)
+        self.assertIn('contig_sizes.tsv', message)
+        self.assertIn('input-contig-sizes.tsv', message)
+
+    def test_event_lookup(self):
+        rows = [('S288C', 'S288C#0', 'chrI', 0, 219929),
+                ('HG002.1', 'HG002#1', 'chr1', 0, 100)]
+        self.assertEqual(event_by_pansn_prefix(rows), {'S288C#0': 'S288C', 'HG002#1': 'HG002.1'})
+
+
+class TestDepthToBed(unittest.TestCase):
+    """ the vg depth -> BED conversion, which is a one-line awk program in the pipe (so that a whole
+    genome's per-base output never reaches python) plus a streaming merge.  the awk program is
+    pinned here by running it for real: an off-by-one would shift every reference gap """
+
+    @staticmethod
+    def depth_lines(path, depths):
+        """ vg depth prints 1-based positions """
+        return ''.join('{}\t{}\t{}\n'.format(path, i + 1, d) for i, d in enumerate(depths))
+
+    def awk(self, text):
+        proc = subprocess.run(['awk', DEPTH_TO_BED_AWK], input=text,
+                              capture_output=True, text=True, check=True)
+        return proc.stdout.splitlines(keepends=True)
+
+    def runs(self, depths, min_length=1, offsets=None, path='R#0#chr1'):
+        return list(merge_sorted_bed_stream(self.awk(self.depth_lines(path, depths)),
+                                            min_length, offsets))
+
+    def test_all_zero_path(self):
+        # a length-10 path with no other assembly aligned is exactly (0, 10), NOT (1, 11)
+        self.assertEqual(self.runs([0] * 10), [('R#0#chr1', 0, 10)])
+
+    def test_interior_gap(self):
+        # 15bp reference, middle 5bp uncovered
+        self.assertEqual(self.runs([1] * 5 + [0] * 5 + [1] * 5), [('R#0#chr1', 5, 10)])
+
+    def test_run_touching_last_base(self):
+        depths = [1] * 5 + [0] * 5
+        runs = self.runs(depths)
+        self.assertEqual(runs, [('R#0#chr1', 5, 10)])
+        # end must equal the contig length, never length + 1
+        self.assertEqual(runs[0][2], len(depths))
+
+    def test_single_base_gap(self):
+        self.assertEqual(self.runs([1, 0, 1]), [('R#0#chr1', 1, 2)])
+
+    def test_min_length_filter(self):
+        depths = [1] + [0] * 3 + [1] + [0] * 10
+        self.assertEqual(self.runs(depths, min_length=5), [('R#0#chr1', 5, 15)])
+        self.assertEqual(len(self.runs(depths, min_length=1)), 2)
+
+    def test_multiple_paths(self):
+        text = self.depth_lines('R#0#chr1', [0, 0]) + self.depth_lines('R#0#chr2', [0, 0, 0])
+        self.assertEqual(list(merge_sorted_bed_stream(self.awk(text), 1)),
+                         [('R#0#chr1', 0, 2), ('R#0#chr2', 0, 3)])
+
+    def test_no_zero_depth(self):
+        self.assertEqual(self.runs([1, 2, 3]), [])
+
+    def test_vg_depth_positions_are_already_absolute(self):
+        """ vg depth adds the subrange offset itself, so nothing downstream may add it again.
+        this pins that the conversion is a pure 1-based -> 0-based shift """
+        depths = ''.join('R#0#chr1\t{}\t0\n'.format(p) for p in range(1001, 1016))
+        self.assertEqual(list(merge_sorted_bed_stream(self.awk(depths), 1)),
+                         [('R#0#chr1', 1000, 1015)])
+
+    def test_merge_is_streaming_over_adjacent_singletons(self):
+        # merge_sorted_bed_stream must join abutting intervals, which is what awk emits per base
+        lines = ['c\t0\t1\n', 'c\t1\t2\n', 'c\t2\t3\n', 'c\t10\t11\n']
+        self.assertEqual(list(merge_sorted_bed_stream(lines, 1)), [('c', 0, 3), ('c', 10, 11)])
+
+
+class TestSplitLog(unittest.TestCase):
+
+    LOG = ('Assigned contig to chrXII: id=YPS128|chrXII  len=1027157 cov=0.972882 (vs 0.25) uf= infinity (vs 2)\n'
+           'Assigned ref-contig to chrIII: id=S288C|chrIII  len=341580 cov=0.999701 (vs 0.5) uf= infinity (vs 2)\n'
+           'Query contig is ambiguous: id=UWOPS034614|chrVII  len=632616 cov=0.407615 (vs 0.5) uf= infinity (vs 2)\n'
+           ' Reference contig mappings:\n'
+           '  chrVII: 353547\n')
+
+    def test_parse(self):
+        tmp_dir = tempfile.mkdtemp()
+        try:
+            path = os.path.join(tmp_dir, 'minigraph.split.log')
+            with open(path, 'w') as log_file:
+                log_file.write(self.LOG)
+            assigned, ambiguous = parse_split_log(path)
+            self.assertEqual(assigned, {('YPS128', 'chrXII', 0): 'chrXII',
+                                        ('S288C', 'chrIII', 0): 'chrIII'})
+            self.assertEqual(ambiguous, {('UWOPS034614', 'chrVII', 0)})
+        finally:
+            shutil.rmtree(tmp_dir)
+
+    def test_fragment_names_resolve_to_contig_and_offset(self):
+        """ the log names a fragment the way cactus named it internally; it has to land in the same
+        (contig, offset) space as the graph and the input contig sizes, or a dropped fragment
+        cannot be matched to its decision """
+        tmp_dir = tempfile.mkdtemp()
+        try:
+            path = os.path.join(tmp_dir, 'minigraph.split.log')
+            with open(path, 'w') as log_file:
+                log_file.write('Assigned contig to chr6: id=HG002.1|chr6_sub_300000_597871  '
+                               'len=297871 cov=0.93 (vs 0.5) uf= infinity (vs 2)\n')
+                log_file.write('Query contig is ambiguous: id=HG002.1|chr1_sub_10_20_sub_2_5  '
+                               'len=3 cov=0.1 (vs 0.5) uf=1.1 (vs 2)\n')
+            assigned, ambiguous = parse_split_log(path)
+            self.assertEqual(assigned, {('HG002.1', 'chr6', 300000): 'chr6'})
+            # nested fragment names collapse to the summed offset, as hal2vg resolves them
+            self.assertEqual(ambiguous, {('HG002.1', 'chr1', 12)})
+        finally:
+            shutil.rmtree(tmp_dir)
+
+    def test_silently_dropped_contig_is_in_neither_bucket(self):
+        """ a contig rgfa-split made no decision about appears in neither map.  conflating that
+        silence with either bucket is exactly the bug this feature exists to surface """
+        tmp_dir = tempfile.mkdtemp()
+        try:
+            path = os.path.join(tmp_dir, 'minigraph.split.log')
+            with open(path, 'w') as log_file:
+                log_file.write(self.LOG)
+            assigned, ambiguous = parse_split_log(path)
+            key = ('UWOPS034614', 'chrVI', 0)
+            self.assertNotIn(key, assigned)
+            self.assertNotIn(key, ambiguous)
+        finally:
+            shutil.rmtree(tmp_dir)
+
+
+class TestComputeExclusions(unittest.TestCase):
+    """ the classification, driven off small fixtures shaped like real coverage files """
+
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp_dir)
+
+    def write_cov(self, name, entries):
+        path = os.path.join(self.tmp_dir, name)
+        with open(path, 'w') as out_file:
+            for pansn, contig, start, end in entries:
+                out_file.write('{}\t{}\t{}\t{}\n'.format(pansn, contig, start, end))
+        return path
+
+    def read_bed(self, event, tag=''):
+        """ tag selects the graph: '' is clip, '.full' the full graph, '.dN' the filtered one """
+        path = os.path.join(self.tmp_dir, 'clipped' + tag + '.beds', '{}.bed'.format(event))
+        with open(path, 'r') as in_file:
+            return [tuple(l.rstrip('\n').split('\t')) for l in in_file]
+
+    BASELINE = [('A', 'A#0', 'chr1', 0, 1000),
+                ('A', 'A#0', 'chr2', 0, 500)]
+
+    def test_clip_and_filter_are_attributed_separately(self):
+        full = self.write_cov('c.full', [('A#0', 'chr1', 0, 1000)])
+        clip = self.write_cov('c.clip', [('A#0', 'chr1', 100, 1000)])
+        filt = self.write_cov('c.filter', [('A#0', 'chr1', 100, 900)])
+        baseline = [('A', 'A#0', 'chr1', 0, 1000)]
+        result = compute_exclusions(baseline, {'full': [full], 'clip': [clip], 'filter': [filt]},
+                                    ['full', 'clip', 'filter'], None, ['chr1'], self.tmp_dir,
+                                    filter_threshold=2)
+        rows = self.read_bed('A', '.d2')
+        self.assertIn(('chr1', '0', '100', 'clip'), rows)
+        self.assertIn(('chr1', '900', '1000', 'filter'), rows)
+        self.assertEqual(result['counts'][('A', 'clip')], [1, 100])
+        self.assertEqual(result['counts'][('A', 'filter')], [1, 100])
+
+    def test_absent_phase_produces_no_rows(self):
+        """ the regression that matters most: under default options 'filter' never runs, and the
+        report must not charge it the entire graph """
+        full = self.write_cov('c.full', [('A#0', 'chr1', 0, 1000)])
+        clip = self.write_cov('c.clip', [('A#0', 'chr1', 100, 1000)])
+        baseline = [('A', 'A#0', 'chr1', 0, 1000)]
+        result = compute_exclusions(baseline, {'full': [full], 'clip': [clip]}, ['full', 'clip'],
+                                    None, ['chr1'], self.tmp_dir)
+        self.assertNotIn(('A', 'filter'), result['counts'])
+        self.assertEqual([r for r in self.read_bed('A') if r[3] == 'filter'], [])
+        self.assertEqual(result['phases'], ['full', 'clip'])
+
+    def test_contig_in_no_graph_is_dropped_not_clipped(self):
+        full = self.write_cov('c.full', [('A#0', 'chr1', 0, 1000)])
+        clip = self.write_cov('c.clip', [('A#0', 'chr1', 0, 1000)])
+        result = compute_exclusions(self.BASELINE, {'full': [full], 'clip': [clip]},
+                                    ['full', 'clip'], ({}, set()), ['chr1'], self.tmp_dir)
+        rows = self.read_bed('A')
+        self.assertIn(('chr2', '0', '500', 'unassigned'), rows)
+        self.assertEqual(result['counts'][('A', 'unassigned')], [1, 500])
+
+    def test_split_log_distinguishes_ambiguous_from_unassigned(self):
+        full = self.write_cov('c.full', [('A#0', 'chr1', 0, 1000)])
+        baseline = self.BASELINE + [('A', 'A#0', 'chr3', 0, 300)]
+        split_log = ({}, {('A', 'chr2', 0)})
+        result = compute_exclusions(baseline, {'full': [full]}, ['full'], split_log,
+                                    ['chr1'], self.tmp_dir)
+        rows = dict((r[0], r[3]) for r in self.read_bed('A', '.full'))
+        self.assertEqual(rows['chr2'], 'ambiguous')
+        self.assertEqual(rows['chr3'], 'unassigned')
+
+    def test_assigned_to_missing_chromosome_graph(self):
+        """ --refContigs without --otherContig drops whole chromosomes after assignment """
+        full = self.write_cov('c.full', [('A#0', 'chr1', 0, 1000)])
+        split_log = ({('A', 'chr2', 0): 'chr2'}, set())
+        result = compute_exclusions(self.BASELINE, {'full': [full]}, ['full'], split_log,
+                                    ['chr1'], self.tmp_dir)
+        self.assertEqual(dict((r[0], r[3]) for r in self.read_bed('A', '.full'))['chr2'],
+                         'no_chromosome_graph')
+
+    def test_contig_folded_into_chrOther_is_unaligned_not_no_graph(self):
+        """ the GRCh38 default: rgfa-split logs the fine-grained ref contig, cactus folds it into
+        chrOther, which IS built.  a contig that reached chrOther and lost all its sequence there
+        is unaligned, not no_chromosome_graph, and files under chrOther """
+        full = self.write_cov('c.full', [('A#0', 'chr1', 0, 1000)])
+        # chr2 was assigned to a random contig that has no graph of its own, folded into chrOther
+        split_log = ({('A', 'chr2', 0): 'chr14_GL000009v2_random'}, set())
+        result = compute_exclusions(self.BASELINE, {'full': [full]}, ['full'], split_log,
+                                    ['chr1', 'chrOther'], self.tmp_dir, other_contig='chrOther')
+        self.assertEqual(dict((r[0], r[3]) for r in self.read_bed('A', '.full'))['chr2'],
+                         'unaligned')
+        # and it files under the graph it reached, not the phantom random contig
+        chrom_of = dict((contig, chrom) for chrom, _ev, contig, *_ in result['contig_rows'])
+        self.assertEqual(chrom_of['chr2'], 'chrOther')
+        # not exempt from the warning, unlike a genuine no_chromosome_graph
+        self.assertIn(('A', 'unaligned'), result['counts'])
+
+    def test_partially_covered_contig_is_never_split_labelled(self):
+        """ any full-phase coverage proves the contig reached a graph, whatever the log says """
+        full = self.write_cov('c.full', [('A#0', 'chr1', 0, 900)])
+        baseline = [('A', 'A#0', 'chr1', 0, 1000)]
+        split_log = ({}, {('A', 'chr1', 0)})
+        compute_exclusions(baseline, {'full': [full]}, ['full'], split_log, ['chr1'], self.tmp_dir)
+        self.assertEqual(dict((r[0], r[3]) for r in self.read_bed('A', '.full'))['chr1'], 'unaligned')
+
+    def test_degraded_baseline_suppresses_dropped(self):
+        full = self.write_cov('c.full', [('A#0', 'chr1', 0, 1000)])
+        clip = self.write_cov('c.clip', [('A#0', 'chr1', 100, 1000)])
+        result = compute_exclusions(None, {'full': [full], 'clip': [clip]}, ['full', 'clip'],
+                                    None, ['chr1'], self.tmp_dir)
+        self.assertFalse(result['report_dropped'])
+        self.assertEqual(result['counts'][('A', 'clip')], [1, 100])
+        self.assertNotIn(('A', 'unassigned'), result['counts'])
+
+    def test_every_genome_gets_a_file_even_with_no_loss(self):
+        full = self.write_cov('c.full', [('A#0', 'chr1', 0, 1000), ('A#0', 'chr2', 0, 500)])
+        compute_exclusions(self.BASELINE, {'full': [full]}, ['full'], None, ['chr1'], self.tmp_dir)
+        self.assertEqual(self.read_bed('A', '.full'), [])
+        self.assertTrue(os.path.exists(os.path.join(self.tmp_dir, 'clipped.full.beds', 'A.bed')))
+
+    def test_single_base_filter_fragments_are_enumerated(self):
+        """ the allele-frequency filter removes private alleles, which are often 1bp.  they are
+        real excluded sequence and must appear in the BED like anything else """
+        full = self.write_cov('c.full', [('A#0', 'chr1', 0, 1000)])
+        clip = self.write_cov('c.clip', [('A#0', 'chr1', 0, 1000)])
+        filt = self.write_cov('c.filter', [('A#0', 'chr1', 0, 10), ('A#0', 'chr1', 11, 1000)])
+        baseline = [('A', 'A#0', 'chr1', 0, 1000)]
+        result = compute_exclusions(baseline, {'full': [full], 'clip': [clip], 'filter': [filt]},
+                                    ['full', 'clip', 'filter'], None, ['chr1'], self.tmp_dir,
+                                    filter_threshold=2)
+        self.assertIn(('chr1', '10', '11', 'filter'), self.read_bed('A', '.d2'))
+        self.assertEqual(result['counts'][('A', 'filter')], [1, 1])
+
+    def test_each_graph_gets_its_own_cumulative_bed(self):
+        """ the whole point of splitting by graph: what is missing from the clipped graph must not
+        include what the later frequency filter took, and the filtered graph must include both """
+        full = self.write_cov('c.full', [('A#0', 'chr1', 0, 1000)])
+        clip = self.write_cov('c.clip', [('A#0', 'chr1', 100, 1000)])
+        filt = self.write_cov('c.filter', [('A#0', 'chr1', 100, 900)])
+        baseline = [('A', 'A#0', 'chr1', 0, 1000),
+                    ('A', 'A#0', 'chr2', 0, 500)]
+        compute_exclusions(baseline, {'full': [full], 'clip': [clip], 'filter': [filt]},
+                           ['full', 'clip', 'filter'], ({}, set()), ['chr1'], self.tmp_dir,
+                           filter_threshold=2)
+        full_bed = self.read_bed('A', '.full')
+        clip_bed = self.read_bed('A', '')
+        filt_bed = self.read_bed('A', '.d2')
+        # chr2 never reached a graph, so it is missing from all three
+        self.assertIn(('chr2', '0', '500', 'unassigned'), full_bed)
+        self.assertIn(('chr2', '0', '500', 'unassigned'), clip_bed)
+        self.assertIn(('chr2', '0', '500', 'unassigned'), filt_bed)
+        # the clip removal is absent from the full graph's set, present in the other two
+        self.assertNotIn(('chr1', '0', '100', 'clip'), full_bed)
+        self.assertIn(('chr1', '0', '100', 'clip'), clip_bed)
+        self.assertIn(('chr1', '0', '100', 'clip'), filt_bed)
+        # the filter removal appears only in the filtered graph's set
+        self.assertNotIn(('chr1', '900', '1000', 'filter'), clip_bed)
+        self.assertIn(('chr1', '900', '1000', 'filter'), filt_bed)
+        self.assertTrue(len(full_bed) < len(clip_bed) < len(filt_bed))
+
+    def test_coverage_outside_baseline_is_counted_not_crashed(self):
+        full = self.write_cov('c.full', [('A#0', 'chr1', 0, 1200)])
+        baseline = [('A', 'A#0', 'chr1', 0, 1000)]
+        result = compute_exclusions(baseline, {'full': [full]}, ['full'], None,
+                                    ['chr1'], self.tmp_dir)
+        self.assertEqual(result['outside_baseline_bp'], 200)
+
+    def test_graph_key_with_no_baseline_row_is_an_orphan_not_a_crash(self):
+        full = self.write_cov('c.full', [('A#0', 'chr1', 0, 1000), ('Z#0', 'chrZ', 0, 77)])
+        baseline = [('A', 'A#0', 'chr1', 0, 1000)]
+        result = compute_exclusions(baseline, {'full': [full]}, ['full'], None,
+                                    ['chr1'], self.tmp_dir)
+        self.assertEqual(result['orphan_paths'], 1)
+        self.assertEqual(result['orphan_bp'], 77)
+
+
+class TestEventFilename(unittest.TestCase):
+
+    def test_accepts_normal_names(self):
+        self.assertEqual(safe_event_filename('HG002.1'), 'HG002.1')
+
+    def test_rejects_path_separators(self):
+        for bad in ['a/b', '..', '.']:
+            with self.assertRaises(RuntimeError):
+                safe_event_filename(bad)
+
+
+
+
+class TestDetectProblems(unittest.TestCase):
+    """ the WARNING heuristics.  the hard part is not spotting a bad run, it is staying quiet on a
+    deliberately lossy one -- calibrated against real yeast and primate runs """
+
+    @staticmethod
+    def result(counts, input_bp, whole_dropped=None, outside=0, orphans=0):
+        return {'counts': counts, 'input_bp': input_bp, 'whole_dropped': whole_dropped or {},
+                'outside_baseline_bp': outside, 'orphan_paths': orphans, 'orphan_keys': []}
+
+    def test_silent_on_a_healthy_panel(self):
+        # every genome loses ~10% to the frequency filter, as the primates run does
+        counts = dict(((s, 'filter'), [100, 1000000]) for s in ['a', 'b', 'c', 'd'])
+        result = self.result(counts, dict((s, 10000000) for s in ['a', 'b', 'c', 'd']))
+        self.assertEqual(detect_problems(result), [])
+
+    def test_flags_a_genome_that_reached_no_graph(self):
+        counts = {('bad', 'ambiguous'): [4, 3000000], ('ok', 'clip'): [2, 100000]}
+        result = self.result(counts, {'bad': 10000000, 'ok': 10000000})
+        problems = detect_problems(result)
+        self.assertTrue(any('bad' in p and 'no graph at all' in p for p in problems))
+        self.assertFalse(any(p.startswith('ok') for p in problems))
+
+    def test_silent_on_uniform_deliberate_loss(self):
+        """ --refContigs drops whole chromosomes from every genome on purpose.  that is
+        no_chromosome_graph, it is uniform, and it must not raise anything """
+        counts = dict(((s, 'no_chromosome_graph'), [3, 2400000]) for s in ['a', 'b', 'c', 'd'])
+        result = self.result(counts, dict((s, 10000000) for s in ['a', 'b', 'c', 'd']))
+        self.assertEqual(detect_problems(result), [])
+
+    def test_flags_an_outlier_genome(self):
+        counts = dict(((s, 'clip'), [10, 500000]) for s in ['a', 'b', 'c'])
+        counts[('bad', 'clip')] = [10, 4000000]
+        input_bp = dict((s, 10000000) for s in ['a', 'b', 'c', 'bad'])
+        problems = detect_problems(self.result(counts, input_bp))
+        self.assertTrue(any('bad' in p and 'differently from the rest' in p for p in problems))
+
+    def test_names_whole_contigs_that_vanished(self):
+        result = self.result({}, {'bad': 10000000},
+                             whole_dropped={'bad': [('chrVII', 632616, 'ambiguous')]})
+        problems = detect_problems(result)
+        self.assertTrue(any('chrVII' in p and '632616' in p for p in problems))
+
+    def test_flags_a_reference_nothing_aligns_to(self):
+        result = self.result({}, {'ref': 10000000})
+        problems = detect_problems(result, refgap_bp={'ref': (10, 5000000)},
+                                   ref_input_bp=10000000)
+        self.assertTrue(any('no other assembly aligned' in p for p in problems))
+
+    def test_flags_internal_inconsistency(self):
+        for kwargs in ({'outside': 1234}, {'orphans': 3}):
+            problems = detect_problems(self.result({}, {'a': 1000}, **kwargs))
+            self.assertTrue(any(p.startswith('INTERNAL') for p in problems))
+
+    def test_no_division_by_zero_on_an_empty_genome(self):
+        self.assertEqual(detect_problems(self.result({}, {'a': 0})), [])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -682,9 +682,14 @@ class TestCase(unittest.TestCase):
         self.assertEqual(proc.returncode, 0,
                          'vg validate failed for {}\nstderr:\n{}'.format(gfa_path, proc.stderr.decode()))
 
-    def _check_exclusion_report(self, join_path, events):
+    def _check_exclusion_report(self, join_path, events, expect_report=True):
         """ every input base that is not in a given graph must be accounted for, exactly once, with
         a cause attached.
+
+        expect_report is False for the step-by-step pipeline, whose cactus-graphmap-join runs
+        standalone without --inputContigSizes: with no record of the input contig lengths it
+        correctly writes no clipping report, only the baseline-free outputs (graph stats, refgaps).
+        That case is asserted positively below rather than skipped.
 
         the headline assertion is closure: for every genome, the bases present in the clipped graph
         plus the bases in that genome's BED must add up to the input length, to the base.  that is
@@ -698,6 +703,16 @@ class TestCase(unittest.TestCase):
 
         stats_dir = os.path.join(join_path, 'yeast.stats')
         self.assertTrue(os.path.isdir(stats_dir), 'no yeast.stats directory')
+
+        if not expect_report:
+            # standalone cactus-graphmap-join with no --inputContigSizes: no clipping report, but
+            # the outputs that do not need the input contig lengths must still be there
+            self.assertFalse(os.path.isfile(os.path.join(stats_dir, 'clipped-by-genome.tsv')),
+                             'a clipping report was written without --inputContigSizes')
+            self.assertFalse(os.path.exists(os.path.join(join_path, 'yeast.WARNING')))
+            self.assertTrue(os.path.isfile(os.path.join(stats_dir, 'graph-stats.tsv')))
+            self.assertTrue(os.path.isfile(os.path.join(stats_dir, 'refgaps.bed.gz')))
+            return
 
         def merged_bp(intervals):
             """ deliberately a second implementation, so this test does not verify the module with
@@ -891,7 +906,7 @@ class TestCase(unittest.TestCase):
         for quiet in ['DBVPG6044', 'Y12', 'YPS128']:
             self.assertNotIn(quiet + ':', warning_text)
 
-    def _check_yeast_pangenome(self, binariesMode, other_ref=None, expect_odgi=False, expect_haplo=False, expect_unchopped_gfa=False, expect_gref=False, grefL=None):
+    def _check_yeast_pangenome(self, binariesMode, other_ref=None, expect_odgi=False, expect_haplo=False, expect_unchopped_gfa=False, expect_gref=False, grefL=None, expect_report=True):
         """ yeast pangenome chromosome by chromosome pipeline
         """
 
@@ -992,7 +1007,7 @@ class TestCase(unittest.TestCase):
             self.assertEqual(len(sizes), 10)
             self.assertGreaterEqual(int(sizes[9]), 200000)
 
-        self._check_exclusion_report(join_path, events)
+        self._check_exclusion_report(join_path, events, expect_report=expect_report)
 
         # make sure the gbz stats are sane
         clip_degree_dist = subprocess.check_output(['vg', 'stats', '-D', os.path.join(join_path, 'yeast.gbz')]).strip().decode('utf-8')
@@ -1637,8 +1652,9 @@ class TestCase(unittest.TestCase):
         name = "local"
         self._run_yeast_pangenome_step_by_step(name)
 
-        # check the output
-        self._check_yeast_pangenome(name)
+        # the step-by-step join runs standalone without --inputContigSizes, so it writes no
+        # clipping report -- only the baseline-free stats
+        self._check_yeast_pangenome(name, expect_report=False)
 
     def testYeastPangenomeLocal(self):
         """ Run pangenome pipeline (including contig splitting!) on yeast dataset using cactus-pangenome """

--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -682,6 +682,215 @@ class TestCase(unittest.TestCase):
         self.assertEqual(proc.returncode, 0,
                          'vg validate failed for {}\nstderr:\n{}'.format(gfa_path, proc.stderr.decode()))
 
+    def _check_exclusion_report(self, join_path, events):
+        """ every input base that is not in a given graph must be accounted for, exactly once, with
+        a cause attached.
+
+        the headline assertion is closure: for every genome, the bases present in the clipped graph
+        plus the bases in that genome's BED must add up to the input length, to the base.  that is
+        what makes this a regression test rather than a smoke test -- any double-counting,
+        coordinate slip or dropped class breaks it.
+
+        absolute bp depend on --refContigs, so only invariants are asserted here; the pinned numbers
+        live in the offline fixture test in pangenome_exclusionsTest.py """
+        import gzip
+        import tarfile
+
+        stats_dir = os.path.join(join_path, 'yeast.stats')
+        self.assertTrue(os.path.isdir(stats_dir), 'no yeast.stats directory')
+
+        def merged_bp(intervals):
+            """ deliberately a second implementation, so this test does not verify the module with
+            the module's own interval arithmetic """
+            total, cur_start, cur_end = 0, None, None
+            for start, end in sorted(intervals):
+                if cur_end is not None and start <= cur_end:
+                    cur_end = max(cur_end, end)
+                else:
+                    if cur_end is not None:
+                        total += cur_end - cur_start
+                    cur_start, cur_end = start, end
+            return total + (cur_end - cur_start if cur_end is not None else 0)
+
+        def read_archive(tag):
+            """ {genome: [(contig, start, end, reason), ...]} out of one clipped archive """
+            path = os.path.join(stats_dir, 'clipped{}.beds.tar.gz'.format(tag))
+            self.assertTrue(os.path.isfile(path), '{} not found'.format(path))
+            out = {}
+            with tarfile.open(path, 'r:gz') as tar:
+                for member in tar.getmembers():
+                    if not member.isfile():
+                        continue
+                    self.assertTrue(member.name.startswith('clipped{}.beds/'.format(tag)),
+                                    'unexpected archive member {}'.format(member.name))
+                    event = os.path.basename(member.name)[:-len('.bed')]
+                    rows = []
+                    for line in tar.extractfile(member).read().decode().splitlines():
+                        contig, start, end, reason = line.split('\t')
+                        rows.append((contig, int(start), int(end), reason))
+                    out[event] = rows
+            return out
+
+        def read_table(name):
+            """ header names -> list of row dicts, for a plain or gzipped stats table """
+            path = os.path.join(stats_dir, name)
+            self.assertTrue(os.path.isfile(path), '{} not found'.format(path))
+            opener = gzip.open if name.endswith('.gz') else open
+            header, rows = None, []
+            with opener(path, 'rt') as in_file:
+                for line in in_file:
+                    line = line.rstrip('\n')
+                    if line.startswith('#'):
+                        # the column header is the last #-line that is tab-separated; the prose
+                        # preamble above it is not
+                        if '\t' in line and ' ' not in line:
+                            header = line[1:].split('\t')
+                        continue
+                    rows.append(dict(zip(header, line.split('\t'))))
+            return header, rows
+
+        summary_header, summary = read_table('clipped-by-genome.tsv')
+        self.assertEqual(summary_header, ['genome', 'reason', 'intervals', 'bp', 'pct_of_input'])
+
+        # only phases that ran are reported.  this test uses --giraffe clip filter, so all three
+        raw_summary = open(os.path.join(stats_dir, 'clipped-by-genome.tsv')).read()
+        self.assertIn('# phases: full,clip,filter', raw_summary)
+        self.assertIn('# outside_baseline_bp: 0', raw_summary)
+        self.assertIn('# orphan_paths: 0', raw_summary)
+        self.assertNotIn('_MINIGRAPH_', raw_summary)
+        self.assertEqual(set(r['genome'] for r in summary) - {'TOTAL'}, set(events))
+
+        full_beds = read_archive('.full')
+        clip_beds = read_archive('')
+        filter_beds = read_archive('.d2')
+        for beds in (full_beds, clip_beds, filter_beds):
+            self.assertEqual(set(beds.keys()), set(events))
+
+        # the baseline, at the top level: it is a pipeline intermediate, not a report
+        sizes_path = os.path.join(join_path, 'yeast.input-contig-sizes.tsv.gz')
+        self.assertTrue(os.path.isfile(sizes_path))
+        baseline, input_bp, event_of = {}, {}, {}
+        with gzip.open(sizes_path, 'rt') as sizes_file:
+            for line in sizes_file:
+                if line.startswith('#'):
+                    continue
+                toks = line.rstrip('\n').split('\t')
+                key = (toks[0], toks[2])
+                baseline[key] = max(baseline.get(key, 0), int(toks[3]) + int(toks[4]))
+                input_bp[toks[0]] = input_bp.get(toks[0], 0) + int(toks[4])
+                event_of[toks[1]] = toks[0]
+        self.assertEqual(set(input_bp.keys()), set(events))
+
+        # what actually survived into the clipped graph, straight off its W-lines
+        coverage = {}
+        with gzip.open(os.path.join(join_path, 'yeast.gfa.gz'), 'rt') as gfa_file:
+            for line in gfa_file:
+                if not line.startswith('W'):
+                    continue
+                fields = line.split('\t')
+                if fields[1] == '_MINIGRAPH_':
+                    continue
+                coverage.setdefault((fields[1] + '#' + fields[2], fields[3]), []).append(
+                    (int(fields[4]), int(fields[5])))
+        graph_bp = {}
+        for (pansn_prefix, contig), intervals in coverage.items():
+            event = event_of[pansn_prefix]
+            graph_bp[event] = graph_bp.get(event, 0) + merged_bp(intervals)
+
+        dropped_reasons = {'ambiguous', 'unassigned', 'no_chromosome_graph', 'unaligned'}
+        for event in events:
+            for beds, allowed in ((full_beds, dropped_reasons),
+                                  (clip_beds, dropped_reasons | {'clip'}),
+                                  (filter_beds, dropped_reasons | {'clip', 'filter'})):
+                for contig, start, end, reason in beds[event]:
+                    self.assertLess(start, end)
+                    self.assertGreaterEqual(start, 0)
+                    self.assertLessEqual(end, baseline[(event, contig)])
+                    self.assertNotEqual(reason, 'refgap')
+                    self.assertIn(reason, allowed,
+                                  '{} in the wrong archive for {}'.format(reason, event))
+            # the archives are cumulative
+            self.assertLessEqual(len(full_beds[event]), len(clip_beds[event]))
+            self.assertLessEqual(len(clip_beds[event]), len(filter_beds[event]))
+
+            # THE closure check, against the graph the unsuffixed archive describes
+            clip_bp = sum(e - s for _c, s, e, _r in clip_beds[event])
+            self.assertEqual(graph_bp.get(event, 0) + clip_bp, input_bp[event],
+                             '{}: clipped graph ({}) + BED ({}) != input ({})'
+                             .format(event, graph_bp.get(event, 0), clip_bp, input_bp[event]))
+
+            # the summary must agree with the deepest archive, reason by reason
+            by_reason = dict((r['reason'], int(r['bp'])) for r in summary
+                             if r['genome'] == event and r['reason'] not in ('TOTAL', 'refgap'))
+            bed_by_reason = {}
+            for _c, start, end, reason in filter_beds[event]:
+                bed_by_reason[reason] = bed_by_reason.get(reason, 0) + end - start
+            self.assertEqual(bed_by_reason, dict((k, v) for k, v in by_reason.items() if v))
+            total_row = [r for r in summary if r['genome'] == event and r['reason'] == 'TOTAL']
+            self.assertEqual(len(total_row), 1)
+            self.assertEqual(int(total_row[0]['bp']), sum(by_reason.values()))
+            # the BED alone accounts for the whole loss: nothing is summarised away
+            self.assertEqual(sum(e - s for _c, s, e, _r in filter_beds[event]),
+                             int(total_row[0]['bp']))
+
+        # the reference is never clipped or frequency-filtered, so it can only lose sequence to a
+        # chromosome that was not built at all (which --refContigs does on purpose)
+        ref_reasons = set(r[3] for r in filter_beds['S288C'])
+        self.assertFalse(ref_reasons - {'no_chromosome_graph'},
+                         'reference lost sequence to {}'.format(ref_reasons))
+
+        # the two roll-up tables must reconcile with the summary and with each other
+        chrom_header, chrom_rows = read_table('clipped-by-reference-contig.tsv')
+        contig_header, contig_rows = read_table('clipped-by-input-contig.tsv.gz')
+        self.assertEqual(chrom_header[:4], ['ref_chrom', 'genome', 'contigs', 'input_bp'])
+        self.assertEqual(contig_header[:4], ['genome', 'contig', 'ref_chrom', 'input_bp'])
+        for phase in ['full', 'clip', 'filter']:
+            for header in (chrom_header, contig_header):
+                self.assertIn('{}_bp'.format(phase), header)
+                self.assertIn('{}_frags'.format(phase), header)
+        for event in events:
+            rolled = sum(int(r['input_bp']) for r in chrom_rows if r['genome'] == event)
+            detail = sum(int(r['input_bp']) for r in contig_rows if r['genome'] == event)
+            self.assertEqual(rolled, input_bp[event])
+            self.assertEqual(detail, input_bp[event])
+            surviving = sum(int(r['filter_bp']) for r in chrom_rows if r['genome'] == event)
+            total_row = [r for r in summary if r['genome'] == event and r['reason'] == 'TOTAL']
+            self.assertEqual(input_bp[event] - surviving, int(total_row[0]['bp']))
+
+        # reference gaps, kept out of the loss totals
+        refgap_path = os.path.join(stats_dir, 'refgaps.bed.gz')
+        self.assertTrue(os.path.isfile(refgap_path))
+        with gzip.open(refgap_path, 'rt') as refgap_file:
+            refgap_rows = [l.rstrip('\n').split('\t') for l in refgap_file]
+        self.assertGreater(len(refgap_rows), 0)
+        for contig, start, end, reason in refgap_rows:
+            self.assertEqual(reason, 'refgap')
+            self.assertGreaterEqual(int(end) - int(start), 10000)
+            self.assertLessEqual(int(end), baseline[('S288C', contig)])
+
+        # the graph tables live here too, with self-describing headers
+        graph_header, graph_rows = read_table('graph-stats.tsv')
+        self.assertEqual(graph_header, ['ref_chrom', 'nodes', 'edges', 'length'])
+        self.assertGreater(len(graph_rows), 0)
+        path_header, _path_rows = read_table('path-stats.tsv.gz')
+        self.assertEqual(path_header, ['ref_chrom', 'path', 'length'])
+        # the old broken clip-vg bed must not have come back
+        self.assertFalse(os.path.exists(os.path.join(join_path, 'yeast.stats.tgz')))
+
+        # UWOPS034614 has inter-chromosomal rearrangements that lose it whole chromosomes during
+        # splitting, so this dataset must trip the warning heuristics.  if it ever stops doing so,
+        # either the detector or the pipeline has changed in a way worth noticing.
+        warning_path = os.path.join(join_path, 'yeast.WARNING')
+        self.assertTrue(os.path.isfile(warning_path),
+                        'expected the yeast run to raise clipping warnings')
+        with open(warning_path, 'r') as warning_file:
+            warning_text = warning_file.read()
+        self.assertIn('UWOPS034614', warning_text)
+        self.assertIn('ambiguous', warning_text)
+        self.assertNotIn('INTERNAL', warning_text)
+        for quiet in ['DBVPG6044', 'Y12', 'YPS128']:
+            self.assertNotIn(quiet + ':', warning_text)
+
     def _check_yeast_pangenome(self, binariesMode, other_ref=None, expect_odgi=False, expect_haplo=False, expect_unchopped_gfa=False, expect_gref=False, grefL=None):
         """ yeast pangenome chromosome by chromosome pipeline
         """
@@ -782,6 +991,8 @@ class TestCase(unittest.TestCase):
         for chr,sizes in contig_sizes.items():
             self.assertEqual(len(sizes), 10)
             self.assertGreaterEqual(int(sizes[9]), 200000)
+
+        self._check_exclusion_report(join_path, events)
 
         # make sure the gbz stats are sane
         clip_degree_dist = subprocess.check_output(['vg', 'stats', '-D', os.path.join(join_path, 'yeast.gbz')]).strip().decode('utf-8')


### PR DESCRIPTION
Adds an <outName>.stats directory.  It contains detailed tables on how much was clipped from each graph (full/defaul/af-filter), along with bed files of the clipped intervals.  There's a summary broken up by reference contig and input contig, as well as reference "gaps", where nothing aligns.  

a "WARNING" file is written in the main output directory if it looks like something was over-clipped / under-aligned (simplistic for now but probably still useful for catastrophic cases).  

All of this shuold make it much easier to check at a glance to see if anything went terribly wrong, and to check which sequence made it through which stage of clipping in the process. 

