### PR TITLE
Harden red

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ all_libs.blastLib: all_libs.api
 testModules = \
     progressive/outgroupTest.py \
     preprocessor/cactus_preprocessorTest.py \
+    preprocessor/checkPreprocessedSequenceTest.py \
     preprocessor/lastzRepeatMasking/cactus_lastzRepeatMaskTest.py \
     progressive/multiCactusTreeTest.py \
     refmap/cactus_panpatchTest.py \

--- a/preprocessor/lastzRepeatMasking/cactus_fasta_softmask_intervals.py
+++ b/preprocessor/lastzRepeatMasking/cactus_fasta_softmask_intervals.py
@@ -136,6 +136,12 @@ def main():
 
 		prevEnd = 0
 		for (start,end) in chromToIntervals[chrom]:
+			# python slicing would quietly clip an interval that runs off the end,
+			# losing the masking without a word.  the length assertion below cannot
+			# see it, since it compares against the sequence we were handed.
+			assert (end <= len(seq)), \
+			      "interval %s %d %d extends past the end of the %d bp sequence" \
+			      % (chrom,start,end,len(seq))
 			if (prevEnd < start):  newSeq += [seq[prevEnd:start]]
 			if (maskChar == None): newSeq += [seq[start:end].lower()]
 			else:                  newSeq += [maskChar*(end-start)]

--- a/src/cactus/preprocessor/cactus_preprocessor.py
+++ b/src/cactus/preprocessor/cactus_preprocessor.py
@@ -45,6 +45,7 @@ from cactus.preprocessor.redMasking import RedMaskJob
 from cactus.preprocessor.fastanMasking import FasTANMaskJob
 from cactus.preprocessor.cutHeaders import CutHeadersJob
 from cactus.preprocessor.fileMasking import maskJobOverride, FileMaskingJob
+from cactus.preprocessor.checkPreprocessedSequence import check_sequence_preserved
 from cactus.progressive.cactus_prepare import human2bytesN
 
 class PreprocessorOptions:
@@ -305,7 +306,14 @@ class BatchPreprocessor(RoundedJob):
 
             ppJob = self.addChild(PreprocessSequence(prepOptions, self.inSequenceID))
             outSeqID = ppJob.rv()
-            self.addFollowOnJobFn(clean_if_different, self.inSequenceID, outSeqID)
+            # make sure the step only masked/renamed, and did not corrupt the sequence.
+            # this has to run before clean_if_different, which drops the input file.
+            inSize = self.inSequenceID.size if hasattr(self.inSequenceID, "size") else None
+            checkJob = self.addFollowOnJobFn(check_preprocessed_sequence, self.inSequenceID, outSeqID,
+                                             prepOptions.preprocessJob, prepOptions.eventName,
+                                             prepOptions.dnabrnnAction,
+                                             disk=3*inSize if inSize else None)
+            checkJob.addFollowOnJobFn(clean_if_different, self.inSequenceID, outSeqID)
         else:
             logger.info("Skipping inactive preprocessor {}".format(prepNode.attrib["preprocessJob"]))
             outSeqID = self.inSequenceID
@@ -314,6 +322,24 @@ class BatchPreprocessor(RoundedJob):
             return self.addFollowOn(BatchPreprocessor(self.prepXmlElems, outSeqID, self.iteration + 1)).rv()
         else:
             return outSeqID
+
+def check_preprocessed_sequence(job, in_seq_id, out_seq_id, step_name, event_name, mask_action):
+    """ fail as soon as a preprocessing step changes the sequence itself, rather than
+    just its name, case or line wrapping.  runs on the whole genome, so it also covers
+    the chunk/merge round trip of the chunked preprocessors. """
+    if in_seq_id == out_seq_id:
+        return
+    # dna-brnn and maskFile are the only jobs that read "action"; clipping removes
+    # sequence by design and hard-masking turns bases into N
+    masking_job = step_name in ('dna-brnn', 'maskFile')
+    if masking_job and mask_action == 'clip':
+        RealtimeLogger.info('Skipping sequence check for {} on {}: clipping removes sequence'.format(
+            step_name, event_name))
+        return
+    in_path = job.fileStore.readGlobalFile(in_seq_id)
+    out_path = job.fileStore.readGlobalFile(out_seq_id)
+    check_sequence_preserved(in_path, out_path, event_name=event_name, step_name=step_name,
+                             allow_hardmask=masking_job and mask_action == 'hardmask')
 
 def clean_if_different(job, file_id, other_file_id):
     """ remove file_id from jobstore if its differetn from other_file_id"""

--- a/src/cactus/preprocessor/cactus_preprocessor.py
+++ b/src/cactus/preprocessor/cactus_preprocessor.py
@@ -46,6 +46,7 @@ from cactus.preprocessor.fastanMasking import FasTANMaskJob
 from cactus.preprocessor.cutHeaders import CutHeadersJob
 from cactus.preprocessor.fileMasking import maskJobOverride, FileMaskingJob
 from cactus.preprocessor.checkPreprocessedSequence import check_sequence_preserved
+from cactus.preprocessor.checkPreprocessedSequence import preprocessed_fasta_id
 from cactus.progressive.cactus_prepare import human2bytesN
 
 class PreprocessorOptions:
@@ -271,6 +272,7 @@ class BatchPreprocessor(RoundedJob):
         lastIteration = self.iteration == len(self.prepXmlElems) - 1
 
         prepNode = self.prepXmlElems[self.iteration]
+        checkJob = None
         if getOptionalAttrib(prepNode, "active", typeFn = bool, default=True):
             prepOptions = PreprocessorOptions(chunkSize = int(prepNode.get("chunkSize", default="-1")),
                                               preprocessJob=prepNode.attrib["preprocessJob"],
@@ -319,7 +321,11 @@ class BatchPreprocessor(RoundedJob):
             outSeqID = self.inSequenceID
 
         if lastIteration == False:
-            return self.addFollowOn(BatchPreprocessor(self.prepXmlElems, outSeqID, self.iteration + 1)).rv()
+            # the next step must wait for the check: a preprocessor with unmask set
+            # starts by deleting its input, which is the very file the check reads as
+            # its output, and follow-ons of the same job would otherwise race
+            previous = checkJob if checkJob is not None else self
+            return previous.addFollowOn(BatchPreprocessor(self.prepXmlElems, outSeqID, self.iteration + 1)).rv()
         else:
             return outSeqID
 
@@ -336,8 +342,9 @@ def check_preprocessed_sequence(job, in_seq_id, out_seq_id, step_name, event_nam
         RealtimeLogger.info('Skipping sequence check for {} on {}: clipping removes sequence'.format(
             step_name, event_name))
         return
-    in_path = job.fileStore.readGlobalFile(in_seq_id)
-    out_path = job.fileStore.readGlobalFile(out_seq_id)
+    # dna-brnn and maskFile return (fasta, bed, merged bed) rather than a bare id
+    in_path = job.fileStore.readGlobalFile(preprocessed_fasta_id(in_seq_id))
+    out_path = job.fileStore.readGlobalFile(preprocessed_fasta_id(out_seq_id))
     check_sequence_preserved(in_path, out_path, event_name=event_name, step_name=step_name,
                              allow_hardmask=masking_job and mask_action == 'hardmask')
 

--- a/src/cactus/preprocessor/checkPreprocessedSequence.py
+++ b/src/cactus/preprocessor/checkPreprocessedSequence.py
@@ -40,6 +40,17 @@ _BLOCK = 1 << 15
 _checksum = zlib.crc32
 
 
+def preprocessed_fasta_id(seq_id):
+    """Pull the fasta out of whatever a preprocessing step returned.
+
+    dna-brnn and maskFile return (fasta, bed, merged bed); every other
+    preprocessor returns the fasta on its own.  Those two run last in the chain,
+    so before this check existed only the caller at the very end of the pipeline
+    had to know about it.
+    """
+    return seq_id[0] if isinstance(seq_id, (tuple, list)) else seq_id
+
+
 def fasta_digest(path):
     """Return [(name, length, checksum)], one entry per record, in file order.
 

--- a/src/cactus/preprocessor/checkPreprocessedSequence.py
+++ b/src/cactus/preprocessor/checkPreprocessedSequence.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Verify that a preprocessing step did not alter the underlying sequence.
+
+Preprocessors are allowed to rename sequences, change the case of bases (this is
+how soft-masking is represented), re-wrap the fasta at a different line length,
+and reorder sequences (cactus_redPrefilter moves the filtered contigs to the end
+of the file).  Anything else -- a base that changed, a sequence that was
+truncated, dropped or added -- is data corruption, and is fatal.
+
+The one sanctioned exception is hard-masking, which turns bases into N.  Pass
+allow_hardmask=True for the preprocessors configured to do that.  That check
+needs the sequences themselves rather than a checksum, so it is much slower; it
+only runs when the fast path has already found a difference.
+
+Clipping preprocessors (dna-brnn / maskFile with action="clip") remove sequence
+on purpose, so the caller skips them entirely.
+
+Each sequence is summarised by its length and a checksum of its upper-cased
+bases.  Truncation -- the failure this exists to catch -- is caught exactly by
+the length; the checksum only has to catch substitutions that preserve length,
+so crc32 is used in preference to a cryptographic hash, which is twice as slow
+for no practical gain here.  Swap _checksum for hashlib.md5 if that tradeoff
+ever needs revisiting.
+"""
+
+import re
+import zlib
+from collections import Counter
+
+# maps a-z to A-Z and leaves everything else alone.  Combined with a deletion
+# set, bytes.translate does the upper-casing and the newline stripping in a
+# single pass over the data.
+_UPPER = bytes(range(256)).upper()
+_STRIP = b'\r\n'
+
+# small enough that each block stays in cache across the translate and the
+# checksum; measured ~650 MB/s here, against ~170 MB/s for megabyte blocks.
+_BLOCK = 1 << 15
+
+_checksum = zlib.crc32
+
+
+def fasta_digest(path):
+    """Return [(name, length, checksum)], one entry per record, in file order.
+
+    Length and checksum are over the upper-cased sequence with all whitespace
+    removed, so both are invariant to soft-masking and to line wrapping.
+    """
+    records = []
+    name = None
+    crc = 0
+    length = 0
+    leftover = b''
+    with open(path, 'rb') as f:
+        while True:
+            block = f.read(_BLOCK)
+            if not block:
+                break
+            data = leftover + block if leftover else block
+            cut = data.rfind(b'\n')
+            if cut < 0:
+                leftover = data
+                continue
+            leftover = data[cut + 1:]
+            if cut + 1 != len(data):
+                data = data[:cut + 1]
+            # headers are rare, so the whole block is usually pure sequence
+            if b'>' not in data:
+                if name is None:
+                    raise RuntimeError('{}: sequence data before the first header'.format(path))
+                bases = data.translate(_UPPER, _STRIP)
+                crc = _checksum(bases, crc)
+                length += len(bases)
+                continue
+            for line in data.splitlines():
+                if line.startswith(b'>'):
+                    if name is not None:
+                        records.append((name, length, crc))
+                    fields = line[1:].split()
+                    name = fields[0].decode('utf-8', 'replace') if fields else ''
+                    crc = 0
+                    length = 0
+                elif line:
+                    if name is None:
+                        raise RuntimeError('{}: sequence data before the first header'.format(path))
+                    bases = line.translate(_UPPER, _STRIP)
+                    crc = _checksum(bases, crc)
+                    length += len(bases)
+    if leftover:
+        # final line of a file that does not end in a newline
+        if leftover.startswith(b'>'):
+            if name is not None:
+                records.append((name, length, crc))
+            fields = leftover[1:].split()
+            name = fields[0].decode('utf-8', 'replace') if fields else ''
+            crc = 0
+            length = 0
+        elif name is not None:
+            bases = leftover.translate(_UPPER, _STRIP)
+            crc = _checksum(bases, crc)
+            length += len(bases)
+    if name is not None:
+        records.append((name, length, crc))
+    return records
+
+
+def iter_fasta(path):
+    """Yield (name, upper-cased sequence) one record at a time.
+
+    Only used by the hard-masking path, which needs the bases themselves.
+    """
+    name = None
+    chunks = []
+    with open(path, 'rb') as f:
+        for line in f:
+            if line.startswith(b'>'):
+                if name is not None:
+                    yield name, b''.join(chunks)
+                fields = line[1:].split()
+                name = fields[0].decode('utf-8', 'replace') if fields else ''
+                chunks = []
+            elif name is not None:
+                chunks.append(line.translate(_UPPER, _STRIP))
+    if name is not None:
+        yield name, b''.join(chunks)
+
+
+def hardmask_ok(in_seq, out_seq):
+    """True if out_seq is in_seq with some bases replaced by N, and nothing else.
+
+    in_seq must already be upper-cased.  Only the stretches between N runs are
+    compared, so no second copy of the sequence is built.
+    """
+    if len(in_seq) != len(out_seq):
+        return False
+    pos = 0
+    for match in re.finditer(b'N+', out_seq):
+        start, end = match.span()
+        if in_seq[pos:start] != out_seq[pos:start]:
+            return False
+        pos = end
+    return in_seq[pos:] == out_seq[pos:]
+
+
+def _describe(records, limit=5):
+    total = sum(length for _, length, _ in records)
+    head = ', '.join('{} ({} bp)'.format(n, l) for n, l, _ in records[:limit])
+    if len(records) > limit:
+        head += ', ...'
+    return '{} sequences totalling {} bp [{}]'.format(len(records), total, head)
+
+
+def check_sequence_preserved(in_path, out_path, event_name=None, step_name=None,
+                             allow_hardmask=False):
+    """Raise RuntimeError if out_path is not in_path modulo names, case and wrapping.
+
+    With allow_hardmask, bases are additionally permitted to become N.
+    """
+    context = 'preprocessor "{}"'.format(step_name) if step_name else 'preprocessor'
+    if event_name:
+        context += ' on genome "{}"'.format(event_name)
+
+    in_records = fasta_digest(in_path)
+    out_records = fasta_digest(out_path)
+
+    # fast path: the same multiset of sequences, whatever the names or the order
+    if (Counter((l, c) for _, l, c in in_records) ==
+            Counter((l, c) for _, l, c in out_records)):
+        return
+
+    in_total = sum(length for _, length, _ in in_records)
+    out_total = sum(length for _, length, _ in out_records)
+
+    if len(in_records) != len(out_records):
+        raise RuntimeError(
+            '{} changed the number of sequences: input had {}, output has {}. '
+            'Input: {}. Output: {}.'.format(
+                context, len(in_records), len(out_records),
+                _describe(in_records), _describe(out_records)))
+
+    # pair up: by name when the names survived, otherwise by position
+    in_names = [n for n, _, _ in in_records]
+    out_names = [n for n, _, _ in out_records]
+    if sorted(in_names) == sorted(out_names) and len(set(in_names)) == len(in_names):
+        by_name = {n: (l, c) for n, l, c in out_records}
+        pairs = [(n, l, c) + by_name[n] for n, l, c in in_records]
+        paired_by = 'name'
+    else:
+        pairs = [(i_n, i_l, i_c, o_l, o_c)
+                 for (i_n, i_l, i_c), (_, o_l, o_c) in zip(in_records, out_records)]
+        paired_by = 'position'
+
+    truncated = [(n, i_l, o_l) for n, i_l, _, o_l, _ in pairs if i_l != o_l]
+    if truncated:
+        detail = '; '.join('{}: {} bp -> {} bp ({:+d})'.format(n, i, o, o - i)
+                           for n, i, o in truncated[:10])
+        if len(truncated) > 10:
+            detail += '; ... {} more'.format(len(truncated) - 10)
+        raise RuntimeError(
+            '{} changed the length of {} sequence(s), total {} bp -> {} bp ({:+d}). '
+            'Sequences paired by {}. {}'.format(
+                context, len(truncated), in_total, out_total, out_total - in_total,
+                paired_by, detail))
+
+    changed = [n for n, _, i_c, _, o_c in pairs if i_c != o_c]
+    if not changed:
+        return
+
+    if allow_hardmask:
+        # lengths already match, so the only legal difference left is base -> N.
+        # this needs the bases themselves, and relies on the order being
+        # unchanged, which holds for every preprocessor that can hard-mask.
+        bad = []
+        for (in_name, in_seq), (_, out_seq) in zip(iter_fasta(in_path),
+                                                   iter_fasta(out_path)):
+            if not hardmask_ok(in_seq, out_seq):
+                bad.append(in_name)
+                if len(bad) >= 10:
+                    break
+        if not bad:
+            return
+        raise RuntimeError(
+            '{} altered {} sequence(s) in a way that is not hard-masking: {}'.format(
+                context, len(bad), ', '.join(bad)))
+
+    detail = ', '.join(changed[:10])
+    if len(changed) > 10:
+        detail += ', ... {} more'.format(len(changed) - 10)
+    raise RuntimeError(
+        '{} changed the bases of {} sequence(s); the lengths are unchanged, so this '
+        'is not truncation. Sequences paired by {}. Affected: {}'.format(
+            context, len(changed), paired_by, detail))
+
+
+def main():
+    import argparse
+    import sys
+    parser = argparse.ArgumentParser(
+        description='Check that a preprocessed fasta has the same sequence as its input. '
+                    'Renaming, case changes, re-wrapping and reordering are allowed.')
+    parser.add_argument('input_fasta')
+    parser.add_argument('output_fasta')
+    parser.add_argument('--allow-hardmask', action='store_true',
+                        help='also allow bases to become N')
+    parser.add_argument('--event', default=None, help='genome name, for the error message')
+    options = parser.parse_args()
+    try:
+        check_sequence_preserved(options.input_fasta, options.output_fasta,
+                                 event_name=options.event,
+                                 allow_hardmask=options.allow_hardmask)
+    except RuntimeError as e:
+        sys.stderr.write('SEQUENCE CHECK FAILED: {}\n'.format(e))
+        sys.exit(1)
+    sys.stderr.write('sequence preserved\n')
+
+
+if __name__ == '__main__':
+    main()

--- a/src/cactus/preprocessor/checkPreprocessedSequenceTest.py
+++ b/src/cactus/preprocessor/checkPreprocessedSequenceTest.py
@@ -1,0 +1,138 @@
+import os
+import random
+import shutil
+import tempfile
+import unittest
+
+from cactus.preprocessor.checkPreprocessedSequence import check_sequence_preserved
+from cactus.preprocessor.checkPreprocessedSequence import fasta_digest, hardmask_ok
+
+"""Tests the guard that stops a preprocessor from quietly altering the sequence.
+
+Renaming, soft-masking, re-wrapping and reordering are all things the preprocessors
+legitimately do and must be accepted.  A changed, truncated, dropped or added
+sequence is data corruption and must be fatal.
+"""
+
+
+class TestCase(unittest.TestCase):
+    def setUp(self):
+        self.tempDir = tempfile.mkdtemp()
+        random.seed(1)
+        self.records = [('chr1', self.randomSequence(5000)),
+                        ('chr2', self.randomSequence(3000)),
+                        ('chr3', self.randomSequence(700))]
+        self.inputPath = self.writeFasta('in.fa', self.records)
+
+    def tearDown(self):
+        shutil.rmtree(self.tempDir, ignore_errors=True)
+
+    def randomSequence(self, length):
+        return ''.join(random.choice('ACGT') for _ in range(length))
+
+    def writeFasta(self, name, records, wrap=60):
+        path = os.path.join(self.tempDir, name)
+        with open(path, 'w') as fh:
+            for header, sequence in records:
+                fh.write('>%s\n' % header)
+                for i in range(0, len(sequence), wrap):
+                    fh.write(sequence[i:i + wrap] + '\n')
+        return path
+
+    def check(self, name, records, wrap=60, allow_hardmask=False):
+        """Run the guard against a fasta built from records, returning the error text."""
+        path = self.writeFasta(name, records, wrap)
+        try:
+            check_sequence_preserved(self.inputPath, path, event_name='testGenome',
+                                     step_name='red', allow_hardmask=allow_hardmask)
+        except RuntimeError as e:
+            return str(e)
+        return None
+
+    # things the preprocessors are allowed to do
+
+    def testIdentical(self):
+        self.assertIsNone(self.check('same.fa', self.records))
+
+    def testRenamed(self):
+        renamed = [('renamed%d' % i, s) for i, (_, s) in enumerate(self.records)]
+        self.assertIsNone(self.check('renamed.fa', renamed))
+
+    def testSoftMasked(self):
+        masked = [(n, s[:100].lower() + s[100:]) for n, s in self.records]
+        self.assertIsNone(self.check('masked.fa', masked))
+
+    def testRewrapped(self):
+        self.assertIsNone(self.check('wrap80.fa', self.records, wrap=80))
+        self.assertIsNone(self.check('wrap7.fa', self.records, wrap=7))
+
+    def testReordered(self):
+        self.assertIsNone(self.check('reordered.fa', list(reversed(self.records))))
+
+    def testRenamedReorderedAndMasked(self):
+        mixed = [('x', self.records[2][1].lower()),
+                 ('y', self.records[0][1]),
+                 ('z', self.records[1][1])]
+        self.assertIsNone(self.check('mixed.fa', mixed))
+
+    # things that are corruption
+
+    def testTruncatedByOneBase(self):
+        cut = [(n, s[:-1]) if n == 'chr2' else (n, s) for n, s in self.records]
+        self.assertIn('changed the length', self.check('cut1.fa', cut))
+
+    def testTruncatedHeavily(self):
+        cut = [(n, s[:100]) if n == 'chr1' else (n, s) for n, s in self.records]
+        error = self.check('cut2.fa', cut)
+        self.assertIn('changed the length', error)
+        self.assertIn('chr1', error)
+
+    def testSequenceDropped(self):
+        self.assertIn('changed the number', self.check('dropped.fa', self.records[:2]))
+
+    def testSequenceAdded(self):
+        extra = self.records + [('chr4', self.randomSequence(400))]
+        self.assertIn('changed the number', self.check('added.fa', extra))
+
+    def testBaseSubstituted(self):
+        def substitute(sequence):
+            replacement = 'T' if sequence[10] != 'T' else 'A'
+            return sequence[:10] + replacement + sequence[11:]
+        changed = [(n, substitute(s)) if n == 'chr3' else (n, s) for n, s in self.records]
+        self.assertIn('changed the bases', self.check('substituted.fa', changed))
+
+    # hard-masking, which is allowed only where it is configured
+
+    def testHardMaskAllowed(self):
+        hardMasked = [(n, s[:50] + 'N' * 200 + s[250:]) for n, s in self.records]
+        self.assertIsNone(self.check('hard.fa', hardMasked, allow_hardmask=True))
+        self.assertIn('changed the bases', self.check('hard2.fa', hardMasked))
+
+    def testHardMaskDoesNotExcuseOtherChanges(self):
+        altered = [(n, s[:50] + 'N' * 200 + 'ACGT' + s[254:]) if n == 'chr1' else (n, s)
+                   for n, s in self.records]
+        self.assertIn('not hard-masking',
+                      self.check('hard3.fa', altered, allow_hardmask=True))
+
+    def testHardMaskOkHelper(self):
+        self.assertTrue(hardmask_ok(b'ACGTACGT', b'ACGTACGT'))
+        self.assertTrue(hardmask_ok(b'ACGTACGT', b'ACNNACGT'))
+        self.assertFalse(hardmask_ok(b'ACGTACGT', b'ACGTACGA'))
+        self.assertFalse(hardmask_ok(b'ACGTACGT', b'ACGTACG'))
+
+    # the digest itself
+
+    def testDigestIgnoresCaseAndWrapping(self):
+        wrapped = self.writeFasta('w.fa', self.records, wrap=13)
+        masked = self.writeFasta('m.fa', [(n, s.lower()) for n, s in self.records])
+        expected = [(l, c) for _, l, c in fasta_digest(self.inputPath)]
+        self.assertEqual(expected, [(l, c) for _, l, c in fasta_digest(wrapped)])
+        self.assertEqual(expected, [(l, c) for _, l, c in fasta_digest(masked)])
+
+    def testDigestLengths(self):
+        self.assertEqual([('chr1', 5000), ('chr2', 3000), ('chr3', 700)],
+                         [(n, l) for n, l, _ in fasta_digest(self.inputPath)])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/cactus/preprocessor/fastanMasking.py
+++ b/src/cactus/preprocessor/fastanMasking.py
@@ -18,6 +18,8 @@ from cactus.shared.common import getOptionalAttrib
 from cactus.shared.common import makeURL
 from cactus.shared.common import get_faidx_subpath_rename_cmd
 from cactus.shared.common import cactus_clamp_memory
+from cactus.preprocessor.maskingCommon import prefilter_cmd, masked_base_count
+from cactus.preprocessor.maskingCommon import soft_mask_intervals, log_masking_delta
 
 from toil.realtimeLogger import RealtimeLogger
 
@@ -46,21 +48,13 @@ class FasTANMaskJob(RoundedJob):
         fileStore.readGlobalFile(self.fastaID, raw_fa_path)
 
         # get rid of small or single-base contigs that might crash FasTAN
-        filter_cmd = ['cactus_redPrefilter', raw_fa_path]
-        if self.fastanPrefilterOpts:
-            assert '-x' not in self.fastanPrefilterOpts and '--extract' not in self.fastanPrefilterOpts
-            filter_cmd += self.fastanPrefilterOpts.split()
+        filter_cmd = prefilter_cmd(raw_fa_path, self.fastanPrefilterOpts)
         cactus_call(parameters=filter_cmd, outfile=in_fa_path)
 
         if os.path.getsize(in_fa_path) > 0:
-            # compute stats for existing masking
-            pre_mask_size = 0
-            if not self.unmask:
-                awkres = cactus_call(parameters=[['cactus_softmask2hardmask', '-b', raw_fa_path],
-                                                 ['awk', '{sum += $3-$2} END {print sum}']],
-                                     check_output=True, rt_log_cmd=False).strip()
-                pre_mask_size = int(float(awkres)) if awkres else 0
-                
+            # measure the masking the input already carried, for the log line below
+            pre_mask_size = masked_base_count(raw_fa_path)
+
             # run FasTAN
             fastan_cmd = ['FasTAN', in_fa_path, out_1aln_path]
             if self.fastanOpts:
@@ -71,21 +65,12 @@ class FasTANMaskJob(RoundedJob):
             out_bed = out_1aln_path + '.bed'
             cactus_call(parameters=['tanbed', out_1aln_path], outfile=out_bed)
 
-            # merge the FasTAN masking back in
+            # and apply it to the input, not to anything FasTAN wrote.  see maskingCommon
             mask_fa_path = os.path.join(work_dir, '{}.mask.fa'.format(self.eventName))
-            softmask_cmd = ['cactus_fasta_softmask_intervals.py', '--origin=zero']
-            if self.unmask:
-                softmask_cmd += ['--unmask']
-            softmask_cmd += [out_bed]            
-            cactus_call(parameters=softmask_cmd, infile=raw_fa_path, outfile=mask_fa_path)
-            
-            awkres = cactus_call(parameters=[['cactus_softmask2hardmask', '-b', mask_fa_path],
-                                             ['awk', '{sum += $3-$2} END {print sum}']],
-                                 check_output=True, rt_log_cmd=False).strip()
-            
-            post_mask_size = int(float(awkres)) if awkres else 0
-            RealtimeLogger.info('FasTAN masked {} bp of {}, increasing masking from {} to {}'.format(
-                post_mask_size - pre_mask_size, self.eventName, pre_mask_size, post_mask_size))
+            soft_mask_intervals(raw_fa_path, out_bed, mask_fa_path, unmask=self.unmask)
+
+            log_masking_delta('FasTAN', self.eventName, pre_mask_size,
+                              masked_base_count(mask_fa_path))
         else:
             RealtimeLogger.info('Skipping FasTAN for {} because contigs are too small'.format(self.eventName))
             mask_fa_path = raw_fa_path

--- a/src/cactus/preprocessor/maskingCommon.py
+++ b/src/cactus/preprocessor/maskingCommon.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Helpers shared by the tool-driven repeat maskers (Red, FasTAN).
+
+Both jobs have the same shape: drop the contigs the tool cannot cope with, run the
+tool, take the intervals it reports, and soft-mask a fasta at those intervals.
+
+The one rule worth stating out loud is that the intervals are always applied to our
+own copy of the input, never to whatever fasta the tool wrote out.  Applying one
+file's coordinates to another file's sequence assumes the tool returned the bases it
+was given, and cactus_fasta_softmask_intervals.py used to clip an interval that ran
+off the end rather than complain.  A tool that half-wrote its output therefore cost
+sequence silently.  Working from the input means such a tool can cost masking, which
+the checks in the callers will catch, but never sequence.
+"""
+
+from cactus.shared.common import cactus_call
+
+from toil.realtimeLogger import RealtimeLogger
+
+
+def prefilter_cmd(raw_fa_path, prefilter_opts):
+    """Command that drops the tiny and low-entropy contigs that upset the maskers.
+
+    The same command with -x appended yields exactly the contigs this one removes.
+    """
+    cmd = ['cactus_redPrefilter', raw_fa_path]
+    if prefilter_opts:
+        assert '-x' not in prefilter_opts and '--extract' not in prefilter_opts
+        cmd += prefilter_opts.split()
+    return cmd
+
+
+def masked_base_count(fa_path):
+    """Number of masked bases in a fasta.
+
+    Counts soft-masked bases and hard-masked Ns alike, since that is what
+    cactus_softmask2hardmask -b reports.
+    """
+    awkres = cactus_call(parameters=[['cactus_softmask2hardmask', '-b', fa_path],
+                                     ['awk', '{sum += $3-$2} END {print sum}']],
+                         check_output=True, rt_log_cmd=False).strip()
+    return int(float(awkres)) if awkres else 0
+
+
+def extract_masking_bed(fa_path, bed_path):
+    """Write the masked intervals of a fasta to bed_path."""
+    cactus_call(parameters=['cactus_softmask2hardmask', '-b', fa_path], outfile=bed_path)
+
+
+def soft_mask_intervals(in_fa_path, bed_path, out_fa_path, unmask=False):
+    """Copy in_fa_path to out_fa_path, soft-masked at the intervals in bed_path.
+
+    Masking already present in the input survives by never being overwritten, unless
+    unmask is set, which strips it and leaves only the intervals in the bed.
+    """
+    cmd = ['cactus_fasta_softmask_intervals.py', '--origin=zero']
+    if unmask:
+        cmd += ['--unmask']
+    cmd += [bed_path]
+    cactus_call(parameters=cmd, infile=in_fa_path, outfile=out_fa_path)
+
+
+def log_masking_delta(tool_name, event_name, pre_mask_size, post_mask_size):
+    """Report what the masker changed.
+
+    A decrease should not be possible now that the intervals are applied to the input,
+    so it is worded rather than signed, to keep a negative from reading as normal.
+    """
+    RealtimeLogger.info('{} masked {} bp of {}, {} masking from {} to {}'.format(
+        tool_name, abs(post_mask_size - pre_mask_size), event_name,
+        'decreasing' if post_mask_size < pre_mask_size else 'increasing',
+        pre_mask_size, post_mask_size))

--- a/src/cactus/preprocessor/redMasking.py
+++ b/src/cactus/preprocessor/redMasking.py
@@ -18,6 +18,10 @@ from cactus.shared.common import getOptionalAttrib
 from cactus.shared.common import makeURL
 from cactus.shared.common import get_faidx_subpath_rename_cmd
 from cactus.shared.common import cactus_clamp_memory
+from cactus.preprocessor.checkPreprocessedSequence import check_sequence_preserved
+from cactus.preprocessor.maskingCommon import prefilter_cmd, masked_base_count
+from cactus.preprocessor.maskingCommon import extract_masking_bed, soft_mask_intervals
+from cactus.preprocessor.maskingCommon import log_masking_delta
 
 from toil.realtimeLogger import RealtimeLogger
 
@@ -35,8 +39,16 @@ class RedMaskJob(RoundedJob):
 
     def run(self, fileStore):
         """
-        mask repeats with RED.  RED ignores existing masking.  So if unmask is false, the old 
-        masking will be explicitly merged back in. 
+        mask repeats with RED.  RED ignores existing masking, so the intervals it reports
+        are merged with the ones the input already carried.
+
+        Only the intervals are taken from RED's output; the sequence itself always comes
+        from our own copy of the input.  RED writes its output with no error checking of
+        any kind, so a full disk gives a silently truncated file and a zero exit status,
+        and applying one file's coordinates to another file's sequence would then drop
+        masking off the end without a word.  Working from the input instead means a bad
+        RED can cost us masking but never sequence.  It is also checked for outright, so
+        it should not get that far.
         """
         # download fasta
         work_dir = fileStore.getLocalTempDir()
@@ -46,45 +58,39 @@ class RedMaskJob(RoundedJob):
         os.makedirs(red_out_dir)
         raw_fa_path = os.path.join(work_dir, '{}.fa'.format(self.eventName))
         in_fa_path = os.path.join(red_in_dir, '{}.filter.fa'.format(self.eventName))
-        out_fa_path = os.path.join(red_out_dir, '{}.filter.msk'.format(self.eventName))
+        red_msk_path = os.path.join(red_out_dir, '{}.filter.msk'.format(self.eventName))
+        out_fa_path = os.path.join(work_dir, '{}.mask.fa'.format(self.eventName))
         fileStore.readGlobalFile(self.fastaID, raw_fa_path)
 
         # get rid of small or single-base contigs that might crash Red
-        filter_cmd = ['cactus_redPrefilter', raw_fa_path]
-        if self.redPrefilterOpts:
-            assert '-x' not in self.redPrefilterOpts and '--extract' not in self.redPrefilterOpts
-            filter_cmd += self.redPrefilterOpts.split()
+        filter_cmd = prefilter_cmd(raw_fa_path, self.redPrefilterOpts)
         cactus_call(parameters=filter_cmd, outfile=in_fa_path)
 
         if os.path.getsize(in_fa_path) > 0:
-            # preserve existing masking
-            pre_mask_size = 0
-            if not self.unmask:
-                bed_path = os.path.join(work_dir, '{}.input.masking.bed'.format(self.eventName))
-                cactus_call(parameters=['cactus_softmask2hardmask', '-b', in_fa_path], outfile=bed_path)
-                awkres = cactus_call(parameters=['awk', '{sum += $3-$2} END {print sum}', bed_path],
-                                                check_output=True, rt_log_cmd=False).strip()
-                pre_mask_size = int(float(awkres)) if awkres else 0
-                
+            # measure the masking the input already carried, for the log line below
+            pre_mask_size = masked_base_count(in_fa_path)
+
             # run red
             red_cmd = ['Red', '-gnm', red_in_dir, '-msk', red_out_dir]
             if self.redOpts:
                 red_cmd += self.redOpts.split()
             cactus_call(parameters=red_cmd)
 
-            # merge the exsiting masking back in
-            if not self.unmask:
-                if pre_mask_size:
-                    cactus_call(infile=out_fa_path, outfile=out_fa_path + '.remask',
-                                parameters=['cactus_fasta_softmask_intervals.py', '--origin=zero', bed_path])
-                    out_fa_path = out_fa_path + '.remask'
+            # RED has been seen returning less sequence than it was given, so make sure
+            # its output still describes the same bases before believing its intervals
+            check_sequence_preserved(in_fa_path, red_msk_path, event_name=self.eventName,
+                                     step_name='Red')
 
-                awkres = cactus_call(parameters=[['cactus_softmask2hardmask', '-b', out_fa_path],
-                                                 ['awk', '{sum += $3-$2} END {print sum}']],
-                                     check_output=True, rt_log_cmd=False).strip()
-                post_mask_size = int(float(awkres)) if awkres else 0
-                RealtimeLogger.info('Red masked {} bp of {}, increasing masking from {} to {}'.format(
-                    post_mask_size - pre_mask_size, self.eventName, pre_mask_size, post_mask_size))
+            # take the intervals RED masked.  this picks up the N runs as well, which is
+            # harmless: they end up soft-masked rather than left as upper case Ns
+            red_bed = os.path.join(work_dir, '{}.red.masking.bed'.format(self.eventName))
+            extract_masking_bed(red_msk_path, red_bed)
+
+            # and apply them to the input, not to RED's output.  see maskingCommon
+            soft_mask_intervals(in_fa_path, red_bed, out_fa_path, unmask=self.unmask)
+
+            log_masking_delta('Red', self.eventName, pre_mask_size,
+                              masked_base_count(out_fa_path))
         else:
             RealtimeLogger.info('Skipping Red for {} because contigs are too small'.format(self.eventName))
 


### PR DESCRIPTION
Here's a terrible bug:

if `red` is writing the masked genome to local scratch, and that disk runs out of space, the output will be truncated.  and since `red` doesn't explicitly check for out stream errors, the truncation is silent leading to missing data in the output alignment (which is horrible). 

This PR adds guards against this at different levels:

1)  general preprocessor check to make sure that sequence content is unchanged. 
2) red itself modified to explicitly check (and fail on) output errors
3) red-masking changed to pure bed (ie the output sequence never used)

