### PR TITLE
Speed up minigraph renaming

### DIFF
--- a/src/cactus/refmap/cactus_graphmap.py
+++ b/src/cactus/refmap/cactus_graphmap.py
@@ -349,8 +349,10 @@ def minigraph_workflow(job, options, config, seq_id_map, gfa_id, graph_event, sa
 
     # convert the GFA from PanSN to Cactus names
     if pansn_gfa_input:
+        # the renaming pass decompresses the GFA before bgzipping it back up, so it needs room for
+        # the raw copy (reckoned at 10x, as elsewhere) on top of the compressed input and output
         rename_gfa_job = root_job.addChildJobFn(minigraph_gfa_from_pansn, genome_names, options.minigraphGFA, gfa_id,
-                                                disk=gfa_id.size*2)
+                                                disk=gfa_id.size*12)
         new_root_job = Job()
         root_job.addFollowOn(new_root_job)
         root_job = new_root_job

--- a/src/cactus/refmap/cactus_graphmap_split.py
+++ b/src/cactus/refmap/cactus_graphmap_split.py
@@ -221,8 +221,10 @@ def graphmap_split_workflow(job, options, config, seq_id_map, seq_name_map, gfa_
 
     # convert the GFA from PanSN to Cactus names
     if pansn_gfa_input:
+        # the renaming pass decompresses the GFA before bgzipping it back up, so it needs room for
+        # the raw copy (reckoned at 10x, as below) on top of the compressed input and output
         rename_gfa_job = root_job.addChildJobFn(minigraph_gfa_from_pansn, genome_names, gfa_path, gfa_id,
-                                                disk=gfa_size*2)
+                                                disk=gfa_size*12)
         new_root_job = Job()
         root_job.addFollowOn(new_root_job)
         root_job = new_root_job

--- a/src/cactus/refmap/cactus_minigraph.py
+++ b/src/cactus/refmap/cactus_minigraph.py
@@ -547,25 +547,37 @@ def minigraph_construct(job, options, config_node, seq_id_map, seq_order, gfa_pa
     if pan_sn_output:
         # rename to pan-sn before serializing, so it's more useful (ie for anything except cactus)
         pansn_gfa_path = os.path.join(work_dir, 'pan-sn.' + os.path.basename(gfa_path))
-        minigraph_gfa_to_pansn(set(seq_id_map.keys()), gfa_path, pansn_gfa_path)
+        minigraph_gfa_to_pansn(set(seq_id_map.keys()), gfa_path, pansn_gfa_path, job.cores)
         pansn_gfa_out_id = job.fileStore.writeGlobalFile(pansn_gfa_path)
         return gfa_out_id, pansn_gfa_out_id
     else:
         return gfa_out_id
 
-def minigraph_gfa_to_pansn(names, gfa_path, out_gfa_path):
+def open_gfa_for_rename(gfa_path, out_gfa_path):
+    """ open a GFA and its renamed copy.  the copy is left uncompressed here and bgzipped by
+    bgzip_gfa_rename() below: python's gzip module is single threaded and defaults to the slowest
+    compression level, which otherwise takes well over 90% of the runtime of these renaming passes """
+    if gfa_path.endswith('.gz'):
+        in_file = gzip.open(gfa_path, 'rb')
+    else:
+        in_file = open(gfa_path, 'rb')
+    raw_out_path = out_gfa_path[:-3] if out_gfa_path.endswith('.gz') else out_gfa_path
+    return in_file, open(raw_out_path, 'wb'), raw_out_path
+
+def bgzip_gfa_rename(raw_out_path, out_gfa_path, threads):
+    """ compress what open_gfa_for_rename() left uncompressed, if the output wanted compressing """
+    if raw_out_path != out_gfa_path:
+        cactus_call(parameters=['bgzip', '--threads', str(threads)], infile=raw_out_path, outfile=out_gfa_path)
+        os.remove(raw_out_path)
+
+def minigraph_gfa_to_pansn(names, gfa_path, out_gfa_path, threads=1):
     """ hack to convert cactus names like id=simChimp.0|simChimp.chr6 to PanSN simChimp#0#simpChimp.chr6
     so that minigraph GFA file can be used outside of catus
 
     todo: Cactus should probably be changed to just use PanSN internally as well, but that's a much
     bigger lift
     """
-    if gfa_path.endswith('.gz'):
-        in_file = gzip.open(gfa_path, 'rb')
-        out_file = gzip.open(out_gfa_path, 'wb')
-    else:
-        in_file = open(gfa_path, 'rb')
-        out_file = open(out_gfa_path, 'wb')
+    in_file, out_file, raw_out_path = open_gfa_for_rename(gfa_path, out_gfa_path)
 
     for line in in_file:
         line = line.decode()
@@ -592,6 +604,7 @@ def minigraph_gfa_to_pansn(names, gfa_path, out_gfa_path):
 
     in_file.close()
     out_file.close()
+    bgzip_gfa_rename(raw_out_path, out_gfa_path, threads)
 
 def minigraph_gfa_from_pansn(job, names, gfa_path, gfa_id):
     """ hack to convert PanSN names like simChimp#0#simpChimp.chr6 to Cactus names like id=simChimp.0|simChimp.chr6
@@ -604,13 +617,8 @@ def minigraph_gfa_from_pansn(job, names, gfa_path, gfa_id):
     gfa_path = os.path.join(work_dir, os.path.basename(gfa_path))
     job.fileStore.readGlobalFile(gfa_id, gfa_path)
     out_gfa_path = os.path.join(work_dir, 'cactus.' + os.path.basename(gfa_path))
-    
-    if gfa_path.endswith('.gz'):
-        in_file = gzip.open(gfa_path, 'rb')
-        out_file = gzip.open(out_gfa_path, 'wb')
-    else:
-        in_file = open(gfa_path, 'rb')
-        out_file = open(out_gfa_path, 'wb')
+
+    in_file, out_file, raw_out_path = open_gfa_for_rename(gfa_path, out_gfa_path)
 
     for line in in_file:
         line = line.decode()
@@ -642,6 +650,7 @@ def minigraph_gfa_from_pansn(job, names, gfa_path, gfa_id):
 
     in_file.close()
     out_file.close()
+    bgzip_gfa_rename(raw_out_path, out_gfa_path, job.cores)
 
     return job.fileStore.writeGlobalFile(out_gfa_path)
 

--- a/src/cactus/refmap/pangenome_exclusions.py
+++ b/src/cactus/refmap/pangenome_exclusions.py
@@ -1096,8 +1096,11 @@ def compute_exclusions_job(job, config, options, phase_coverage, baseline_id, sp
     if result['outside_baseline_bp']:
         RealtimeLogger.warning('exclusion report: {} bp of graph coverage fall outside the input '
                                'contig bounds'.format(result['outside_baseline_bp']))
-    with open(summary_path, 'r') as summary_file:
-        RealtimeLogger.info('Exclusion report:\n' + summary_file.read())
+    # a row per genome per reason is worth having as a file but not worth dumping into the main log:
+    # the warnings above are the part that needs to reach the console.  note graphmap-join exports
+    # this as clipped-by-genome.tsv, which is the name to point at
+    RealtimeLogger.info('Exclusion report written to {}.stats/clipped-by-genome.tsv'.format(
+        getattr(options, 'outName', '<outName>')))
 
     # one tarball per graph, so the common case -- "give me what is missing from the graph I am
     # using" -- is a single download with no post-processing


### PR DESCRIPTION
There was a bottleneck due to using python's gzip:  when adding pan-sn names to minigraph gfas, it'd take like 40 miinutes to write the file.  Very annoying.  This PR finally fixes it by using a bgzip process instead. 