### PR TITLE
Trim unsupported alleles off the sites filterAC0 keeps

### DIFF
--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -491,7 +491,7 @@
 	<!-- vcfwaveNorm: run bcftools norm -f (left shift) after vcfwave -->
 	<!-- bcftoolsNorm: Run bcftools norm -f (left shifting) on (non-raw, non-wave) VCF output (may result in overlapping variants) -->
 	<!-- mergeDuplicatesOptions: Run merge_duplicates script with these options (empty string means default options) after bcftools norm to prevent multiple entries at the same position.  If "0", merge_duplicates will not be run.  This applies to normalization as toggled by vcfwaveNorm and/or bctoolsNorm (and is ever run after bcftools norm) -->
-	<!-- sometimes vg deconstruct will report "conflict" sites where there are no alt genotypes found.  Setting this flag to 1 will filter these out (except in .raw.vcf.gz) -->
+	<!-- filterAC0: sometimes vg deconstruct will report "conflict" sites where there are no alt genotypes found.  Setting this flag to 1 will filter these out: a site with no carried allele at all is dropped, and any allele nothing carries is trimmed off the sites that remain, so a big bubble is reported with just the alleles its samples actually take.  Never applies to .raw.vcf.gz, which keeps every traversal the graph has -->
 	<graphmap_join
 		 maxNodeLength="1024"
 		 gfaffix="1"

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -1880,6 +1880,17 @@ def vcfbub(job, config, out_name, vcf_ref, vcf_id, tbi_id, max_ref_allele, fasta
         # so a plain AC=0 would drop the whole site over one unsupported allele, taking the
         # supported ones with it
         bub_cmd.append(['bcftools', 'view', '-e', 'MAX(AC)=0'])
+        # ...but -e only decides whether to emit the row, so the unsupported alleles are still
+        # sitting in the ones it keeps.  -a drops them, and since vg declares AC/AF Number=A and
+        # AT Number=R, bcftools subsets all three in step with ALT and renumbers the GT indices.
+        # AN/NS stay right without a fixup pass: trimming changes which alleles ALT lists, not
+        # which samples are called.  this matters most at the big tangled sites, where a bubble
+        # can carry hundreds of traversals and one called genotype
+        #
+        # order is load-bearing.  -a first would trim every allele off an all-unsupported site,
+        # leaving ALT=. with no AC at all -- and MAX(AC)=0 does not match a missing tag, so the
+        # empty record would survive the filter that exists to remove it
+        bub_cmd.append(['bcftools', 'view', '-a'])
     bub_cmd.append(['bgzip'])
     cactus_call(parameters = bub_cmd, outfile = vcfbub_path)
 

--- a/src/cactus/refmap/cactus_graphmap_join.py
+++ b/src/cactus/refmap/cactus_graphmap_join.py
@@ -2072,7 +2072,7 @@ def fix_vcf_ploidies(in_vcf_path, out_vcf_path, threads=1):
             out_file.write(b'\t'.join(toks) + b'\n')
 
     if raw_out_path != out_vcf_path:
-        cactus_call(parameters=['bgzip', '--threads', str(threads)], infile=raw_out_path,
+        cactus_call(parameters=['bgzip', raw_out_path, '--threads', str(threads)], infile=raw_out_path,
                     outfile=out_vcf_path)
         os.remove(raw_out_path)
 


### PR DESCRIPTION
filterAC0 is a record-level filter: `bcftools view -e MAX(AC)=0` decides whether to emit a row, never what is in it.  So a bubble carrying 200 traversals of which one is genotyped comes through with all 200 alleles and all 200 AT strings attached.  Dropping the whole site instead is what the plain `AC=0` form used to do, and that was worse -- the point here is that neither end of the record-level choice is what the option is for.

Add `bcftools view -a` behind it.  vg declares AC/AF Number=A and AT Number=R, so bcftools subsets all three in step with ALT and renumbers the GT indices; AN and NS need no fixup pass, since trimming changes which alleles ALT lists, not which samples are called.

Order is load-bearing.  `-a` first would trim every allele off a site nothing carries, leaving ALT=. with no AC at all, and MAX(AC)=0 does not match a missing tag -- the empty record would then survive the filter that exists to remove it.

chunked_vcfwave is deliberately untouched: it runs `norm -m -any` ahead of its own AC=0, so the split already makes that a per-allele decision. .raw.vcf.gz never goes through vcfbub() and still keeps every traversal.