### PR TITLE
Memory savings and overflow guards

### DIFF
--- a/api/impl/cactusDisk.c
+++ b/api/impl/cactusDisk.c
@@ -43,17 +43,55 @@ void cactusDisk_removeSequence(CactusDisk *cactusDisk, Sequence *sequence) {
 
 /*
  * Functions for strings
+ *
+ * Sequence is held two bases to the byte rather than one. Every sequence reaching this point is
+ * drawn from {A,C,G,T,N} in either case: cactus_sanitizeFastaHeaders folds the IUPAC ambiguity
+ * codes to N and rejects anything else, and the ancestral base caller in blockMLString.c emits the
+ * same alphabet. Ten symbols fit in a nibble with room to spare, so a genome costs half of what it
+ * used to, for the whole life of the process.
  */
+
+// Code 0 means "not a base we can store", so an unexpected character is caught rather than
+// silently read back as an A.
+static const uint8_t cactusDisk_baseToCode[256] = {
+    ['A'] = 1, ['C'] = 2, ['G'] = 3, ['T'] = 4, ['N'] = 5,
+    ['a'] = 6, ['c'] = 7, ['g'] = 8, ['t'] = 9, ['n'] = 10
+};
+
+static const char cactusDisk_codeToBase[16] = {
+    0, 'A', 'C', 'G', 'T', 'N', 'a', 'c', 'g', 't', 'n', 0, 0, 0, 0, 0
+};
+
+typedef struct _packedString {
+    int64_t length;
+    uint8_t bases[]; // Base i is in the low nibble of bases[i/2] if i is even, the high nibble if odd
+} PackedString;
 
 Name cactusDisk_addString(CactusDisk *cactusDisk, const char *string) {
     /*
      * Adds a string to the database.
      */
     Name name = cactusDisk_getUniqueID(cactusDisk);
+    int64_t length = strlen(string);
+    PackedString *packedString = st_malloc(sizeof(PackedString) + (length + 1) / 2);
+    packedString->length = length;
+    for (int64_t i = 0; i < length; i++) {
+        uint8_t code = cactusDisk_baseToCode[(unsigned char) string[i]];
+        if (code == 0) {
+            st_errAbort("Sequence contains '%c' (0x%02x) at position %" PRIi64 ", but only A, C, G, T "
+                        "and N, in either case, can be stored", string[i], (unsigned char) string[i], i);
+        }
+        if (i % 2 == 0) {
+            packedString->bases[i / 2] = code; // Also zeroes the high nibble, so a trailing odd base
+                                               // leaves the byte in a defined state
+        } else {
+            packedString->bases[i / 2] |= code << 4;
+        }
+    }
 #if defined(_OPENMP)
     omp_set_lock(&(cactusDisk->writelock));
 #endif
-    stHash_insert(cactusDisk->allStrings, (void *)name, stString_copy(string)); // Cheeky 64bit to pointer conversion
+    stHash_insert(cactusDisk->allStrings, (void *)name, packedString); // Cheeky 64bit to pointer conversion
 #if defined(_OPENMP)
     omp_unset_lock(&(cactusDisk->writelock));
 #endif
@@ -74,13 +112,21 @@ char *cactusDisk_getString(CactusDisk *cactusDisk, Name name, int64_t start, int
 #if defined(_OPENMP)
     omp_set_lock(&(cactusDisk->writelock));
 #endif
-    char *string = stHash_search(cactusDisk->allStrings, (void *)name); // Cheeky 64bit int to pointer conversion
+    PackedString *packedString = stHash_search(cactusDisk->allStrings, (void *)name); // Cheeky 64bit int to pointer conversion
 #if defined(_OPENMP)
     omp_unset_lock(&(cactusDisk->writelock));
 #endif
 
-    assert(string != NULL);
-    string = stString_getSubString(string, start, length);
+    assert(packedString != NULL);
+    assert(start >= 0);
+    assert(start + length <= packedString->length);
+    char *string = st_malloc(length + 1);
+    for (int64_t i = 0; i < length; i++) {
+        int64_t j = start + i;
+        uint8_t byte = packedString->bases[j / 2];
+        string[i] = cactusDisk_codeToBase[j % 2 == 0 ? (byte & 0x0f) : (byte >> 4)];
+    }
+    string[length] = '\0';
     if(!strand) {
         char *reverseComplement = stString_reverseComplementString(string);
         free(string);

--- a/api/impl/cactusDiskPrivate.h
+++ b/api/impl/cactusDiskPrivate.h
@@ -19,7 +19,7 @@ struct _cactusDisk {
 #if defined(_OPENMP)
     omp_lock_t writelock; // This lock used to gate access to concurrently accessed variables
 #endif
-    stHash *allStrings; // If the strings are being all stored in memory, a map of names to strings
+    stHash *allStrings; // A map of names to sequence, held packed two bases to the byte (see cactusDisk.c)
     Name currentName; // Used as a counter for issuing names
 };
 

--- a/api/tests/cactusSequenceTest.c
+++ b/api/tests/cactusSequenceTest.c
@@ -85,6 +85,44 @@ void testSequence_isTrivialSequence(CuTest* testCase) {
     cactusSequenceTestTeardown(testCase);
 }
 
+void testSequence_getString_packedAlphabet(CuTest* testCase) {
+    // Sequence is held two bases to the byte, so check every symbol the preprocessor can hand us
+    // survives a round trip, at both nibble offsets, on both strands, and at an odd length.
+    cactusSequenceTestSetup(testCase);
+    const char *alphabet = "ACGTNacgtn";
+    for(int64_t offset = 0; offset < 2; offset++) {
+        // A leading pad shifts the whole alphabet between the low and high nibble of each byte
+        char *padded = stString_print("%.*s%s", (int)offset, "A", alphabet);
+        int64_t length = strlen(padded);
+        Sequence *s = sequence_construct(1, length, padded, ">packed", event, cactusDisk);
+
+        char *whole = sequence_getString(s, 1, length, 1);
+        CuAssertStrEquals(testCase, padded, whole);
+        free(whole);
+
+        // Every sub range, so each base is read from both nibble positions
+        for(int64_t i = 0; i < length; i++) {
+            for(int64_t j = 1; i + j <= length; j++) {
+                char *sub = sequence_getString(s, 1 + i, j, 1);
+                CuAssertTrue(testCase, (int64_t)strlen(sub) == j);
+                CuAssertTrue(testCase, strncmp(sub, padded + i, j) == 0);
+                free(sub);
+            }
+        }
+
+        // Reverse complement of the whole thing
+        char *expectedRC = stString_reverseComplementString(padded);
+        char *rc = sequence_getString(s, 1, length, 0);
+        CuAssertStrEquals(testCase, expectedRC, rc);
+        free(expectedRC);
+        free(rc);
+
+        sequence_destruct(s);
+        free(padded);
+    }
+    cactusSequenceTestTeardown(testCase);
+}
+
 CuSuite* cactusSequenceTestSuite(void) {
     CuSuite* suite = CuSuiteNew();
     SUITE_ADD_TEST(suite, testSequence_getName);
@@ -92,6 +130,7 @@ CuSuite* cactusSequenceTestSuite(void) {
     SUITE_ADD_TEST(suite, testSequence_getLength);
     SUITE_ADD_TEST(suite, testSequence_getEvent);
     SUITE_ADD_TEST(suite, testSequence_getString);
+    SUITE_ADD_TEST(suite, testSequence_getString_packedAlphabet);
     SUITE_ADD_TEST(suite, testSequence_isTrivialSequence);
     SUITE_ADD_TEST(suite, testSequence_getHeader);
     return suite;

--- a/bar/impl/poaBarAligner.c
+++ b/bar/impl/poaBarAligner.c
@@ -4,6 +4,7 @@
  * Released under the MIT license, see LICENSE.txt
  */
 
+#include <limits.h>
 #include "abpoa.h"
 #include "poaBarAligner.h"
 #include "flowerAligner.h"
@@ -814,7 +815,7 @@ void alignmentBlock_destruct(AlignmentBlock *alignmentBlock) {
     }
 }
 
-char *get_adjacency_string(Cap *cap, int *length, bool return_string) {
+char *get_adjacency_string(Cap *cap, int64_t *length, bool return_string) {
     assert(!cap_getSide(cap));
     Sequence *sequence = cap_getSequence(cap);
     assert(sequence != NULL);
@@ -834,6 +835,27 @@ char *get_adjacency_string(Cap *cap, int *length, bool return_string) {
     }
 }
 
+/*
+ * Materialises [offset, offset+length) of the adjacency without building the whole thing. An
+ * adjacency can span most of a chromosome, which is gigabytes of ASCII, and BAR holds one per
+ * thread.
+ */
+static char *get_adjacency_substring(Cap *cap, int64_t offset, int64_t length) {
+    assert(!cap_getSide(cap));
+    assert(offset >= 0 && length >= 0);
+    Sequence *sequence = cap_getSequence(cap);
+    Cap *cap2 = cap_getAdjacency(cap);
+    if (cap_getStrand(cap)) {
+        // base i of the adjacency is at coordinate cap+1+i
+        return sequence_getString(sequence, cap_getCoordinate(cap) + 1 + offset, length, 1);
+    }
+    // on the reverse strand the adjacency is the reverse complement of [cap2+1, cap-1], so base i
+    // is at coordinate cap-1-i and the window we want starts that far in from the other end
+    int64_t total = cap_getCoordinate(cap) - cap_getCoordinate(cap2) - 1;
+    assert(offset + length <= total);
+    return sequence_getString(sequence, cap_getCoordinate(cap2) + 1 + (total - offset - length), length, 0);
+}
+
 /**
  * Used to find where a run of masked (hard or soft) of at least mask_filter bases starts
  * @param seq : The string
@@ -843,7 +865,7 @@ char *get_adjacency_string(Cap *cap, int *length, bool return_string) {
  * @param mask_filter : Cut a string as soon as we hit more than this many hard or softmasked bases (cut is before first masked base)
  * @return length of the filtered string
  */
-static int get_unmasked_length(char* seq, int64_t seq_length, int64_t length, bool reversed, int64_t mask_filter) {
+static int64_t get_unmasked_length(char* seq, int64_t seq_length, int64_t length, bool reversed, int64_t mask_filter) {
     if (mask_filter >= 0) {
         int64_t run_start = -1;
         for (int64_t i = 0; i < length; ++i) {
@@ -855,14 +877,14 @@ static int get_unmasked_length(char* seq, int64_t seq_length, int64_t length, bo
                 }
                 if (i + 1 - run_start > mask_filter) {
                     // our run exceeds the mask_filter, cap before the first masked base
-                    return (int)run_start;
+                    return run_start;
                 }
             } else {
                 run_start = -1;
             }
         }
     }
-    return (int)length;
+    return length;
 }
 
 /**
@@ -874,35 +896,48 @@ static int get_unmasked_length(char* seq, int64_t seq_length, int64_t length, bo
  * @return
  */
 char *get_adjacency_string_and_overlap(Cap *cap, int *length, int64_t *overlap, int64_t max_seq_length, int64_t mask_filter) {
-    // Get the complete adjacency string
-    int seq_length;
-    char *adjacency_string = get_adjacency_string(cap, &seq_length, 1);
+    // Take the adjacency's length without materialising it: only the prefix we keep, and the
+    // suffix the mask filter scans, are ever fetched.
+    int64_t seq_length;
+    get_adjacency_string(cap, &seq_length, 0);
     assert(seq_length >= 0);
 
-    // Calculate the length of the prefix up to max_seq_length
-    *length = seq_length > max_seq_length ? max_seq_length : seq_length;
-    assert(*length >= 0);
-    int length_backward = *length;
+    // The prefix, up to max_seq_length
+    int64_t length_forward = seq_length > max_seq_length ? max_seq_length : seq_length;
+    bool have_whole_adjacency = length_forward == seq_length;
+    char *adjacency_string = get_adjacency_substring(cap, 0, length_forward);
+    int64_t length_backward = length_forward;
 
     if (mask_filter >= 0) {
         // apply the mask filter on the forward strand
-        *length = get_unmasked_length(adjacency_string, seq_length, *length, false, mask_filter);
-        length_backward = get_unmasked_length(adjacency_string, seq_length, *length, true, mask_filter);
+        length_forward = get_unmasked_length(adjacency_string, length_forward, length_forward, false, mask_filter);
+        if (have_whole_adjacency) {
+            length_backward = get_unmasked_length(adjacency_string, seq_length, length_forward, true, mask_filter);
+        } else {
+            // the backward scan reads the last length_forward bases, which are not in the prefix
+            char *suffix = get_adjacency_substring(cap, seq_length - length_forward, length_forward);
+            length_backward = get_unmasked_length(suffix, length_forward, length_forward, true, mask_filter);
+            free(suffix);
+        }
     }
 
     // Cleanup the string
-    adjacency_string[*length] = '\0'; // Terminate the string at the given length
+    adjacency_string[length_forward] = '\0'; // Terminate the string at the given length
     char *c = stString_copy(adjacency_string);
     free(adjacency_string);
     adjacency_string = c;
 
     // Calculate the overlap with the reverse complement
-    if (*length + length_backward > seq_length) { // There is overlap
-        *overlap = *length + length_backward - seq_length;
+    if (length_forward + length_backward > seq_length) { // There is overlap
+        *overlap = length_forward + length_backward - seq_length;
         assert(*overlap >= 0);
     } else { // There is no overlap
         *overlap = 0;
     }
+
+    // Bounded by max_seq_length (<bar bandingLimit>), and abpoa takes its lengths as int
+    assert(length_forward <= INT_MAX);
+    *length = (int)length_forward;
 
     return adjacency_string;
 }
@@ -1052,7 +1087,7 @@ void create_alignment_blocks(Msa *msa, Cap **row_indexes_to_caps, stList *alignm
 
 
 int caps_comp_by_adjacency_length(const void *a, const void *b) {
-    int length1, length2;
+    int64_t length1, length2;
     get_adjacency_string((Cap *)a, &length1, 0);
     get_adjacency_string((Cap *)b, &length2, 0);
     return length1 > length2 ? -1 : (length1 < length2 ? 1 : 0); // sort in descending order of length
@@ -1102,7 +1137,7 @@ int64_t getMaxSequenceLength(End *end) {
         if (cap_getSide(cap)) {
             cap = cap_getReverse(cap);
         }
-        int length;
+        int64_t length;
         get_adjacency_string(cap, &length, 0);
         if(length > max_length) {
             max_length = length;

--- a/bar/inc/poaBarAligner.h
+++ b/bar/inc/poaBarAligner.h
@@ -133,7 +133,14 @@ void alignmentBlock_print(AlignmentBlock *ab, FILE *f);
  * Get the string connecting two ends for the given cap. If return_string is 0 then does not return the string,
  * just calculates the length of the string.
  */
-char *get_adjacency_string(Cap *cap, int *length, bool return_string);
+char *get_adjacency_string(Cap *cap, int64_t *length, bool return_string);
+
+/**
+ * Get the prefix of the adjacency string for the given cap, up to max_seq_length and up to the
+ * first run of more than mask_filter masked bases (mask_filter < 0 disables that). Returns the
+ * retained length in *length and, in *overlap, how far it overlaps its own reverse complement.
+ */
+char *get_adjacency_string_and_overlap(Cap *cap, int *length, int64_t *overlap, int64_t max_seq_length, int64_t mask_filter);
 
 /**
  * Makes alignments of the the unaligned sequence using the bar algorithm.

--- a/bar/tests/poaBarTest.c
+++ b/bar/tests/poaBarTest.c
@@ -200,7 +200,7 @@ void test_make_flower_alignment_poa(CuTest *testCase) {
             if (cap_getSide(cap)) {
                 cap = cap_getReverse(cap);
             }
-            int length;
+            int64_t length;
             char *s = get_adjacency_string(cap, &length, 1);
             Cap *adjacentCap = cap_getAdjacency(cap);
 #ifdef stderr_logging            
@@ -223,6 +223,81 @@ void test_make_flower_alignment_poa(CuTest *testCase) {
     }
 
     abpoa_free_para(abpt);
+    teardown(testCase);
+}
+
+
+/*
+ * Reference implementation of the mask-filter scan, run over the whole adjacency. This is what
+ * get_adjacency_string_and_overlap used to do before it started fetching bounded windows.
+ */
+static int64_t ref_unmasked_length(const char *seq, int64_t seq_length, int64_t length, bool reversed, int64_t mask_filter) {
+    if (mask_filter >= 0) {
+        int64_t run_start = -1;
+        for (int64_t i = 0; i < length; ++i) {
+            char base = reversed ? seq[seq_length - 1 - i] : seq[i];
+            if (islower(base) || base == 'N') {
+                if (run_start == -1) {
+                    run_start = i;
+                }
+                if (i + 1 - run_start > mask_filter) {
+                    return run_start;
+                }
+            } else {
+                run_start = -1;
+            }
+        }
+    }
+    return length;
+}
+
+/*
+ * get_adjacency_string_and_overlap fetches only the prefix it keeps and the suffix the mask filter
+ * scans, rather than materialising the whole adjacency. Check that agrees with slicing the whole
+ * thing, at every truncation point and on both strands -- the reverse strand takes its window from
+ * the far end, which is where this is easy to get wrong.
+ */
+void test_get_adjacency_string_and_overlap_bounded(CuTest *testCase) {
+    setup(testCase);
+    End *end;
+    Flower_EndIterator *endIterator = flower_getEndIterator(flower);
+    while ((end = flower_getNextEnd(endIterator)) != NULL) {
+        Cap *cap;
+        End_InstanceIterator *capIterator = end_getInstanceIterator(end);
+        while ((cap = end_getNext(capIterator)) != NULL) {
+            if (cap_getSide(cap)) {
+                cap = cap_getReverse(cap);
+            }
+            int64_t seq_length;
+            char *whole = get_adjacency_string(cap, &seq_length, 1);
+            CuAssertTrue(testCase, (int64_t) strlen(whole) == seq_length);
+
+            for (int64_t max_len = 0; max_len <= seq_length + 1; max_len++) {
+                for (int64_t mask_filter = -1; mask_filter <= 3; mask_filter++) {
+                    int length;
+                    int64_t overlap;
+                    char *got = get_adjacency_string_and_overlap(cap, &length, &overlap, max_len, mask_filter);
+
+                    int64_t forward = seq_length > max_len ? max_len : seq_length;
+                    int64_t backward = forward;
+                    if (mask_filter >= 0) {
+                        forward = ref_unmasked_length(whole, seq_length, forward, false, mask_filter);
+                        backward = ref_unmasked_length(whole, seq_length, forward, true, mask_filter);
+                    }
+                    int64_t expected_overlap = forward + backward > seq_length ? forward + backward - seq_length : 0;
+
+                    CuAssertTrue(testCase, length == forward);
+                    CuAssertTrue(testCase, overlap == expected_overlap);
+                    CuAssertTrue(testCase, (int64_t) strlen(got) == forward);
+                    CuAssertTrue(testCase, strncmp(got, whole, forward) == 0);
+                    free(got);
+                }
+            }
+            free(whole);
+        }
+        end_destructInstanceIterator(capIterator);
+    }
+    flower_destructEndIterator(endIterator);
     teardown(testCase);
 }
 
@@ -269,6 +344,7 @@ CuSuite* poaBarAlignerTestSuite(void) {
     SUITE_ADD_TEST(suite, test_make_partial_order_alignment);
     SUITE_ADD_TEST(suite, test_make_consistent_partial_order_alignments_two_ends);
     SUITE_ADD_TEST(suite, test_make_flower_alignment_poa);
+    SUITE_ADD_TEST(suite, test_get_adjacency_string_and_overlap_bounded);
     SUITE_ADD_TEST(suite, test_alignment_block_iterator);
     return suite;
 }

--- a/src/cactus/paf/local_alignment.py
+++ b/src/cactus/paf/local_alignment.py
@@ -222,8 +222,12 @@ def run_fastga(job, name_A, genome_A, name_B, genome_B, distance, params):
         params_lastz = copy.deepcopy(params)
         params_lastz.find('blast').attrib['mapper'] = 'lastz'
         params_lastz.find('blast').attrib['cpu'] = '1'
-        lastz_job = root.addChildJobFn(make_chunked_alignments, name_A, job.fileStore.writeGlobalFile(unaligned_fasta_a_file),
-                                       name_B, job.fileStore.writeGlobalFile(unaligned_fasta_b_file), distance, params_lastz)
+        unaligned_fasta_a_id = job.fileStore.writeGlobalFile(unaligned_fasta_a_file)
+        unaligned_fasta_b_id = job.fileStore.writeGlobalFile(unaligned_fasta_b_file)
+        lastz_job = root.addChildJobFn(make_chunked_alignments, name_A, unaligned_fasta_a_id,
+                                       name_B, unaligned_fasta_b_id, distance, params_lastz,
+                                       memory=chunked_alignment_memory(unaligned_fasta_a_id, unaligned_fasta_b_id,
+                                                                       params_lastz))
         # run paffy dechunk a second time, since they contigs were chunked both by extract and chunk
         dechunk_job = root.addFollowOnJobFn(combine_chunks, [lastz_job.rv()], 1)
             
@@ -367,6 +371,28 @@ def merge_combined_chunks(job, combined_chunks):
     return job.fileStore.writeGlobalFile(output_path)
 
 
+def chunked_alignment_memory(genome_a, genome_b, params):
+    """ Memory for a make_chunked_alignments job.
+
+    faffy chunk holds a whole sequence in memory at a time -- fasta_chunk.c reads through
+    fastaReadToFunction, which hands the callback one complete record -- and sonLib grows that
+    buffer by allocate-copy-free, so the peak is a few times the LONGEST SEQUENCE rather than the
+    chunk size. A chromosome-scale assembly has sequences hundreds of times bigger than a chunk, so
+    sizing this off chunkSize under-asks by that same factor and the job gets killed.
+
+    Scale with the input instead, which covers any assembly whose longest sequence is under about a
+    quarter of it. The two genomes are chunked one after the other, so take the larger rather than
+    the sum. There are only a handful of these jobs per run, so over-asking is cheap next to a
+    failed one.
+    """
+    blast_node = params.find("blast")
+    gpu = getOptionalAttrib(blast_node, 'gpu', typeFn=int, default=0)
+    fastga = getOptionalAttrib(blast_node, 'mapper', typeFn=str) == 'fastga'
+    chunk_attr = 'bigChunkSize' if gpu or fastga else 'chunkSize'
+    return cactus_clamp_memory(max(1.2 * float(blast_node.attrib[chunk_attr]),
+                                   genome_a.size, genome_b.size))
+
+
 def make_chunked_alignments(job, event_a, genome_a, event_b, genome_b, distance, params):
     lastz_params_node = params.find("blast")
     gpu = getOptionalAttrib(lastz_params_node, 'gpu', typeFn=int, default=0)
@@ -432,19 +458,14 @@ def make_ingroup_to_outgroup_alignments_1(job, ingroup_event, outgroup_events, e
     root_job = Job()
     job.addChild(root_job)
 
-    # override chunk size 
-    lastz_params_node = params.find("blast")
-    gpu = getOptionalAttrib(lastz_params_node, 'gpu', typeFn=int, default=0)
-    fastga = getOptionalAttrib(lastz_params_node, 'mapper', typeFn=str) == 'fastga'
-    chunk_attr = 'bigChunkSize' if gpu or fastga else 'chunkSize'
-    
     #  align ingroup to first outgroup to produce paf alignments
     outgroup = outgroup_events[0] # The first outgroup
     logger.info("Building alignment between ingroup event: {} and outgroup event: {}".format(ingroup_event.iD, outgroup.iD))
     alignment = root_job.addChildJobFn(make_chunked_alignments,
                                        outgroup.iD, event_names_to_sequences[outgroup.iD],
                                        ingroup_event.iD, event_names_to_sequences[ingroup_event.iD], distances[ingroup_event, outgroup], params,
-                                       memory=cactus_clamp_memory(1.2 * float(params.find("blast").attrib[chunk_attr])),
+                                       memory=chunked_alignment_memory(event_names_to_sequences[outgroup.iD],
+                                                                       event_names_to_sequences[ingroup_event.iD], params),
                                        disk=4*(event_names_to_sequences[ingroup_event.iD].size+event_names_to_sequences[outgroup.iD].size)).rv()
 
     #  post process the alignments and recursively generate alignments to remaining outgroups
@@ -780,11 +801,7 @@ def make_paf_alignments(job, event_tree_string, event_names_to_sequences, ancest
     # Calculate the total sequence size
     total_sequence_size = sum(event_names_to_sequences[event.iD].size for event in get_leaves(event_tree))
 
-    # override chunk size 
     lastz_params_node = params.find("blast")
-    gpu = getOptionalAttrib(lastz_params_node, 'gpu', typeFn=int, default=0)
-    fastga = getOptionalAttrib(lastz_params_node, 'mapper', typeFn=str) == 'fastga'
-    chunk_attr = 'bigChunkSize' if gpu or fastga else 'chunkSize'
 
     # unmask overly-masked contigs
     unmask_job = None
@@ -808,7 +825,12 @@ def make_paf_alignments(job, event_tree_string, event_names_to_sequences, ancest
         ingroup_alignments.append(root_job.addChildJobFn(make_chunked_alignments,
                                                          ingroup.iD, event_names_to_sequences[ingroup.iD],
                                                          ingroup2.iD, event_names_to_sequences[ingroup2.iD], distance_a_b, params,
-                                                         memory=cactus_clamp_memory(1.2 * float(lastz_params_node.attrib[chunk_attr])),
+                                                         # sized off input_sequence_map, not event_names_to_sequences:
+                                                         # unmasking replaces the latter with promises, which have no
+                                                         # size until they resolve. Unmasking only changes case, so the
+                                                         # pre-unmask size is the right number anyway.
+                                                         memory=chunked_alignment_memory(input_sequence_map[ingroup.iD],
+                                                                                         input_sequence_map[ingroup2.iD], params),
                                                          disk=2*total_sequence_size).rv())
         ingroup_alignment_names.append('{}-{}_vs_{}'.format(ancestor_event_string, ingroup.iD, ingroup2.iD))
 
@@ -830,7 +852,8 @@ def make_paf_alignments(job, event_tree_string, event_names_to_sequences, ancest
                                                       ingroup.iD, event_names_to_sequences[ingroup.iD],
                                                       outgroup.iD, event_names_to_sequences[outgroup.iD],
                                                       distances[ingroup, outgroup], params,
-                                                      memory=cactus_clamp_memory(1.2 * float(lastz_params_node.attrib[chunk_attr])),
+                                                      memory=chunked_alignment_memory(input_sequence_map[ingroup.iD],
+                                                                                      input_sequence_map[outgroup.iD], params),
                                                       disk=2*total_sequence_size).rv()
                                for ingroup in ingroup_events for outgroup in outgroup_events]
     # for better logs


### PR DESCRIPTION
Brings in some changes to pinch graphs that use less memory and better guard against overflow. 

Use more compact representation for dna seqeunces in cactus disk.

Hoping that this combined with some bar-scaling-back parameter tuning can align some newts. 