### PR TITLE
Add --panacus option to cactus-graphmap-join / cactus-pangenome

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ variables:
 before_script:
   - whoami
   - sudo apt-get -q -y update
-  - sudo apt-get -q -y install --no-upgrade liblz4-dev libzstd-dev libblas-dev liblapack-dev libpcre3-dev gfortran libjansson-dev
+  - sudo apt-get -q -y install --no-upgrade liblz4-dev libzstd-dev libblas-dev liblapack-dev libpcre3-dev gfortran libjansson-dev zstd
   - startdocker || true
   - docker info
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/comparative-genomics-toolkit/ubuntu:22.04 AS builder
 
 # apt dependencies for build
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential git python3 python3-dev python3-pip zlib1g-dev wget libbz2-dev pkg-config libhdf5-dev liblzo2-dev libtokyocabinet-dev wget liblzma-dev libxml2-dev libssl-dev libpng-dev uuid-dev libcurl4-gnutls-dev libffi-dev python3-virtualenv rsync python-is-python3 libdeflate-dev cmake libjemalloc-dev python3-distutils pybind11-dev autoconf libzstd-dev liblz4-dev libhts-dev libblas-dev liblapack-dev libpcre3-dev gfortran libjansson-dev
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential git python3 python3-dev python3-pip zlib1g-dev wget libbz2-dev pkg-config libhdf5-dev liblzo2-dev libtokyocabinet-dev wget liblzma-dev libxml2-dev libssl-dev libpng-dev uuid-dev libcurl4-gnutls-dev libffi-dev python3-virtualenv rsync python-is-python3 libdeflate-dev cmake libjemalloc-dev python3-distutils pybind11-dev autoconf libzstd-dev liblz4-dev libhts-dev libblas-dev liblapack-dev libpcre3-dev gfortran libjansson-dev zstd
 
 # copy cactus
 RUN mkdir -p /home/cactus

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Cactus uses many different algorithms and individual code contributions, princip
 - Martin Frith and collaborators for `last-train` from [last](https://gitlab.com/mcfrith/last). [last-train citation](https://academic.oup.com/bioinformatics/article-lookup/doi/10.1093/bioinformatics/btw742)
 - Han Cao for [merge_duplicates](https://github.com/Han-Cao/collapse-bubble) vcf cleanup script
 - Gene Myers, Richard Durbin and Chenxi Zhou for [FastGA](https://github.com/thegenemyers/FASTGA/), [FasTAN](https://github.com/thegenemyers/FASTAN/) and [alntools](https://github.com/richarddurbin/alntools).
+- Luca Parmigiani, Erik Garrison, Daniel Doerr and co-authors for [panacus](https://github.com/codialab/panacus), used for optional pangenome coverage and growth statistics (`cactus-graphmap-join --panacus`). Make sure to [cite panacus](https://doi.org/10.1093/bioinformatics/btae720) when using its outputs.
 
 ## Installing Manually From Source
 

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -12,6 +12,8 @@
 # - vg
 # The following tool is included for cactus-panpatch
 # - panpatch
+# The following tool is included for pangenome coverage/growth statistics (cactus-graphmap-join --panacus)
+# - panacus
 # If, updating any versions here, update the release notes as well
 #
 # all binaries get copied into cactus/bin
@@ -374,6 +376,20 @@ mv mash ${binDir}
 # disabling the static check as this binary is not fully static.
 # but.. I can't figure out how to build proper static binary from
 # source and this one seems broadly compatible with many systems...
+
+# panacus (pangenome coverage/growth statistics with native interactive-html plots)
+# We ship the small (~2MB) bioconda build rather than the ~half-gigabyte upstream release tarball,
+# which bundles large example graphs.  Like mash, this binary is not fully static (glibc-dynamic,
+# built against an old glibc baseline so it is broadly compatible), so we skip the static check.
+# (bumping the version: update the URL below -- the filename includes bioconda's build hash.)
+cd ${pangenomeBuildDir}
+wget -nv --tries=5 --waitretry=3 --timeout=60 --retry-connrefused https://conda.anaconda.org/bioconda/linux-64/panacus-0.5.2-h54198d6_0.conda
+# a .conda package is a zip of zstd-compressed tarballs; pull the binary out of the package layer
+# (python's zipfile avoids needing the unzip tool; zstd is needed to decompress the inner tarball)
+python3 -c "import zipfile,glob; zipfile.ZipFile(glob.glob('panacus-*.conda')[0]).extractall('panacus-conda')"
+zstd -d -f panacus-conda/pkg-panacus-*.tar.zst -o panacus-conda/panacus-pkg.tar
+tar --no-same-owner -xf panacus-conda/panacus-pkg.tar -C panacus-conda bin/panacus
+mv panacus-conda/bin/panacus ${binDir}
 
 # odgi
 cd ${pangenomeBuildDir}

--- a/doc/pangenome.md
+++ b/doc/pangenome.md
@@ -14,6 +14,7 @@ Please cite the [Minigraph-Cactus paper](https://doi.org/10.1038/s41587-023-0179
 * [Patching Assemblies (cactus-panpatch)](#patching-assemblies-cactus-panpatch)
 * [Advanced Configuration](#advanced-configuration)
 * [Visualization](#visualization)
+* [Pangenome Statistics (panacus)](#pangenome-statistics-panacus)
 * [Yeast Graph](#yeast-graph)
 * [MHC Graph](#mhc-graph)
 * [GRCh38 Alts Graph](#grch38-alts-graph)
@@ -581,6 +582,23 @@ vg chunk -x yeast-pg/yeast-pg.gbz -S yeast-pg/yeast-pg.snarls -p S288C#0#chrI:10
 <img src="yeast-pg-chunk-viz.png" height=120% width=100%>
 
 Please cite [vg](https://doi.org/10.1038/nbt.4227) when using these visualizations.
+
+## Pangenome Statistics (panacus)
+
+[panacus](https://github.com/codialab/panacus) computes pangenome coverage and growth statistics: how much sequence is shared across the samples, how the pangenome grows as samples are added, and how big its core is. Passing `--panacus` to `cactus-graphmap-join` (or `cactus-pangenome`) runs panacus on the resulting whole-genome graph and writes both the source table data and a self-contained interactive HTML report of the plots.
+
+```
+cactus-pangenome ./js ./seqfile.txt --outDir ./out --outName mygraph --reference GRCh38 --panacus
+```
+
+`--panacus` takes an optional list of graph types (`clip`, `full`, `filter`); with no argument it defaults to the clipped graph (`full` if clipping is disabled), matching the other graph-type options like `--gfa` and `--vcf`. The results are written into the **`<outName>.stats/` subdirectory** (along with the other run statistics), for example:
+
+* `<outName>.stats/<outName>.panacus.report.html`: a single self-contained interactive report with a section for every requested graph type (`clip`, `full`, `filter`) and count type (`bp`, `node`) — coverage histogram, growth and core-size curves, path-similarity heatmap and node distribution — that opens in any web browser
+* `<outName>.stats/<outName>.panacus.histgrowth.<count>.tsv`: the source coverage/growth tables, one per count type (the `full` and `filter` graphs' tables are named `<outName>.full.panacus.*` and `<outName>.d<N>.panacus.*`)
+
+panacus renders its plots directly from the graph, so no extra plotting dependencies are needed. The count type(s) reported (`bp`, `node`, `edge`) can be changed with the `panacus` element in the [configuration](#advanced-configuration) XML.
+
+Please [cite panacus](https://doi.org/10.1093/bioinformatics/btae720) when using these statistics.
 
 ## Yeast Graph
 

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -528,6 +528,17 @@
 		 prependGenomeNames="1"
 		 hal2vgOptions="--progress --inMemory"
 		 />
+	<!-- panacus options (pangenome coverage/growth statistics with a native interactive-HTML plot) -->
+	<!-- countType: comma-separated graph feature(s) to count, each one of node, bp, edge (a separate report section is made for each) -->
+	<!-- groupBy: how paths are grouped (PanSN-spec), one of haplotype, sample -->
+	<!-- quorum: comma-separated quorum thresholds for the growth curves (0=whole pangenome, 1=core genome) -->
+	<!-- clusterMethod: linkage for the similarity heatmap, one of Single, Complete, Average, Weighted, Ward, Centroid, Median -->
+	<panacus
+		 countType="bp,node"
+		 groupBy="haplotype"
+		 quorum="0,0.1,0.5,1"
+		 clusterMethod="Average"
+		 />
   	<multi_cactus>
 	        <!-- stategy: outgroup selection algorithm, can be one of greedy, greedyPreference, greedyLeaves or greedyLeavesPreference -->
 		<!-- threshold: depth increases by at most k per outgroup -->

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -55,6 +55,7 @@ from toil.statsAndLogging import set_logging_from_options
 from toil.realtimeLogger import RealtimeLogger
 from cactus.shared.common import cactus_cpu_count
 from cactus.refmap.cactus_minigraph import check_sample_names
+from cactus.refmap.panacus import run_panacus
 from cactus.refmap.pangenome_exclusions import path_coverage_job, ref_gaps_job, compute_exclusions_job
 from cactus.refmap.pangenome_exclusions import check_baseline_header
 from cactus.progressive.cactus_prepare import human2bytesN
@@ -181,7 +182,8 @@ def graphmap_join_options(parser):
     parser.add_argument("--vcfwaveCores", type=int, help = "Number of cores for each vcfwave job [default=4].", default=4)
     parser.add_argument("--vcfwaveMemory", type=human2bytesN, help = "Memory for reach vcfwave job [default=32Gi].", default=32000000000)
     parser.add_argument("--snarlStats", nargs='*', help = "Write a list of snarl statistics for the graph type(s). Valid types are 'full', 'clip' and 'filter'. If no type specified, 'clip' will be used ('full' used if clipping disabled). Multipe types can be provided separated by space")
-        
+    parser.add_argument("--panacus", nargs='*', default=None, help = "Run panacus (pangenome coverage/growth statistics with a native interactive-HTML plot) on the GFA of the given graph type(s). Valid types are 'full', 'clip' and 'filter'. If no type specified, 'clip' will be used ('full' used if clipping disabled). Multiple types can be provided separated by space. Please cite panacus (https://github.com/codialab/panacus) if you use these outputs")
+
     parser.add_argument("--giraffe", nargs='*', default=None, help = "Generate Giraffe (.dist, .shortread.withzip.min, .shortread.zipcodes) indexes for the given graph type(s). Valid types are 'full', 'clip' and 'filter'. If not type specified, 'filter' will be used (will fall back to 'clip' than full if filtering, clipping disabled, respectively). Multiple types can be provided seperated by a space. NOTE: do not use this option if you want to use haplotype sampling. Use --haplo instead.")
 
     parser.add_argument("--lrGiraffe", nargs='*', default=None, help = "Generate Long Read Giraffe (.dist, .longread.withzip.min, .longread.zipcodes) indexes for the given graph type(s). Valid types are 'full', 'clip' and 'filter'. If not type specified, 'filter' will be used (will fall back to 'clip' than full if filtering, clipping disabled, respectively). Multiple types can be provided seperated by a space. NOTE: do not use this option if you want to use haplotype sampling. Use --haplo instead.")
@@ -480,6 +482,17 @@ def graphmap_join_validate_options(options):
         if snarl_stats == 'filter' and not options.filter:
             raise RuntimeError('--snarlStats cannot be set to filter since filtering is disabled')
 
+    if options.panacus == []:
+        options.panacus = ['clip'] if options.clip else ['full']
+    options.panacus = list(set(options.panacus)) if options.panacus else []
+    for panacus_type in options.panacus:
+        if panacus_type not in ['clip', 'filter', 'full']:
+            raise RuntimeError('Unrecognized value for --panacus: {}. Must be one of {{clip, filter, full}}'.format(panacus_type))
+        if panacus_type == 'clip' and not options.clip:
+            raise RuntimeError('--panacus cannot be set to clip since clipping is disabled')
+        if panacus_type == 'filter' and not options.filter:
+            raise RuntimeError('--panacus cannot be set to filter since filtering is disabled')
+
     if options.giraffe == []:
         options.giraffe = ['filter'] if options.filter else ['clip'] if options.clip else ['full']
     options.giraffe = list(set(options.giraffe)) if options.giraffe else []        
@@ -536,11 +549,11 @@ def graphmap_join_validate_options(options):
     # Prevent some useless compute due to default param combos
     gref_needs_clip = options.gref in ['clip', 'filter'] if options.gref else False
     gref_needs_filter = options.gref == 'filter' if options.gref else False
-    if options.clip and 'clip' not in options.gfa + options.gbz + options.odgi + options.chrom_vg + options.chrom_og + options.vcf + options.giraffe + options.lrGiraffe + options.viz + options.draw\
-       and 'filter' not in options.gfa + options.gbz + options.odgi + options.chrom_vg + options.chrom_og + options.vcf + options.giraffe + options.lrGiraffe + options.viz + options.draw\
+    if options.clip and 'clip' not in options.gfa + options.gbz + options.odgi + options.chrom_vg + options.chrom_og + options.vcf + options.giraffe + options.lrGiraffe + options.viz + options.draw + options.panacus\
+       and 'filter' not in options.gfa + options.gbz + options.odgi + options.chrom_vg + options.chrom_og + options.vcf + options.giraffe + options.lrGiraffe + options.viz + options.draw + options.panacus\
        and not gref_needs_clip:
         options.clip = None
-    if options.filter and 'filter' not in options.gfa + options.gbz + options.odgi + options.chrom_vg + options.chrom_og + options.vcf + options.giraffe + options.lrGiraffe + options.viz + options.draw\
+    if options.filter and 'filter' not in options.gfa + options.gbz + options.odgi + options.chrom_vg + options.chrom_og + options.vcf + options.giraffe + options.lrGiraffe + options.viz + options.draw + options.panacus\
        and not gref_needs_filter:
         options.filter = None
 
@@ -557,7 +570,7 @@ def graphmap_join_validate_options(options):
         all_output_types = set()
         for opt_list in [options.gfa, options.unchopped_gfa, options.gbz, options.xg,
                          options.odgi, options.vcf, options.giraffe, options.lrGiraffe,
-                         options.haplo, options.snarlStats]:
+                         options.haplo, options.snarlStats, options.panacus]:
             all_output_types.update(opt_list)
         unavailable = all_output_types - options.bypass_available_types
         if unavailable:
@@ -657,7 +670,7 @@ def graphmap_join_workflow(job, options, config, vg_ids, hal_ids, sv_gfa_ids,
     job.addChild(root_job)
 
     root_job = vcflib_checks(root_job, options, config.xmlRoot)
-        
+
     # make sure reference doesn't have a haplotype suffix, as it will have been changed upstream
     ref_base, ref_ext = os.path.splitext(options.reference[0])
     assert len(ref_base) > 0
@@ -844,6 +857,10 @@ def graphmap_join_workflow(job, options, config, vg_ids, hal_ids, sv_gfa_ids,
     exclusion_refgap_ids = {}
     do_exclusions = not getattr(options, 'noJoinExport', False) and not options.bypass
 
+    # collected across the phase loop; a single combined panacus report is built afterwards
+    panacus_phase_dicts = {}
+    panacus_merge_jobs = []
+
     for workflow_phase, phase_vg_ids, phase_root_job in workflow_phases:
 
         # make a gfa for each
@@ -854,7 +871,7 @@ def graphmap_join_workflow(job, options, config, vg_ids, hal_ids, sv_gfa_ids,
         do_gbz = workflow_phase in options.gbz + options.giraffe + options.lrGiraffe + options.xg
         if workflow_phase == 'full' and need_ref_fasta and not options.bypass:
             do_gbz = True
-        if do_gbz or workflow_phase in options.gfa:
+        if do_gbz or workflow_phase in options.gfa or workflow_phase in options.panacus:
             assert len(options.vg) == len(phase_vg_ids) == len(vg_ids)
             for vg_path, vg_id, input_vg_id in zip(options.vg, phase_vg_ids, vg_ids):
                 gfa_job = gfa_root_job.addChildJobFn(vg_to_gfa, options, config, vg_path, vg_id,
@@ -977,6 +994,25 @@ def graphmap_join_workflow(job, options, config, vg_ids, hal_ids, sv_gfa_ids,
                                                                   tag=workflow_phase + '.',
                                                                   disk=sum(f.size for f in vg_ids) * 2)
             out_dicts.append(snarl_stats_merge_job.rv())
+
+        # collect this phase's merged GFA; a single combined panacus report is built after the loop
+        if workflow_phase in options.panacus:
+            panacus_phase_dicts[workflow_phase] = current_out_dict
+            panacus_merge_jobs.append(gfa_merge_job)
+
+    # one combined panacus report covering every requested graph type (each a distinct !Gfa section).
+    # run_panacus consumes every phase's merged GFA, so it must be a follow-on of *all* their merge
+    # jobs: Toil promises do not by themselves create scheduling edges (a promise only resolves once
+    # its producing job has structurally run before the consumer), so the merge jobs must be real
+    # predecessors here -- otherwise run_panacus can start early and hit an unfulfilled promise.
+    if panacus_phase_dicts:
+        panacus_job = Job.wrapJobFn(run_panacus, options, config, panacus_phase_dicts,
+                                    cores=options.indexCores,
+                                    disk=sum(f.size for f in vg_ids) * 6 * len(panacus_phase_dicts),
+                                    memory=index_mem)
+        for merge_job in panacus_merge_jobs:
+            merge_job.addFollowOn(panacus_job)
+        out_dicts.append(panacus_job.rv())
 
     # optional graph reference
     if options.gref:
@@ -2538,7 +2574,13 @@ def export_join_data(toil, options, full_ids, clip_ids, clip_stats, filter_ids, 
                 if 'filter.' in out_ext:
                     out_ext = out_ext.replace('filter.', 'd{}.'.format(options.filter))
                 if idx_id is not None:
-                    toil.exportFile(idx_id, makeURL(os.path.join(options.outDir, '{}.{}'.format(options.outName, out_ext))))
+                    # panacus reports/tables go in the .stats subdirectory; everything else at top level
+                    dest_dir = options.outDir
+                    if 'panacus' in out_ext:
+                        dest_dir = stats_dir
+                        if not dest_dir.startswith('s3://') and not os.path.isdir(dest_dir):
+                            os.makedirs(dest_dir)
+                    toil.exportFile(idx_id, makeURL(os.path.join(dest_dir, '{}.{}'.format(options.outName, out_ext))))
                 else:
                     logger.warning('Skipping export of {} because no output was generated. This can happen when a secondary --vcfReference or --reference name does not match any path in the input graphs.'.format(makeURL(os.path.join(options.outDir, '{}.{}'.format(options.outName, out_ext)))))
         

--- a/src/cactus/refmap/cactus_panpatch.py
+++ b/src/cactus/refmap/cactus_panpatch.py
@@ -284,7 +284,7 @@ def disable_pangenome_outputs(options):
     graphmap_join_validate_options(), which turns a default GFA back on if it finds no whole-genome
     output selected """
     for opt in ['gfa', 'unchopped_gfa', 'gbz', 'xg', 'odgi', 'viz', 'draw', 'chrom_og',
-                'vcf', 'giraffe', 'lrGiraffe', 'haplo', 'snarlStats']:
+                'vcf', 'giraffe', 'lrGiraffe', 'haplo', 'snarlStats', 'panacus']:
         setattr(options, opt, [])
     options.gref = None
     options.grefL = None

--- a/src/cactus/refmap/panacus.py
+++ b/src/cactus/refmap/panacus.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Run panacus (pangenome coverage/growth statistics with native interactive-HTML plots) on one or
+more whole-genome pangenome GFAs, and return the source table data plus a single combined report.
+
+panacus renders its plots directly from the (Rust) binary as a single self-contained HTML file, so
+no python plotting stack is needed.  A panacus report is a list of graph sections, so we put every
+requested graph type (clip/full/filter) and count type (bp/node/...) into one report -- each as its
+own !Gfa section with a distinct graph path (panacus keys sections by graph path, so they must
+differ) and a clean human-readable name.
+
+This function is reusable: it takes the merged-GFA dicts and is callable from cactus-graphmap-join,
+cactus-pangenome, or a future standalone entry point.
+
+panacus: https://github.com/codialab/panacus  --  please cite panacus if you use these outputs.
+"""
+import os
+from toil.realtimeLogger import RealtimeLogger
+from cactus.shared.common import cactus_call, getOptionalAttrib, findRequiredNode
+
+def run_panacus(job, options, config, phase_out_dicts):
+    """ Build one panacus report (plus per-graph/per-count-type source TSVs) covering every requested
+    graph type.
+
+    :param phase_out_dicts: {phase: make_vg_indexes-output-dict} for each requested phase, where each
+           dict holds the merged GFA under the key '<phase>.gfa.gz' (phase is 'clip'/'full'/'filter').
+    :returns: a dict of FileIDs keyed for automatic export by graphmap-join (a single
+              'panacus.report.html' plus '<phase>.panacus.histgrowth.<count>.tsv' tables).
+    """
+    work_dir = job.fileStore.getLocalTempDir()
+
+    # config knobs (see the <panacus> element in the config XML)
+    pnode = findRequiredNode(config.xmlRoot, "panacus")
+    count_types = [c.strip().lower() for c in getOptionalAttrib(pnode, "countType", typeFn=str, default="bp,node").split(',') if c.strip()]
+    # dedupe (identical count types would collide on the same graph path) and never end up empty
+    count_types = list(dict.fromkeys(count_types)) or ['bp']
+    group_by = getOptionalAttrib(pnode, "groupBy", typeFn=str, default="haplotype").lower()
+    quorum = getOptionalAttrib(pnode, "quorum", typeFn=str, default="0,0.1,0.5,1")
+    cluster_method = getOptionalAttrib(pnode, "clusterMethod", typeFn=str, default="Average")
+
+    # panacus PanSN grouping flag for the histgrowth CLI (-H haplotype / -S sample); the report YAML
+    # uses the capitalized form.  count types are lowercase for the CLI, capitalized for the YAML.
+    group_flag = {'haplotype': ['-H'], 'sample': ['-S']}.get(group_by, [])
+    # the report's !Growth needs coverage and quorum as equal-length paired lists; hold coverage at 1
+    # so the quorum values alone select pangenome (0) / shell / core (1) growth curves.
+    coverage = ','.join(['1'] * len(quorum.split(',')))
+    grouping = group_by.capitalize()
+    out_label = getattr(options, 'outName', None) or 'graph'
+
+    # match cactus's exported-filename convention for the graph label: clip is the default and has no
+    # label (its '.clip' is stripped on export), full stays 'full', filter becomes 'd<filter>'.
+    def phase_label(phase):
+        if phase == 'clip':
+            return ''
+        if phase == 'filter':
+            return 'd{}'.format(getattr(options, 'filter', '') or '')
+        return phase
+
+    out = {}
+    sections = []  # (label, count_type, graph_name) for the report YAML, in order
+
+    # process each requested graph type: decompress its merged GFA (bgzipped) once, then for each
+    # count type make a distinctly-named hardlink (panacus keys sections by graph path) and a TSV.
+    for phase in sorted(phase_out_dicts):
+        label = phase_label(phase)
+        gfa_gz = os.path.join(work_dir, '{}.{}.gfa.gz'.format(out_label, phase))
+        job.fileStore.readGlobalFile(phase_out_dicts[phase]['{}.gfa.gz'.format(phase)], gfa_gz)
+        base_gfa = os.path.join(work_dir, '{}.{}.gfa'.format(out_label, phase))
+        cactus_call(parameters=['bgzip', '-d', '-c', gfa_gz], outfile=base_gfa)
+        RealtimeLogger.info('panacus: prepared {} graph {}'.format(phase, os.path.basename(base_gfa)))
+
+        for count_type in count_types:
+            # a distinct path per (phase, count type) so panacus keeps the sections separate; the name
+            # mirrors the exported filenames -- <outName>[.<label>].<count>.gfa (clip has no label)
+            graph_name = '.'.join([out_label] + ([label] if label else []) + [count_type, 'gfa'])
+            link = os.path.join(work_dir, graph_name)
+            if not os.path.exists(link):
+                os.link(base_gfa, link)
+            tsv = os.path.join(work_dir, '{}.panacus.histgrowth.{}.tsv'.format(phase, count_type))
+            cactus_call(parameters=['panacus', 'histgrowth', '-t', str(int(job.cores)),
+                                    '-c', count_type, '-q', quorum, '-a'] + group_flag + [graph_name],
+                        outfile=tsv, work_dir=work_dir, job_memory=job.memory)
+            out['{}.panacus.histgrowth.{}.tsv'.format(phase, count_type)] = job.fileStore.writeGlobalFile(tsv)
+            sections.append((label, count_type, graph_name))
+
+    # one self-contained HTML report with a section per (graph type, count type).  panacus ties an
+    # analysis' count type to its !Gfa section (only !Hist/!OrderedGrowth/!Similarity can override it,
+    # !Growth cannot), so a section per count type is needed.  !Info and !NodeDistribution are
+    # count-type independent and describe the graph, so they go in each graph's first section only.
+    # panacus otherwise titles a section by its graph path (ugly, and identical across count types);
+    # give each an explicit human-readable 'name'.
+    yaml_name = 'panacus.report.yaml'
+    with open(os.path.join(work_dir, yaml_name), 'w') as yf:
+        for label, count_type, graph_name in sections:
+            ct = count_type.capitalize()
+            suffix = ' ({})'.format(count_type) if len(count_types) > 1 else ''
+            name = out_label + (' ' + label if label else '') + suffix
+            yf.write('- !Gfa\n')
+            yf.write('  graph: {}\n'.format(graph_name))
+            yf.write('  name: "{}"\n'.format(name))
+            yf.write('  count_type: {}\n'.format(ct))
+            yf.write('  grouping: {}\n'.format(grouping))
+            yf.write('  analyses:\n')
+            if count_type == count_types[0]:
+                yf.write('    - !Info\n')
+            yf.write('    - !Hist\n      count_type: {}\n'.format(ct))
+            yf.write('    - !Growth\n      coverage: {}\n      quorum: {}\n'.format(coverage, quorum))
+            yf.write('    - !OrderedGrowth\n      count_type: {}\n      coverage: {}\n      quorum: {}\n'.format(ct, coverage, quorum))
+            yf.write('    - !Similarity\n      count_type: {}\n      cluster_method: {}\n'.format(ct, cluster_method))
+            if count_type == count_types[0]:
+                yf.write('    - !NodeDistribution\n')
+    html = os.path.join(work_dir, 'panacus.report.html')
+    cactus_call(parameters=['panacus', 'report', '-t', str(int(job.cores)), yaml_name],
+                outfile=html, work_dir=work_dir, job_memory=job.memory)
+    out['panacus.report.html'] = job.fileStore.writeGlobalFile(html)
+
+    return out


### PR DESCRIPTION
This will automatically use panacus to make an html report in the stats part of the output.  all graphs (filter, default, full) that at are selected (via --panacus) will appear in the report, each one for bp and node-based stats.  