### PR TITLE
Allow non-reference --vcfReferences

### DIFF
--- a/src/cactus/refmap/cactus_graphmap.py
+++ b/src/cactus/refmap/cactus_graphmap.py
@@ -233,7 +233,7 @@ def graph_map(options):
                 
             # run the workflow
             # output_dict is chrom -> paf_id, gfa_fa_id, gaf_id, unfiltered_paf_id, paf_filter_log, paf_was_filtered
-            output_dict = toil.start(Job.wrapJobFn(minigraph_batch_workflow, options, config_wrapper, input_dict, graph_event, True))
+            output_dict = toil.start(Job.wrapJobFn(minigraph_batch_separate_workflow, options, config_wrapper, input_dict, graph_event, True))
 
         export_graphmap_output(options, config_node, input_map, output_dict, toil)
 
@@ -250,7 +250,7 @@ def export_graphmap_output(options, config_node, input_map, output_dict, toil):
     for chrom, output_ids in output_dict.items():
         paf_id, gfa_fa_id, gaf_id, unfiltered_paf_id, paf_filter_log, paf_was_filtered = output_ids[:6]
         # the batch path appends the log of the pass that holds multi-reference-contig bins apart
-        disjoin_log_id = output_ids[6] if len(output_ids) > 6 else None
+        separate_log_id = output_ids[6] if len(output_ids) > 6 else None
         if options.batch:
             paf_path = os.path.join(options.outputPAF, chrom + '.paf')
         else:
@@ -264,8 +264,8 @@ def export_graphmap_output(options, config_node, input_map, output_dict, toil):
         if paf_was_filtered:
             toil.exportFile(unfiltered_paf_id, makeURL(paf_path + ".unfiltered.gz"))
             toil.exportFile(paf_filter_log, makeURL(paf_path + ".filter.log"))
-        if disjoin_log_id:
-            toil.exportFile(disjoin_log_id, makeURL(os.path.join(os.path.dirname(paf_path),
+        if separate_log_id:
+            toil.exportFile(separate_log_id, makeURL(os.path.join(os.path.dirname(paf_path),
                                                                  'mgSplit.{}.log'.format(chrom))))
 
         #export the fa and add it to the seqfile
@@ -311,16 +311,25 @@ def minigraph_batch_workflow(job, options, config, input_dict, graph_event, sani
         mgwf_job = job.addChildJobFn(minigraph_workflow, chrom_options, config, seq_id_map, gfa_id, graph_event,
                                      sanitize, ref_collapse_paf_id, pansn_gfa_input)
         output_dict[chrom] = mgwf_job.rv()
-    if options.batch:
-        # a bin can hold more than one reference contig (--otherContig), and the graphmap above can
-        # align a sample contig across two of them.  drop those alignments so the contigs stay in
-        # separate components, as they are when minigraph is run on the whole genome at once.
-        # imported here because cactus_graphmap_split imports this module
-        from cactus.refmap.cactus_graphmap_split import disjoin_ref_contigs_batch
-        reference = options.reference[0] if type(options.reference) is list else options.reference
-        return job.addFollowOnJobFn(disjoin_ref_contigs_batch, config, input_dict, output_dict, reference,
-                                    getattr(options, 'permissiveContigFilter', None)).rv()
     return output_dict
+
+def add_separate_ref_contigs_job(batch_job, options, config, input_dict):
+    """ chain the pass that holds multi-reference-contig bins apart onto a minigraph_batch_workflow
+    job, and return it.  it has to hang off the batch job rather than being added inside it: whoever
+    reads these results must run after the separation pass's own children, and sibling follow-ons of the
+    same job run concurrently, so a follow-on added inside would race with the caller's """
+    # imported here because cactus_graphmap_split imports this module
+    from cactus.refmap.cactus_graphmap_split import separate_ref_contigs_batch
+    reference = options.reference[0] if type(options.reference) is list else options.reference
+    return batch_job.addFollowOnJobFn(separate_ref_contigs_batch, config, input_dict, batch_job.rv(), reference,
+                                      getattr(options, 'permissiveContigFilter', None))
+
+def minigraph_batch_separate_workflow(job, options, config, input_dict, graph_event, sanitize, pansn_gfa_input=True):
+    """ minigraph_batch_workflow followed by the separation pass, for callers that just want the final
+    result and add nothing after it """
+    batch_job = job.addChildJobFn(minigraph_batch_workflow, options, config, input_dict, graph_event, sanitize,
+                                  pansn_gfa_input)
+    return add_separate_ref_contigs_job(batch_job, options, config, input_dict).rv()
 
 def minigraph_workflow(job, options, config, seq_id_map, gfa_id, graph_event, sanitize, ref_collapse_paf_id, pansn_gfa_input=True):
     """ Overall workflow takes command line options and returns (paf-id, (optional) fa-id) """

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -1209,6 +1209,20 @@ def clip_vg(job, options, config, vg_path, vg_id, phase):
 
     clipped_path = vg_path + '.clip'
 
+    # everything below selects on --reference[0], so if it has no path here the graph quietly empties
+    # out and some tool several steps later fails on the empty stream with an error that names
+    # neither the reference nor this file.  say it plainly instead
+    if options.reference:
+        graph_samples = sorted(set(p.split('#')[0] for p in
+                                   cactus_call(parameters=['vg', 'paths', '-x', vg_path, '-L'],
+                                               check_output=True).split('\n') if p.strip()))
+        if options.reference[0] not in graph_samples:
+            raise RuntimeError(
+                'reference sample "{}" has no path in {}. The samples in that graph are: {}. '
+                'Check --reference against the graph: it must name a sample that is actually present, '
+                'and for a per-chromosome run it must be present in this chromosome.'.format(
+                    options.reference[0], os.path.basename(vg_path), ', '.join(graph_samples)))
+
     join_xml_node = findRequiredNode(config.xmlRoot, "graphmap_join")
     graph_event = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap"), "assemblyName", default="_MINIGRAPH_")
 
@@ -1738,7 +1752,14 @@ def deconstruct(job, config, out_name, vcf_ref, vg_id, decon_L, tag):
 
     # make the vcf
     vcf_path = os.path.join(work_dir, os.path.basename(out_name) + '.' + tag + 'raw.vcf.gz')
-    decon_cmd = ['vg', 'deconstruct', vg_path, '-P', vcf_ref, '-C', '-a', '-t', str(job.cores)]
+    # -p with the paths we just found, not -P with the sample name: only --reference[0] is
+    # reference-sense in a per-chromosome graph (hal2vg --refGenomes sets that back in cactus-align,
+    # from cactus-pangenome --reference), and vg >= 1.74 will not match a haplotype-sense path by
+    # prefix.  -p takes the path by name whatever its sense, and gives identical output where -P
+    # works, so any --reference can be deconstructed without having been named at pangenome time
+    decon_cmd = ['vg', 'deconstruct', vg_path, '-C', '-a', '-t', str(job.cores)]
+    for ref_path in ref_paths:
+        decon_cmd += ['-p', ref_path]
     if decon_L is not None:
         decon_cmd += ['-L', str(decon_L)]
     cactus_call(parameters=[decon_cmd, ['bgzip', '--threads', str(job.cores)]], outfile=vcf_path, job_memory=job.memory)
@@ -1756,7 +1777,7 @@ def deconstruct(job, config, out_name, vcf_ref, vg_id, decon_L, tag):
     if pansn_contigs:
         raise RuntimeError(
             'vg deconstruct ignored -C and emitted PanSN contig names for {} (e.g. {}). That means it found '
-            'more than one reference sample or haplotype under -P {}, which normally indicates a reference-sense '
+            'more than one reference sample or haplotype among the paths selected for {}, which normally indicates a reference-sense '
             'path whose name is not valid PanSN. The resulting VCF would not match the reference FASTA or the '
             'other VCFs from this run, so it is being rejected rather than written. Check the reference-sense '
             'path names in {} with `vg paths -L`.'.format(

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -1752,14 +1752,27 @@ def deconstruct(job, config, out_name, vcf_ref, vg_id, decon_L, tag):
 
     # make the vcf
     vcf_path = os.path.join(work_dir, os.path.basename(out_name) + '.' + tag + 'raw.vcf.gz')
-    # -p with the paths we just found, not -P with the sample name: only --reference[0] is
-    # reference-sense in a per-chromosome graph (hal2vg --refGenomes sets that back in cactus-align,
-    # from cactus-pangenome --reference), and vg >= 1.74 will not match a haplotype-sense path by
-    # prefix.  -p takes the path by name whatever its sense, and gives identical output where -P
-    # works, so any --reference can be deconstructed without having been named at pangenome time
+    # -P names the sample in one argument, but vg >= 1.74 only matches reference-sense paths with
+    # it.  only --reference[0] is reference-sense in a per-chromosome graph (hal2vg --refGenomes
+    # sets that back in cactus-align, from cactus-pangenome --reference), so a reference that was
+    # not one when the graph was built needs -p, which takes paths by name whatever their sense and
+    # gives identical output where -P works.  enumerate only when we have to: a gref graph has an
+    # _alt path per fragment, tens of thousands of them per chromosome, and the whole command goes
+    # to `bash -c` as a single argument that the kernel caps at 128k
     decon_cmd = ['vg', 'deconstruct', vg_path, '-C', '-a', '-t', str(job.cores)]
-    for ref_path in ref_paths:
-        decon_cmd += ['-p', ref_path]
+    if any(ref_path in ref_sense_paths for ref_path in ref_paths):
+        decon_cmd += ['-P', vcf_ref]
+    else:
+        enumerated_len = sum(len(ref_path) + 4 for ref_path in ref_paths)
+        if enumerated_len > 100000:
+            raise RuntimeError(
+                '{} needs its {} reference paths in {} named individually, because none of them is '
+                'reference-sense and vg deconstruct will not match those by prefix, but that command '
+                'would be {} bytes and the limit is about 128k. Pass {} to --reference when building '
+                'the graph so its paths come out reference-sense.'.format(
+                    vcf_ref, len(ref_paths), os.path.basename(vg_path), enumerated_len, vcf_ref))
+        for ref_path in ref_paths:
+            decon_cmd += ['-p', ref_path]
     if decon_L is not None:
         decon_cmd += ['-L', str(decon_L)]
     cactus_call(parameters=[decon_cmd, ['bgzip', '--threads', str(job.cores)]], outfile=vcf_path, job_memory=job.memory)

--- a/src/cactus/refmap/cactus_graphmap_split.py
+++ b/src/cactus/refmap/cactus_graphmap_split.py
@@ -479,7 +479,7 @@ def count_ref_contigs(gfa_path):
                     ref_contigs.add(sn[0])
     return len(ref_contigs)
 
-def disjoin_ref_contigs_batch(job, config, graphmap_input_dict, graphmap_batch_results, reference_event,
+def separate_ref_contigs_batch(job, config, graphmap_input_dict, graphmap_batch_results, reference_event,
                               permissive_contig_filter):
     """ --otherContig lumps every leftover reference contig into a single bin, so with --mgSplit that
     bin gets one minigraph covering all of them.  minigraph keeps those contigs disjoint, but the
@@ -500,12 +500,12 @@ def disjoin_ref_contigs_batch(job, config, graphmap_input_dict, graphmap_batch_r
         # the per-chromosome GFA comes in bgzipped, and we decompress it here: budget for that the
         # same way the first-pass split does
         tot_size = gfa_id.size * 10 + paf_id.size
-        output_dict[chrom] = job.addChildJobFn(disjoin_ref_contigs, config, chrom, gfa_id, gm_result, reference_event,
+        output_dict[chrom] = job.addChildJobFn(separate_ref_contigs, config, chrom, gfa_id, gm_result, reference_event,
                                                disk=tot_size * 5,
                                                memory=cactus_clamp_memory(tot_size * 3)).rv()
     return output_dict
 
-def disjoin_ref_contigs(job, config, chrom, gfa_id, gm_result, reference_event):
+def separate_ref_contigs(job, config, chrom, gfa_id, gm_result, reference_event):
     """ Use rgfa-split to assign each query in one chromosome's PAF to a single reference contig, and
     drop the alignments that don't fit that assignment.  Bins with a single reference contig -- every
     normal chromosome -- are left untouched.  A query that straddles two contigs evenly is ambiguous
@@ -515,8 +515,8 @@ def disjoin_ref_contigs(job, config, chrom, gfa_id, gm_result, reference_event):
     work_dir = job.fileStore.getLocalTempDir()
     gfa_path = os.path.join(work_dir, 'mg.gfa')
     paf_path = os.path.join(work_dir, 'mg.paf')
-    out_prefix = os.path.join(work_dir, 'disjoin_')
-    log_path = os.path.join(work_dir, 'disjoin.log')
+    out_prefix = os.path.join(work_dir, 'separate_')
+    log_path = os.path.join(work_dir, 'separate.log')
     job.fileStore.readGlobalFile(gfa_id, gfa_path)
     with open(gfa_path, 'rb') as gfa_file:
         is_gzipped = gfa_file.read(2) == b'\x1f\x8b'
@@ -558,17 +558,17 @@ def disjoin_ref_contigs(job, config, chrom, gfa_id, gm_result, reference_event):
             if name != amb_name:
                 keep_pafs.append(os.path.join(work_dir, out_name))
 
-    disjoint_paf_path = os.path.join(work_dir, 'disjoint.paf')
-    catFiles(keep_pafs, disjoint_paf_path)
+    separated_paf_path = os.path.join(work_dir, 'separated.paf')
+    catFiles(keep_pafs, separated_paf_path)
 
     def line_count(path):
         with open(path, 'r') as paf_file:
             return sum(1 for line in paf_file if line.strip())
-    before, after = line_count(paf_path), line_count(disjoint_paf_path)
-    RealtimeLogger.info('Disjoining {} reference contigs in {}: kept {} of {} PAF records'.format(
+    before, after = line_count(paf_path), line_count(separated_paf_path)
+    RealtimeLogger.info('Separating {} reference contigs in {}: kept {} of {} PAF records'.format(
         num_ref_contigs, chrom, after, before))
 
-    return (job.fileStore.writeGlobalFile(disjoint_paf_path),) + tuple(gm_result[1:]) + \
+    return (job.fileStore.writeGlobalFile(separated_paf_path),) + tuple(gm_result[1:]) + \
         (job.fileStore.writeGlobalFile(log_path),)
 
 def split_fas(job, seq_id_map, seq_name_map, split_id_map):

--- a/src/cactus/refmap/cactus_pangenome.py
+++ b/src/cactus/refmap/cactus_pangenome.py
@@ -45,7 +45,7 @@ from cactus.refmap.cactus_minigraph import minigraph_construct_workflow, minigra
 from cactus.refmap.cactus_minigraph import check_sample_names, read_chromfile
 from cactus.refmap.cactus_minigraph import minigraph_construct_import_sequences, export_minigraph_construct_output
 from cactus.refmap.cactus_graphmap import minigraph_workflow, minigraph_batch_workflow, export_graphmap_output
-from cactus.refmap.cactus_graphmap import apply_mgsplit_filter_overrides
+from cactus.refmap.cactus_graphmap import apply_mgsplit_filter_overrides, add_separate_ref_contigs_job
 from cactus.refmap.cactus_graphmap_split import graphmap_split_workflow, export_split_data
 from cactus.setup.cactus_align import make_batch_align_jobs, batch_align_jobs
 from cactus.refmap.cactus_graphmap_join import graphmap_join_workflow, export_join_data, graphmap_join_options, graphmap_join_validate_options, vcflib_checks
@@ -425,7 +425,7 @@ def export_graphmap_batch_wrapper(job, options, config_node, graphmap_batch_resu
     # put these in easy to delete lists
     output_list = []
     for chrom, gm_output in graphmap_batch_results.items():
-        #chrom -> paf_id, gfa_fa_id, gaf_id, unfiltered_paf_id, paf_filter_log, paf_was_filtered, disjoin_log_id
+        #chrom -> paf_id, gfa_fa_id, gaf_id, unfiltered_paf_id, paf_filter_log, paf_was_filtered, separate_log_id
         for fid in gm_output:
             if fid and fid != True:
                 output_list.append(fid)
@@ -613,10 +613,12 @@ def pangenome_end_to_end_workflow(job, options, config_wrapper, seq_id_map, seq_
         graphmap_batch_job = minigraph_batch_export_job.addFollowOnJobFn(minigraph_batch_workflow, options, config_wrapper,
                                                                          graphmap_input_dict, graph_event, sanitize=False,
                                                                          pansn_gfa_input=False)
-        # note minigraph_batch_workflow also holds any multi-reference-contig bin's contigs apart,
-        # so what comes back here is already disjoint
-        graphmap_batch_results = graphmap_batch_job.rv()
-        graphmap_batch_export_job = graphmap_batch_job.addFollowOnJobFn(export_graphmap_batch_wrapper, options, config_node,
+        # hold the contigs of any multi-reference-contig bin apart.  the export has to be chained
+        # onto this job, not onto graphmap_batch_job alongside it, or it runs while the separation
+        # pass's children are still going and reads their promises unresolved
+        separate_job = add_separate_ref_contigs_job(graphmap_batch_job, options, config_wrapper, graphmap_input_dict)
+        graphmap_batch_results = separate_job.rv()
+        graphmap_batch_export_job = separate_job.addFollowOnJobFn(export_graphmap_batch_wrapper, options, config_node,
                                                                         graphmap_batch_results, input_seqfiles)
         graphmap_file_ids = graphmap_batch_export_job.rv(0)
         chromfile_path = graphmap_batch_export_job.rv(1)

--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -639,8 +639,13 @@ class TestCase(unittest.TestCase):
 
         # join up the graphs and index for giraffe
         join_path = os.path.join(self.tempDir, 'join')
+        # UWOPS034614 is a second reference here but was not one when the graphs above were built,
+        # so its paths are haplotype-sense.  that is the case cactus-graphmap-join has to handle on
+        # its own, and it is not covered by the tests that pass both references to cactus-pangenome.
+        # it is also absent from several chromosomes, which exercises the skip-and-warn path
         subprocess.check_call(['cactus-graphmap-join', self._job_store(binariesMode), '--outDir', join_path, '--outName', 'yeast',
-                               '--reference', 'S288C', '--vg'] +  vg_files + ['--hal'] + hal_files +
+                               '--reference', 'S288C', 'UWOPS034614', '--vcfReference', 'S288C', 'UWOPS034614',
+                               '--vg'] +  vg_files + ['--hal'] + hal_files +
                                ['--xg', '--vcf', '--giraffe', 'clip', 'filter', '--lrGiraffe'] + cactus_opts + ['--indexCores', '4'])
 
     def _run_yeast_pangenome(self, binariesMode, mgSplit=False, collapse=False, gref=None, vcfL=None):
@@ -1687,7 +1692,7 @@ class TestCase(unittest.TestCase):
 
         # the step-by-step join runs standalone without --inputContigSizes, so it writes no
         # clipping report -- only the baseline-free stats
-        self._check_yeast_pangenome(name, expect_report=False)
+        self._check_yeast_pangenome(name, other_ref='UWOPS034614', expect_report=False)
 
     def testYeastPangenomeLocal(self):
         """ Run pangenome pipeline (including contig splitting!) on yeast dataset using cactus-pangenome """


### PR DESCRIPTION
Resolves #1970 and #1971

Now that vg deconstruct is done on .vg (not .gbz), we can relax constraint that `--vcfReference` samples be true references.  

Also, give better error if selected reference not in the graph. 

Both affect `cactus-graphmap-join` but not `cactus-pangenome`. 