### PR TITLE
update taffy and mafTools to latest master

### DIFF
--- a/build-tools/downloadMafTools
+++ b/build-tools/downloadMafTools
@@ -63,7 +63,7 @@ export HTSLIB_LIBS="$(pwd)/libhts.a -lbz2 -ldeflate -lm -lpthread -lz -llzma -pt
 cd ${mafBuildDir}
 git clone https://github.com/ComparativeGenomicsToolkit/taffy.git
 cd taffy
-git checkout fd0e04b501ed3d90dffe91a93801a7a7545f2147
+git checkout b3f889c7e0c77a909375a0be1673fed113634477
 git submodule update --init --recursive
 export HALDIR=${CWD}/submodules/hal
 LIBS="${jemallocLib} -llz4 -lzstd" make -j ${numcpu}
@@ -78,7 +78,7 @@ fi
 cd ${mafBuildDir}
 git clone https://github.com/ComparativeGenomicsToolkit/mafTools.git
 cd mafTools
-git checkout 4e2a7f2e2a59ad59533fb9dccd76dcea2133b3e3
+git checkout e772866ddca394ddebfe178155abfbf51d398b5a
 find . -name "*.mk" | xargs sed -ie "s/-Werror//g"
 find . -name "Makefile*" | xargs sed -ie "s/-Werror//g"
 # hack in flags support


### PR DESCRIPTION
taffy fd0e04b -> b3f889c: MAF input for coverage/stats/annotate/norm/sort/ add-gap-bases, URL inputs for view -r, -T/--threads bgzf_mt, faster MAF/TAF I/O, norm gap-sequence fixes and --unnormalize.

mafTools 4e2a7f2 -> e772866: fix stack buffer overflow on long --includeSeq/--excludeSeq lists, add --includeSeqFile/--excludeSeqFile.