### PR TITLE
General GAF cleanup

### DIFF
--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -378,21 +378,6 @@
 	</hal>
 	<!-- cactus-graphmap options -->
 	<!-- assemblyName: special name of "virtual" minigraph assembly, which is just the list of sequences from the graph. -->
-	<!-- universalMZFilter: only use minimizers who appear in this proportion (1.0 == 100%) of sequences that map over them. -->
-	<!-- nodeBasedUniversal: universal filter calculated in terms of nodes istead of mapped regions. -->
-	<!-- minMZBlockLength: only use minimizers that form contiguous blocks at least this long -->
-	<!-- minMAPQ: ignore minigraph alignments with mapping quality less than this -->
-	<!-- minGAFBlockLength: ignore minigraph alignments with block length less than this -->
-	<!-- minGAFNodeLength: ignore minigraph nodes with length less than this -->
-	<!-- minGAFQueryOverlapFilter: if 2 or more query regions in blocks of at least this size, filter them out. -->
-	<!--                           if 1 query region in a block of at least this size overlaps query regions in blocks smaller than this, filter out the smaller ones -->
-	<!--                           Filter is disabled when set to 0.  Any non-zero value will prevent query overlaps -->
-	<!-- maskFilter: any softmasked sequence intervals > than this many bp will be hardmasked before being read by the minigraph mapper [negative value = disable]-->
-	<!-- delFilter: any deletions implied by split-read mappings greater than this are removed from the paf (by removing all lines of the smallest block bordering deletion)-->
-	<!-- removeMinigraphFromPAF: replace all minigraph contigs with transitive alignments in cactus-align-->
-	<!-- cpu: use up to this many cpus for each minigraph command. -->
-	<!-- cactus-graphmap options -->
-	<!-- assemblyName: special name of "virtual" minigraph assembly, which is just the list of sequences from the graph. -->
 	<!-- minigraphMapOptions: flags to pass to minigraph for mapping -->
 	<!-- minigraphConstructOptions: flags to pass to minigraph for construction -->
 	<!-- minigraphConstructBatchSize: break minigraph construction into chunks of this size. this allows recovering from a failure during graph construction, and avoiding really long argument lists for each job. -->
@@ -404,9 +389,6 @@
 	<!-- minigraphSortBySample: Toggle weather mash distances are considered at the sample (1) or haplotype level (0). By default it's set to "nonbatch" which defaults to 1 unless the batch/mgsplit option is used then 0 -->
 	<!-- minMAPQ: ignore minigraph alignments with mapping quality less than this -->
 	<!-- minGAFBlockLength: ignore minigraph alignments with block length less than this -->
-	<!-- minGAFQueryOverlapFilter: if 2 or more query regions in blocks of at least this size, filter them out. -->
-	<!--                           if 1 query region in a block of at least this size overlaps query regions in blocks smaller than this, filter out the smaller ones -->
-	<!--                           Filter is disabled when set to 0.  Any non-zero value will prevent query overlaps [NOTE:holdover from pre-cigar days; should probably remove -->		  
 	<!-- GAFOverlapFilterRatio: filter overlapping (by query) gaf records. keep records if their MAPQ or query length are <ratio> bigger than overlapping interval (see gaffilter -r) [0=disable] -->
 	<!-- GAFOverlapFilterMinLengthRatio: only consider overlaps (for above) whose lengths represent at least this much (ratio between 0 and 1) of the block length -->
 	<!-- PAFOverlapFilterRatio: Same as GAFOverlapFilterRatio, but applied after conversion to PAF -->
@@ -432,7 +414,6 @@
 		 minigraphSortBySample="nonbatch"
 		 minMAPQ="5"
 		 minGAFBlockLength="250000"
-		 minGAFQueryOverlapFilter="0"
 		 GAFOverlapFilterRatio="5"
 		 GAFOverlapFilterMinLengthRatio="0.25"
 		 PAFOverlapFilterRatio="5"

--- a/src/cactus/refmap/cactus_graphmap.py
+++ b/src/cactus/refmap/cactus_graphmap.py
@@ -520,7 +520,10 @@ def export_gaf_dir(job, gaf_id_map, gaf_dir):
         job.fileStore.exportFile(gaf_id, makeURL(os.path.join(gaf_dir, '{}.gaf'.format(event_name))))
 
 # id=EVENT|CONTIG, as it appears in a stable GAF's query column and in each of its path segments
-gaf_pansn_re = re.compile(r'id=([^|\t\n<>]+)\|')
+# anchored to a field start (line start or tab) or a path-segment orientation mark, because
+# "id=" is only a name prefix in those positions.  unanchored it also fires inside a contig
+# name that happens to contain id=...|, rewriting a name that exists in no graph and no input
+gaf_pansn_re = re.compile(r'(^|[\t><])id=([^|\t\n<>]+)\|')
 
 def gaf_to_pansn(gaf_path, out_path):
     """ rewrite cactus's internal id=EVENT|CONTIG names as PanSN SAMPLE#HAP#CONTIG
@@ -532,7 +535,7 @@ def gaf_to_pansn(gaf_path, out_path):
     nowhere else in the record, so a single substitution over the line covers it. """
     with open(gaf_path, 'r') as in_file, open(out_path, 'w') as out_file:
         for line in in_file:
-            out_file.write(gaf_pansn_re.sub(lambda m: event_to_pansn_prefix(m.group(1)) + '#', line))
+            out_file.write(gaf_pansn_re.sub(lambda m: m.group(1) + event_to_pansn_prefix(m.group(2)) + '#', line))
 
 def minigraph_map_one(job, config, event_name, fa_file_id, gfa_file_id):
     """ Run minigraph to map a Fasta file to a GFA graph, producing a GAF output """

--- a/src/cactus/refmap/cactus_graphmap.py
+++ b/src/cactus/refmap/cactus_graphmap.py
@@ -52,7 +52,6 @@ def main():
     parser.add_argument("--maskFilter", type=int, help = "Ignore softmasked sequence intervals > Nbp (overrides config option of same name)")
     parser.add_argument("--delFilter", type=int, help = "Filter out split-mapping-implied deletions > Nbp (default will be \"delFilter\" from the config")
     parser.add_argument("--minIdentity", type=float, help = "Ignore PAF lines with identity (column 10/11) < this (overrides minIdentity in <graphmap> in config)")
-    parser.add_argument("--outputGAFDir", type=str, help = "Output GAF alignments (raw minigraph output before PAF conversion) to this directory")
     parser.add_argument("--reference", nargs='+', type=str, help = "Reference genome name.  MAPQ filter will not be applied to it")
     parser.add_argument("--refFromGFA", action="store_true", help = "Do not align reference (--reference) from seqfile, and instead extract its alignment from the rGFA tags (must have been used as reference for minigraph GFA construction)")
     parser.add_argument("--mapCores", type=int, help = "Number of cores for minigraph.  Overrides graphmap cpu in configuration")
@@ -82,10 +81,6 @@ def main():
     setupBinaries(options)
     set_logging_from_options(options)
     enableDumpStack()
-
-    if options.outputGAFDir:
-        if not os.path.isdir(options.outputGAFDir):
-            os.makedirs(options.outputGAFDir)
 
     # support but ignore multi reference
     if options.reference:
@@ -495,29 +490,14 @@ def minigraph_map_all(job, options, config, gfa_id, fa_id_map, graph_event):
         minigraph_map_job = top_job.addChildJobFn(minigraph_map_one, config, event_name, fa_id, gfa_id,
                                                   cores=mg_cores, disk=5*fa_id.size + gfa_id.size,
                                                   memory=cactus_clamp_memory(mem))
-        # keyed by event_name, not event, so that --batch runs (where event_name carries the
-        # chromosome) get distinct filenames in --outputGAFDir.  merge_pafs uses only the values.
-        gaf_id_map[event_name] = minigraph_map_job.rv(0)
-        paf_id_map[event_name] = minigraph_map_job.rv(1)
+        gaf_id_map[event] = minigraph_map_job.rv(0)
+        paf_id_map[event] = minigraph_map_job.rv(1)
 
     # merge up
     paf_merge_job = top_job.addFollowOnJobFn(merge_pafs, paf_id_map)
     gaf_merge_job = top_job.addFollowOnJobFn(merge_pafs, gaf_id_map, gzip=True)
 
-    # cactus-pangenome's options object doesn't carry outputGAFDir, hence the getattr
-    gaf_dir = getattr(options, 'outputGAFDir', None)
-    if gaf_dir:
-        top_job.addFollowOnJobFn(export_gaf_dir, gaf_id_map, gaf_dir)
-
     return paf_merge_job.rv(), gaf_merge_job.rv()
-
-def export_gaf_dir(job, gaf_id_map, gaf_dir):
-    """ write the per-genome GAFs out to --outputGAFDir
-
-    the merged GAF is exported by default, but the option promised the unmerged ones and was
-    never implemented beyond creating the directory. """
-    for event_name, gaf_id in gaf_id_map.items():
-        job.fileStore.exportFile(gaf_id, makeURL(os.path.join(gaf_dir, '{}.gaf'.format(event_name))))
 
 # id=EVENT|CONTIG, as it appears in a stable GAF's query column and in each of its path segments
 # anchored to a field start (line start or tab) or a path-segment orientation mark, because
@@ -529,8 +509,12 @@ def gaf_to_pansn(gaf_path, out_path):
     """ rewrite cactus's internal id=EVENT|CONTIG names as PanSN SAMPLE#HAP#CONTIG
 
     minigraph_gfa_to_pansn() converts the GFA on the way out, but the GAF was left in cactus
-    naming, so the two published artifacts sat in different namespaces and nothing downstream
-    (gaf2unstable included) could resolve a GAF path segment against the graph it came from.
+    naming, so the two files cactus publishes sat in different namespaces.  Nothing inside
+    cactus was affected -- gaf2unstable runs above on the cactus-named GAF against the
+    cactus-named GFA -- but a reader of the published pair could not resolve a GAF path
+    segment against the graph it came from, nor recover sample and haplotype without knowing
+    that cactus encodes the haplotype as a .N suffix.
+
     Both the query column and the path column are rewritten: id=EVENT| appears in each and
     nowhere else in the record, so a single substitution over the line covers it. """
     with open(gaf_path, 'r') as in_file, open(out_path, 'w') as out_file:
@@ -602,6 +586,9 @@ def minigraph_map_one(job, config, event_name, fa_file_id, gfa_file_id):
     # (the filtering chain above has already consumed gaf_path in its cactus-named form)
     pansn_gaf_path = gaf_path + '.pansn'
     gaf_to_pansn(gaf_path, pansn_gaf_path)
+    # nothing reads the cactus-named copy after this, and the job's disk request did not grow
+    # to hold both
+    os.remove(gaf_path)
 
     # return the stable gaf (minigraph output) and the unstable paf
     return job.fileStore.writeGlobalFile(pansn_gaf_path), job.fileStore.writeGlobalFile(unstable_paf_path)

--- a/src/cactus/refmap/cactus_graphmap.py
+++ b/src/cactus/refmap/cactus_graphmap.py
@@ -7,7 +7,7 @@
             by the rest of cactus)
 
 """
-import os, sys
+import os, sys, re
 from argparse import ArgumentParser
 import xml.etree.ElementTree as ET
 import copy
@@ -28,6 +28,7 @@ from cactus.shared.common import getOptionalAttrib, findRequiredNode
 from cactus.shared.common import unzip_gz, zip_gz
 from cactus.shared.version import cactus_commit
 from cactus.preprocessor.checkUniqueHeaders import sanitize_fasta_headers
+from cactus.refmap.pangenome_exclusions import event_to_pansn_prefix
 from toil.job import Job
 from toil.common import Toil
 from toil.statsAndLogging import logger
@@ -459,7 +460,7 @@ def make_minigraph_fasta(job, gfa_file_id, gfa_file_path, name):
     job.fileStore.readGlobalFile(gfa_file_id, gfa_path)
     cmd = [["gfatools", "gfa2fa", gfa_path]]
     if name:
-        cmd.append(["sed", "-e", "s/^>\(.\)/>id={}|\\1/g".format(name)])
+        cmd.append(["sed", "-e", r"s/^>\(.\)/>id={}|\1/g".format(name)])
     if gfa_file_path.endswith('.gz'):
         cmd.append(['bgzip', '--threads', str(job.cores)])
         fa_path += '.gz'
@@ -477,11 +478,6 @@ def minigraph_map_all(job, options, config, gfa_id, fa_id_map, graph_event):
 
     mg_cores = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap"), "cpu", typeFn=int, default=1)
 
-    # doing the paf conversion is more efficient when done separately for each genome.  we can get away
-    # with doing this if the universal filter (which needs to process everything at once) is disabled
-    xml_node = findRequiredNode(config.xmlRoot, "graphmap")
-    paf_per_genome = not getOptionalAttrib(xml_node, "universalMZFilter", float)
-    
     # do the mapping
     gaf_id_map = {}
     paf_id_map = {}
@@ -496,14 +492,44 @@ def minigraph_map_all(job, options, config, gfa_id, fa_id_map, graph_event):
         minigraph_map_job = top_job.addChildJobFn(minigraph_map_one, config, event_name, fa_id, gfa_id,
                                                   cores=mg_cores, disk=5*fa_id.size + gfa_id.size,
                                                   memory=cactus_clamp_memory(mem))
-        gaf_id_map[event] = minigraph_map_job.rv(0)
-        paf_id_map[event] = minigraph_map_job.rv(1)
+        # keyed by event_name, not event, so that --batch runs (where event_name carries the
+        # chromosome) get distinct filenames in --outputGAFDir.  merge_pafs uses only the values.
+        gaf_id_map[event_name] = minigraph_map_job.rv(0)
+        paf_id_map[event_name] = minigraph_map_job.rv(1)
 
     # merge up
     paf_merge_job = top_job.addFollowOnJobFn(merge_pafs, paf_id_map)
     gaf_merge_job = top_job.addFollowOnJobFn(merge_pafs, gaf_id_map, gzip=True)
-    
+
+    # cactus-pangenome's options object doesn't carry outputGAFDir, hence the getattr
+    gaf_dir = getattr(options, 'outputGAFDir', None)
+    if gaf_dir:
+        top_job.addFollowOnJobFn(export_gaf_dir, gaf_id_map, gaf_dir)
+
     return paf_merge_job.rv(), gaf_merge_job.rv()
+
+def export_gaf_dir(job, gaf_id_map, gaf_dir):
+    """ write the per-genome GAFs out to --outputGAFDir
+
+    the merged GAF is exported by default, but the option promised the unmerged ones and was
+    never implemented beyond creating the directory. """
+    for event_name, gaf_id in gaf_id_map.items():
+        job.fileStore.exportFile(gaf_id, makeURL(os.path.join(gaf_dir, '{}.gaf'.format(event_name))))
+
+# id=EVENT|CONTIG, as it appears in a stable GAF's query column and in each of its path segments
+gaf_pansn_re = re.compile(r'id=([^|\t\n<>]+)\|')
+
+def gaf_to_pansn(gaf_path, out_path):
+    """ rewrite cactus's internal id=EVENT|CONTIG names as PanSN SAMPLE#HAP#CONTIG
+
+    minigraph_gfa_to_pansn() converts the GFA on the way out, but the GAF was left in cactus
+    naming, so the two published artifacts sat in different namespaces and nothing downstream
+    (gaf2unstable included) could resolve a GAF path segment against the graph it came from.
+    Both the query column and the path column are rewritten: id=EVENT| appears in each and
+    nowhere else in the record, so a single substitution over the line covers it. """
+    with open(gaf_path, 'r') as in_file, open(out_path, 'w') as out_file:
+        for line in in_file:
+            out_file.write(gaf_pansn_re.sub(lambda m: event_to_pansn_prefix(m.group(1)) + '#', line))
 
 def minigraph_map_one(job, config, event_name, fa_file_id, gfa_file_id):
     """ Run minigraph to map a Fasta file to a GFA graph, producing a GAF output """
@@ -550,13 +576,12 @@ def minigraph_map_one(job, config, event_name, fa_file_id, gfa_file_id):
     # optional gaf overlap filter
     overlap_ratio = getOptionalAttrib(xml_node, "GAFOverlapFilterRatio", typeFn=float, default=0)
     length_ratio = getOptionalAttrib(xml_node, "GAFOverlapFilterMinLengthRatio", typeFn=float, default=0)
-    overlap_filter_len = getOptionalAttrib(xml_node, "minGAFQueryOverlapFilter", int, default=0)    
     min_block = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap"), "minGAFBlockLength", typeFn=int, default=0)
     min_mapq = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap"), "minMAPQ", typeFn=int, default=0)
     min_ident = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap"), "minIdentity", typeFn=float, default=0)    
-    if overlap_ratio or overlap_filter_len:
+    if overlap_ratio:
         cmd = [cmd, ['gaffilter', '-', '-r', str(overlap_ratio), '-m', str(length_ratio), '-q', str(min_mapq),
-                     '-b', str(min_block), '-o', str(overlap_filter_len), '-i', str(min_ident)]]
+                     '-b', str(min_block), '-i', str(min_ident)]]
     cactus_call(parameters=cmd, outfile=unstable_gaf_path, job_memory=job.memory)
 
     # convert the unstable gaf into unstable paf, which is what cactus expects
@@ -567,8 +592,13 @@ def minigraph_map_one(job, config, event_name, fa_file_id, gfa_file_id):
                         ['awk', 'BEGIN{{OFS=\"	\"}} {{$6="id={}|"$6; print}}'.format(graph_event)]]
     cactus_call(parameters=unstable_paf_cmd, outfile=unstable_paf_path, job_memory=job.memory)
 
+    # the gaf is published as-is, so put it in PanSN to match the exported minigraph GFA
+    # (the filtering chain above has already consumed gaf_path in its cactus-named form)
+    pansn_gaf_path = gaf_path + '.pansn'
+    gaf_to_pansn(gaf_path, pansn_gaf_path)
+
     # return the stable gaf (minigraph output) and the unstable paf
-    return job.fileStore.writeGlobalFile(gaf_path), job.fileStore.writeGlobalFile(unstable_paf_path)
+    return job.fileStore.writeGlobalFile(pansn_gaf_path), job.fileStore.writeGlobalFile(unstable_paf_path)
 
 def merge_pafs(job, paf_file_id_map, gzip=False):
     """ merge up some pafs """
@@ -704,9 +734,10 @@ def filter_paf(job, paf_id, config, reference=None):
                 # we use it to be able to filter by the gaf block even after it's been broken in the paf
                 if tok.startswith('gl:i:'):
                     bl = int(tok[5:])
-                # we can also get the identity of the parent gaf block 
-                if tok.startswith('gi:i:'):
-                    ident = min(ident, float(toks[5:]))
+                # we can also get the identity of the parent gaf block
+                # (gaf2paf writes this as a float, gi:f:, not gi:i:)
+                if tok.startswith('gi:f:'):
+                    ident = min(ident, float(tok[5:]))
                 if tok.startswith('AS:i:'):
                     score = int(tok[5:])
             if query_name == target_name and max_collapse_ratio >= 0:

--- a/src/cactus/refmap/cactus_graphmap.py
+++ b/src/cactus/refmap/cactus_graphmap.py
@@ -698,7 +698,11 @@ def apply_mgsplit_filter_overrides(config_node):
 
 def filter_paf(job, paf_id, config, reference=None):
     """ run basic paf-filtering.  these are quick filters that are best to do on-the-fly when reading the paf and
-        as such, they are called by cactus-graphmap-split and cactus-align, not here """
+        as such, they are called by cactus-graphmap-split and cactus-align, not here
+
+        both callers must pass the same arguments: depending on --noSplit and on how a step-by-step
+        run is driven, this may run before the split, before cactus-align, or both, and those three
+        need to agree """
     work_dir = job.fileStore.getLocalTempDir()
     paf_path = os.path.join(work_dir, 'mg.paf')
     filter_paf_path = os.path.join(work_dir, 'mg.paf.filter')

--- a/src/cactus/refmap/cactus_graphmap.py
+++ b/src/cactus/refmap/cactus_graphmap.py
@@ -51,6 +51,7 @@ def main():
     parser.add_argument("--outputFasta", type=str, help = "Output graph sequence file in FASTA format (required if not present in seqFile)")
     parser.add_argument("--maskFilter", type=int, help = "Ignore softmasked sequence intervals > Nbp (overrides config option of same name)")
     parser.add_argument("--delFilter", type=int, help = "Filter out split-mapping-implied deletions > Nbp (default will be \"delFilter\" from the config")
+    parser.add_argument("--minIdentity", type=float, help = "Ignore PAF lines with identity (column 10/11) < this (overrides minIdentity in <graphmap> in config)")
     parser.add_argument("--outputGAFDir", type=str, help = "Output GAF alignments (raw minigraph output before PAF conversion) to this directory")
     parser.add_argument("--reference", nargs='+', type=str, help = "Reference genome name.  MAPQ filter will not be applied to it")
     parser.add_argument("--refFromGFA", action="store_true", help = "Do not align reference (--reference) from seqfile, and instead extract its alignment from the rGFA tags (must have been used as reference for minigraph GFA construction)")
@@ -157,6 +158,8 @@ def graph_map(options):
                 findRequiredNode(config_node, "graphmap").attrib["maskFilter"] = str(options.maskFilter)
             if options.delFilter is not None:
                 findRequiredNode(config_node, "graphmap").attrib["delFilter"] = str(options.delFilter)
+            if options.minIdentity is not None:
+                findRequiredNode(config_node, "graphmap").attrib["minIdentity"] = str(options.minIdentity)
 
             # apply cpu override                
             if options.mapCores is not None:

--- a/src/cactus/refmap/cactus_graphmap_split.py
+++ b/src/cactus/refmap/cactus_graphmap_split.py
@@ -52,7 +52,7 @@ def main():
     parser.add_argument("--otherContig", type=str, help = "Lump all reference contigs unselected by above options into single one with this name")
     parser.add_argument("--reference", required=True, nargs='+', type=str, help = "Name of reference (in seqFile).  Ambiguity filters will not be applied to it")
     parser.add_argument("--maskFilter", type=int, help = "Ignore softmasked sequence intervals > Nbp")
-    parser.add_argument("--minIdentity", type=float, help = "Ignore PAF lines with identity (column 10/11) < this (overrides minIdentity in <graphmap_split> in config)")
+    parser.add_argument("--minIdentity", type=float, help = "Ignore PAF lines with identity (column 10/11) < this (overrides minIdentity in <graphmap> in config)")
     parser.add_argument("--permissiveContigFilter", nargs='?', const='0.25', default=None, type=float, help = "If specified, override the configuration to accept contigs so long as they have at least given fraction of coverage (0.25 if no fraction specified). This can increase sensitivity of very small, fragmented and/or diverse assemblies.")
     parser.add_argument("--mgSplit", action="store_true", default=False,
                         help="Use this when the input PAF was produced against a reference-only minigraph (cactus-pangenome --mgSplit / cactus-minigraph --refOnly): relaxes the block-length and overlap filters so palindromic mappings don't get axed before rgfa-split.")

--- a/src/cactus/refmap/cactus_minigraph.py
+++ b/src/cactus/refmap/cactus_minigraph.py
@@ -18,6 +18,7 @@ import gzip
 
 from cactus.progressive.seqFile import SeqFile
 from cactus.shared.common import setupBinaries, importSingularityImage
+from cactus.refmap.pangenome_exclusions import event_to_pansn_prefix
 from cactus.shared.common import cactusRootPath
 from cactus.shared.configWrapper import ConfigWrapper
 from cactus.shared.common import makeURL, catFiles, write_s3
@@ -589,14 +590,11 @@ def minigraph_gfa_to_pansn(names, gfa_path, out_gfa_path, threads=1):
                     assert barpos > 8
                     name = tok[8:barpos]
                     assert name in names
-                    dotpos = name.rfind('.')
-                    if dotpos > 0:
-                        hap = name[dotpos+1:]
-                        name = name[:dotpos]
-                    else:
-                        # add #0 to names without haplotype to make valid PAN-SN
-                        hap = '0'
-                    toks[4+i] = 'SN:Z:{}#{}#{}'.format(name, hap, tok[barpos+1:])
+                    # one splitter for every artifact: this GFA, the GAF that indexes into it,
+                    # and hal2vg's final graph.  splitting here on the last '.' verbatim instead
+                    # gave HG002.01 -> HG002#01# against the GAF's HG002#1#, and HG002.pat ->
+                    # HG002#pat#, which is not a PanSN haplotype at all
+                    toks[4+i] = 'SN:Z:{}#{}'.format(event_to_pansn_prefix(name), tok[barpos+1:])
                     break
             out_file.write(('\t'.join(toks) + '\n').encode())
         else:

--- a/src/cactus/refmap/cactus_pangenome.py
+++ b/src/cactus/refmap/cactus_pangenome.py
@@ -79,6 +79,7 @@ def pangenome_options(parser):
     parser.add_argument("--otherContig", type=str, help = "Lump all reference contigs unselected by above options into single one with this name")
     parser.add_argument("--permissiveContigFilter", nargs='?', const='0.25', default=None, type=float, help = "If specified, override the configuration to accept contigs so long as they have at least given fraction of coverage (0.25 if no fraction specified). This can increase sensitivity of very small, fragmented and/or diverse assemblies.")
     parser.add_argument("--noSplit", action='store_true', help = "Do not split by ref chromsome. This will require much more memory and potentially produce a more complex graph")
+    parser.add_argument("--minIdentity", type=float, help = "Ignore PAF lines with identity (column 10/11) < this (overrides minIdentity in <graphmap> in config)")
 
     # cactus-align options
     # note: when changing this, make sure to keep option in cactus-align consistent
@@ -131,7 +132,6 @@ def pangenome_validate_options(options):
     options.pafMaskFilter = None
     options.outVG = True
     options.outGFA = False
-    options.minIdentity = None
     options.chromInfo = None
     # these let cactus-panpatch turn off output it would only throw away (the hal) or write
     # twice (the chromosome vgs)
@@ -216,6 +216,12 @@ def pangenome_config_overrides(options, config_node):
 
     if options.collapse:
         findRequiredNode(config_node, "graphmap").attrib["collapse"] = 'all'
+
+    # written here, before the --mgSplit deep-copy below, so that the one flag reaches all three
+    # consumers: gaffilter -i in cactus-graphmap, and the filter_paf line filter in both
+    # cactus-graphmap-split and cactus-align
+    if options.minIdentity is not None:
+        findRequiredNode(config_node, "graphmap").attrib["minIdentity"] = str(options.minIdentity)
 
 def main():
     parser = Job.Runner.getDefaultArgumentParser()

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -62,6 +62,7 @@ def main():
                         " The overridden configuration will be saved in <outHal>.pg-conf.xml")
 
     parser.add_argument("--collapse", help = "Incorporate minimap2 self-alignments.", action='store_true', default=False)
+    parser.add_argument("--minIdentity", type=float, help = "Ignore PAF lines with identity (column 10/11) < this (overrides minIdentity in <graphmap> in config)")
     parser.add_argument("--scoresFile", type=str,
                         help = "File containing scoring parameters (output of last-train / cactus-minigraphr --lastTrain)")
     parser.add_argument("--scoresFromChromfile", action="store_true", default=False,
@@ -277,6 +278,8 @@ def make_align_job(options, toil, config_wrapper=None, chrom_name=None):
         config_wrapper.substituteAllPredefinedConstantsWithLiterals(options)
         if options.collapse:
             findRequiredNode(config_node, "graphmap").attrib["collapse"] = 'all'
+        if getattr(options, 'minIdentity', None) is not None:
+            findRequiredNode(config_node, "graphmap").attrib["minIdentity"] = str(options.minIdentity)
     if hasattr(options, 'hdf5Codec') and options.hdf5Codec:
         config_node.find("hal").attrib["hdf5Codec"] = options.hdf5Codec
     config_wrapper.setSystemMemory(options)

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -433,8 +433,14 @@ def cactus_align(job, config_wrapper, mc_tree, input_seq_map, input_seq_id_map, 
     # skipped by --noSplit (and by anyone running step-by-step without it), so this call cannot assume
     # it has already happened.  running it in both places is harmless: the line filter is stateless
     # per line, and the overlap filter is idempotent -- gaffilter drops a record only when a competitor
-    # beats it, so a second pass over its own output has nothing left to remove.  what matters is that
-    # both call sites pass the same arguments, hence reference= here to match cactus-graphmap-split.
+    # beats it, so a second pass over its own output has nothing left to remove.
+    #
+    # what is not harmless is the two call sites disagreeing on arguments.  cactus-graphmap-split
+    # passes reference=, which exempts queries belonging to the reference genome from the MAPQ,
+    # block-length, identity and score thresholds; this call passed nothing, so an ordinary split
+    # run spent the split stage preserving those reference alignments and then dropped them here
+    # anyway.  that is the common path, not just --noSplit.  referenceEvents[0] matches the "first
+    # reference" convention cactus-graphmap-split already normalises to.
     if do_filter_paf:
         paf_filter_mem = max(paf_id.size * 10, 2**32)
         paf_filter_job = head_job.addChildJobFn(filter_paf, paf_id, config_wrapper,

--- a/src/cactus/setup/cactus_align.py
+++ b/src/cactus/setup/cactus_align.py
@@ -426,10 +426,17 @@ def cactus_align(job, config_wrapper, mc_tree, input_seq_map, input_seq_id_map, 
     sanitize_job = head_job.addChildJobFn(sanitize_fasta_headers, input_seq_id_map, pangenome=doVG or doGFA or do_filter_paf)
     new_seq_id_map = sanitize_job.rv()
 
-    # run pangenome-specific paf filter
+    # run pangenome-specific paf filter.  this also runs in cactus-graphmap-split, but that stage is
+    # skipped by --noSplit (and by anyone running step-by-step without it), so this call cannot assume
+    # it has already happened.  running it in both places is harmless: the line filter is stateless
+    # per line, and the overlap filter is idempotent -- gaffilter drops a record only when a competitor
+    # beats it, so a second pass over its own output has nothing left to remove.  what matters is that
+    # both call sites pass the same arguments, hence reference= here to match cactus-graphmap-split.
     if do_filter_paf:
         paf_filter_mem = max(paf_id.size * 10, 2**32)
-        paf_filter_job = head_job.addChildJobFn(filter_paf, paf_id, config_wrapper, disk = paf_id.size * 10, memory=paf_filter_mem)
+        paf_filter_job = head_job.addChildJobFn(filter_paf, paf_id, config_wrapper,
+                                                reference=referenceEvents[0] if referenceEvents else None,
+                                                disk = paf_id.size * 10, memory=paf_filter_mem)
         paf_id = paf_filter_job.rv()
 
     # apply tree scaling to reflect branch scaling and/or uncertainty in ancestor placement/sequences


### PR DESCRIPTION
Split this off a different session that was getting unruly.  It fixes a few minor things:
 * adds pansn prefix to GAF output
 * fixes identity filter (and adds command line for it)
 * removes a bunch of config options that are no longer used (or usable)
 * fixes some logic about how reference name was not always passed to gaffilter. 