### PR TITLE
Add --outType single-ref to cactus-hal2maf

### DIFF
--- a/build-tools/downloadMafTools
+++ b/build-tools/downloadMafTools
@@ -78,7 +78,7 @@ fi
 cd ${mafBuildDir}
 git clone https://github.com/ComparativeGenomicsToolkit/mafTools.git
 cd mafTools
-git checkout 46479b60592c22708abfa6ed901d9d6ecf10d395
+git checkout 4e2a7f2e2a59ad59533fb9dccd76dcea2133b3e3
 find . -name "*.mk" | xargs sed -ie "s/-Werror//g"
 find . -name "Makefile*" | xargs sed -ie "s/-Werror//g"
 # hack in flags support

--- a/doc/progressive.md
+++ b/doc/progressive.md
@@ -202,6 +202,7 @@ These issues are all at least partially addressed by a new tool, `cactus-hal2maf
 * "raw": No normalization: return the direct output of `hal2maf`
 * "norm (default)": Run basic `taffy` normalization as parameterized using the normalization options described above.
 * "single" : Uses greedy heuristics to pick the copy for each species that results in fewest mutations and block breaks, in addition to taffy normalization..
+* "single-ref" : Like "single" but only filters duplicates of the *reference* genome (keeping the true reference / first row of each block), leaving all other species untouched. Use this when you only need to guarantee the reference is single-copy but want to preserve every other species' paralogous rows.
 * "consensus" : Uses [maf_stream merge_dups consensus](https://github.com/ComparativeGenomicsToolkit/maf_stream#resolving-duplicated-entries) to make a single "consensus" row for all duplicate rows. This row won't actually reflect a real sequence in the fasta, but the individual columns will be more sensitive to the true coverage than when using "single".  Recommended when only looking for maximum coverage of columns, without considering duplications.
 
 #### TAF output

--- a/src/cactus/maf/cactus_hal2maf.py
+++ b/src/cactus/maf/cactus_hal2maf.py
@@ -59,8 +59,8 @@ def main():
     parser.add_argument("--onlyOrthologs", action="store_true", help = "Run hal2maf with --onlyOrthologs option which attempts to  keep only duplications that are also separate in ancestor")
 
     # newer output type selection option
-    parser.add_argument("--outType", nargs='+', default=['norm'], choices=["raw", "norm", "single", "consensus"],
-                        help="Select which kind of postprocessing to apply to the hal2maf output. Multiple selections allowed. raw: return hal2maf output as-is; norm: run taffy normalization to merge adjacent blocks where possible; single: heuristically choose single, most similar homolog for each species for each (normalized) block using mafDuplicateFilter; consensus:  squish all duplicate rows for each (normalized) block into a single conensus row using maf_stream. [default=norm]")
+    parser.add_argument("--outType", nargs='+', default=['norm'], choices=["raw", "norm", "single", "single-ref", "consensus"],
+                        help="Select which kind of postprocessing to apply to the hal2maf output. Multiple selections allowed. raw: return hal2maf output as-is; norm: run taffy normalization to merge adjacent blocks where possible; single: heuristically choose single, most similar homolog for each species for each (normalized) block using mafDuplicateFilter; single-ref: like single but only filter duplicates of the reference genome (keeping the true reference / first row), leaving all other species untouched; consensus:  squish all duplicate rows for each (normalized) block into a single conensus row using maf_stream. [default=norm]")
     # new dupe-handler option
 
     # toggle taffy indexing
@@ -440,7 +440,10 @@ def taf_cmd(hal_path, chunk, chunk_num, genome_list_path, sed_script_paths, opti
     if genome_list_path:
         cmd += ' | taffy view | taffy sort -n {} | taffy view -m'.format(os.path.basename(genome_list_path), chunk_num)        
     if out_type == 'single':
-        cmd += ' | mafDuplicateFilter -m - -k'                                               
+        cmd += ' | mafDuplicateFilter -m - -k'
+    elif out_type == 'single-ref':
+        # -r: only collapse duplicates of the reference genome; -k: keep the first (true reference) row
+        cmd += ' | mafDuplicateFilter -m - -k -r'
     elif out_type == 'consensus':
         cmd += ' | maf_stream merge_dups consensus'
         # need to resort after merge_dups

--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -988,10 +988,13 @@ class TestCase(unittest.TestCase):
         # this is downloaded in the Makefile
         ground_truth_file = 'test/{}-truth.maf'.format(dataset)
 
-        # run mafComparator on the evolver output
+        # run mafComparator on the evolver output. also produce a single-ref output (Anc0 is the
+        # reference so it's single-copy regardless, but this exercises the --outType single-ref path)
         subprocess.check_call(['cactus-hal2maf', self._job_store('h2m'), halPath,  halPath + '.maf', '--chunkSize', '10000', '--batchCount', '2',
-                               '--refGenome', 'Anc0', '--outType', 'norm', 'single', '--index', '--binariesMode', binariesMode], shell=False)
-        self.assertGreaterEqual(os.path.getsize(halPath + '.maf.tai'), 50)        
+                               '--refGenome', 'Anc0', '--outType', 'norm', 'single', 'single-ref', '--index', '--binariesMode', binariesMode], shell=False)
+        self.assertGreaterEqual(os.path.getsize(halPath + '.maf.tai'), 50)
+        # make sure the single-ref output was actually produced
+        self.assertGreaterEqual(os.path.getsize(halPath + '.single-ref.maf'), 50)
 
         # run it with --dupeMode consensus just to make sure it doesn't crash
         # (but only if we have maf_stream, which we probably don't on arm)


### PR DESCRIPTION
Filters the reference genome down to single-copy (keeping the true reference / first row of each block) while leaving every other species' rows untouched. This is implemented with the new `mafDuplicateFilter -r/--ref-only` option.