### PR TITLE
Fix compiler flags in release build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,11 @@ RUN find /home/cactus -name include.local.mk -exec rm -f {} \; && \
 # https://github.com/yangao07/abPOA/issues/26
 ENV avx2 1
 
+# This image is distributed, so build it the way the binary release is built: include.mk's
+# portable baseline rather than the -march=native a plain "make" would otherwise pick.  The
+# value itself stays in include.mk; this only selects it.
+ENV CACTUS_PORTABLE_BUILD 1
+
 # install Phast and enable halPhyloP compilation
 RUN cd /home/cactus && ./build-tools/downloadPhast
 ENV ENABLE_PHYLOP 1

--- a/Makefile
+++ b/Makefile
@@ -318,24 +318,24 @@ suball.paffy:
 
 suball.red: suball.jemalloc
 	cd submodules/red && sed -i -e '/LIBS/!s/-o \$$(TRed) \$$(OBJS)/-o $$(TRed) $$(OBJS) $$(LIBS)/' src/Makefile
-	cd submodules/red && LIBS="${jemallocSubLibs}" ${MAKE}
+	cd submodules/red && CXXFLAGS="$${CXXFLAGS} ${CACTUS_ARCH_FLAGS}" LIBS="${jemallocSubLibs}" ${MAKE}
 	ln -f submodules/red/bin/Red ${BINDIR}
 
 suball.collapse-bubble:
 	chmod +x submodules/collapse-bubble/scripts/merge_duplicates.py
 	ln -f submodules/collapse-bubble/scripts/merge_duplicates.py ${BINDIR}
 suball.FASTGA: suball.jemalloc
-	cd submodules/FASTGA && sed -i -e '/-lpthread/!s/-lm -lz/-lpthread -lm -lz/g' -e '/LIBS/!s/-lpthread -lm -lz/-lpthread -lm -lz $$(LIBS)/g' Makefile && LIBS="${jemallocSubLibs}" ${MAKE}
+	cd submodules/FASTGA && sed -i -e '/-lpthread/!s/-lm -lz/-lpthread -lm -lz/g' -e '/LIBS/!s/-lpthread -lm -lz/-lpthread -lm -lz $$(LIBS)/g' Makefile && LIBS="${jemallocSubLibs}" ${MAKE} CC="$${CC:-gcc} ${CACTUS_ARCH_FLAGS}"
 	ln -f submodules/FASTGA/FastGA ${BINDIR}
 	ln -f submodules/FASTGA/ALNtoPAF ${BINDIR}
 	ln -f submodules/FASTGA/FAtoGDB ${BINDIR}
 	ln -f submodules/FASTGA/GIXmake ${BINDIR}
 	ln -f submodules/FASTGA/GIXrm ${BINDIR}
 suball.FASTAN: suball.jemalloc
-	cd submodules/FASTAN && sed -i -e 's/-lm -lz/-lm -lpthread -lz/g' -e '/LIBS/!s/-lm -lpthread -lz/-lm -lpthread -lz $$(LIBS)/g' Makefile && LIBS="${jemallocSubLibs}" ${MAKE} || true
+	cd submodules/FASTAN && sed -i -e 's/-lm -lz/-lm -lpthread -lz/g' -e '/LIBS/!s/-lm -lpthread -lz/-lm -lpthread -lz $$(LIBS)/g' Makefile && LIBS="${jemallocSubLibs}" ${MAKE} CC="$${CC:-gcc} ${CACTUS_ARCH_FLAGS}" || true
 	ln -f submodules/FASTAN/FasTAN ${BINDIR}
 suball.alntools:
-	cd submodules/alntools && ${MAKE}
+	cd submodules/alntools && ${MAKE} CC="$${CC:-gcc} ${CACTUS_ARCH_FLAGS}"
 	ln -f submodules/alntools/tanbed ${BINDIR}
 
 ifeq ($(jemalloc),on)

--- a/Makefile
+++ b/Makefile
@@ -264,7 +264,7 @@ suball1: ${submodules1:%=suball.%}
 suball2: ${submodules2:%=suball.%}
 
 suball.sonLib:
-	cd submodules/sonLib && PKG_CONFIG_PATH=${CWD}/lib/pkgconfig:${PKG_CONFIG_PATH} ${archEnv} ${MAKE}
+	cd submodules/sonLib && PKG_CONFIG_PATH=${CWD}/lib/pkgconfig:${PKG_CONFIG_PATH} ${archEnvExt} ${MAKE} ${archCC}
 	rm -rf submodules/sonLib/bin/*.dSYM
 	ln -f submodules/sonLib/bin/[a-zA-Z]* ${BINDIR}
 	ln -f submodules/sonLib/lib/*.a ${LIBDIR}
@@ -286,13 +286,13 @@ suball.jemalloc:
 endif
 
 suball.pinchesAndCacti: suball.sonLib
-	cd submodules/pinchesAndCacti && ${archEnv} ${MAKE}
+	cd submodules/pinchesAndCacti && ${archEnvExt} ${MAKE} ${archCC}
 
 suball.matchingAndOrdering: suball.sonLib
-	cd submodules/matchingAndOrdering && ${archEnv} ${MAKE}
+	cd submodules/matchingAndOrdering && ${archEnvExt} ${MAKE} ${archCC}
 
 suball.cPecan: suball.sonLib
-	cd submodules/cPecan && ${archEnv} ${MAKE}
+	cd submodules/cPecan && ${archEnvExt} ${MAKE} ${archCC}
 	rm -f ${BINDIR}/cPecanLastz*
 
 suball.cactus2hal: suball.sonLib suball.hal all_libs.api
@@ -329,7 +329,7 @@ suball.lastz: suball.jemalloc
 
 suball.paffy:
 	git -C submodules/paffy/submodules/sonLib checkout $$(git -C submodules/sonLib rev-parse HEAD)
-	cd submodules/paffy && ${archEnv} LIBS="${jemallocLib}" ${MAKE}
+	cd submodules/paffy && ${archEnvExt} LIBS="${jemallocLib}" ${MAKE} ${archCC}
 	rm -rf submodules/paffy/bin/*.dSYM
 	ln -f submodules/paffy/bin/[a-zA-Z]* ${BINDIR}
 	ln -f submodules/paffy/lib/*.a ${LIBDIR}

--- a/Makefile
+++ b/Makefile
@@ -303,9 +303,9 @@ suball.abPOA:
 	ln -f submodules/abPOA/include/*.h ${INCLDIR}
 	rm -fr ${INCLDIR}/simde && cp -r submodules/abPOA/include/simde ${INCLDIR}
 
-suball.lastz:
+suball.lastz: suball.jemalloc
 	cd submodules/lastz/src && sed -i -e 's/-lm -o/-lm $${LIBS} -o/g' Makefile
-	cd submodules/lastz && LIBS="${jemallocLib}" ${MAKE}
+	cd submodules/lastz && LIBS="${jemallocSubLibs}" ${MAKE}
 	ln -f submodules/lastz/src/lastz bin
 
 suball.paffy:
@@ -316,22 +316,23 @@ suball.paffy:
 	ln -f submodules/paffy/lib/*.a ${LIBDIR}
 	ln -f submodules/paffy/inc/*.h ${INCLDIR}
 
-suball.red:
-	cd submodules/red && ${MAKE}
+suball.red: suball.jemalloc
+	cd submodules/red && sed -i -e '/LIBS/!s/-o \$$(TRed) \$$(OBJS)/-o $$(TRed) $$(OBJS) $$(LIBS)/' src/Makefile
+	cd submodules/red && LIBS="${jemallocSubLibs}" ${MAKE}
 	ln -f submodules/red/bin/Red ${BINDIR}
 
 suball.collapse-bubble:
 	chmod +x submodules/collapse-bubble/scripts/merge_duplicates.py
 	ln -f submodules/collapse-bubble/scripts/merge_duplicates.py ${BINDIR}
-suball.FASTGA:
-	cd submodules/FASTGA && sed -i '/-lpthread/!s/-lm -lz/-lpthread -lm -lz/g' Makefile && ${MAKE}
+suball.FASTGA: suball.jemalloc
+	cd submodules/FASTGA && sed -i -e '/-lpthread/!s/-lm -lz/-lpthread -lm -lz/g' -e '/LIBS/!s/-lpthread -lm -lz/-lpthread -lm -lz $$(LIBS)/g' Makefile && LIBS="${jemallocSubLibs}" ${MAKE}
 	ln -f submodules/FASTGA/FastGA ${BINDIR}
 	ln -f submodules/FASTGA/ALNtoPAF ${BINDIR}
 	ln -f submodules/FASTGA/FAtoGDB ${BINDIR}
 	ln -f submodules/FASTGA/GIXmake ${BINDIR}
 	ln -f submodules/FASTGA/GIXrm ${BINDIR}
-suball.FASTAN:
-	cd submodules/FASTAN && sed -i -e 's/-lm -lz/-lm -lpthread -lz/g' Makefile && ${MAKE} || true
+suball.FASTAN: suball.jemalloc
+	cd submodules/FASTAN && sed -i -e 's/-lm -lz/-lm -lpthread -lz/g' -e '/LIBS/!s/-lm -lpthread -lz/-lm -lpthread -lz $$(LIBS)/g' Makefile && LIBS="${jemallocSubLibs}" ${MAKE} || true
 	ln -f submodules/FASTAN/FasTAN ${BINDIR}
 suball.alntools:
 	cd submodules/alntools && ${MAKE}

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,10 @@ CWD = ${PWD}
 export sonLibRootDir = ${CWD}/submodules/sonLib
 .PHONY: all all.% clean clean.% selfClean suball suball.% subclean.% arch-flags
 
+# Pinned, because make's default goal is whatever rule comes first and a helper target
+# above "all" would silently turn a bare "make" into a no-op that still exits 0.
+.DEFAULT_GOAL := all
+
 # The CPU baseline, for the build-tools/download* shell scripts.  They build tools that end
 # up in the same release as everything make builds, so they need the same flags -- but they
 # are shell, and CACTUS_ARCH_FLAGS is a make variable set in include.mk.  Rather than have

--- a/Makefile
+++ b/Makefile
@@ -304,7 +304,15 @@ suball.abPOA:
 	rm -fr ${INCLDIR}/simde && cp -r submodules/abPOA/include/simde ${INCLDIR}
 
 suball.lastz: suball.jemalloc
-	cd submodules/lastz/src && sed -i -e 's/-lm -o/-lm $${LIBS} -o/g' Makefile
+# Inject ${LIBS} into lastz's link lines so jemalloc reaches it.  This must not assume the
+# link line is still pristine: makeBinRelease seds 's/-lm/-lm -static/g' into this same file
+# *before* make runs, and the old pattern here ('-lm -o') then no longer matched, so ${LIBS}
+# was silently never injected and every release shipped a lastz without jemalloc.  It looked
+# fine in developer trees only because a previous build had already patched the file, which
+# is why it survived local testing.  Match around whatever sits between -lm and -o instead,
+# skip lines that already have LIBS so repeated builds stay idempotent, and verify.
+	cd submodules/lastz/src && sed -i -e '/LIBS/!s/-lm\(.*\) -o \$$@/-lm\1 $${LIBS} -o $$@/' Makefile \
+	  && grep -q 'LIBS' Makefile
 	cd submodules/lastz && LIBS="${jemallocSubLibs}" ${MAKE}
 	ln -f submodules/lastz/src/lastz bin
 

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,14 @@ CWD = ${PWD}
 
 # these must be absolute, as used in submodules.
 export sonLibRootDir = ${CWD}/submodules/sonLib
-.PHONY: all all.% clean clean.% selfClean suball suball.% subclean.%
+.PHONY: all all.% clean clean.% selfClean suball suball.% subclean.% arch-flags
+
+# The CPU baseline, for the build-tools/download* shell scripts.  They build tools that end
+# up in the same release as everything make builds, so they need the same flags -- but they
+# are shell, and CACTUS_ARCH_FLAGS is a make variable set in include.mk.  Rather than have
+# each script re-implement the arm/legacy/x86 selection and drift out of sync, they ask here.
+arch-flags:
+	@echo '${CACTUS_ARCH_FLAGS}'
 
 ##
 # Building.  First build submodules, then a pass for libs and a pass for bins

--- a/Makefile
+++ b/Makefile
@@ -264,7 +264,7 @@ suball1: ${submodules1:%=suball.%}
 suball2: ${submodules2:%=suball.%}
 
 suball.sonLib:
-	cd submodules/sonLib && PKG_CONFIG_PATH=${CWD}/lib/pkgconfig:${PKG_CONFIG_PATH} ${MAKE}
+	cd submodules/sonLib && PKG_CONFIG_PATH=${CWD}/lib/pkgconfig:${PKG_CONFIG_PATH} ${archEnv} ${MAKE}
 	rm -rf submodules/sonLib/bin/*.dSYM
 	ln -f submodules/sonLib/bin/[a-zA-Z]* ${BINDIR}
 	ln -f submodules/sonLib/lib/*.a ${LIBDIR}
@@ -286,21 +286,21 @@ suball.jemalloc:
 endif
 
 suball.pinchesAndCacti: suball.sonLib
-	cd submodules/pinchesAndCacti && ${MAKE}
+	cd submodules/pinchesAndCacti && ${archEnv} ${MAKE}
 
 suball.matchingAndOrdering: suball.sonLib
-	cd submodules/matchingAndOrdering && ${MAKE}
+	cd submodules/matchingAndOrdering && ${archEnv} ${MAKE}
 
 suball.cPecan: suball.sonLib
-	cd submodules/cPecan && ${MAKE}
+	cd submodules/cPecan && ${archEnv} ${MAKE}
 	rm -f ${BINDIR}/cPecanLastz*
 
 suball.cactus2hal: suball.sonLib suball.hal all_libs.api
-	cd submodules/cactus2hal && ${MAKE}
+	cd submodules/cactus2hal && ${archEnv} ${MAKE}
 	-ln -f submodules/cactus2hal/bin/* bin/
 
 suball.hal: suball.sonLib
-	cd submodules/hal && LIBS="${jemallocLib}" ${MAKE}
+	cd submodules/hal && ${archEnv} LIBS="${jemallocLib}" ${MAKE}
 	-ln -f submodules/hal/bin/* bin/
 	-ln -f submodules/hal/lib/libHal.a submodules/hal/lib/halLib.a
 
@@ -324,12 +324,12 @@ suball.lastz: suball.jemalloc
 # skip lines that already have LIBS so repeated builds stay idempotent, and verify.
 	cd submodules/lastz/src && sed -i -e '/LIBS/!s/-lm\(.*\) -o \$$@/-lm\1 $${LIBS} -o $$@/' Makefile \
 	  && grep -q 'LIBS' Makefile
-	cd submodules/lastz && LIBS="${jemallocSubLibs}" ${MAKE}
+	cd submodules/lastz && ${archEnv} LIBS="${jemallocSubLibs}" ${MAKE}
 	ln -f submodules/lastz/src/lastz bin
 
 suball.paffy:
 	git -C submodules/paffy/submodules/sonLib checkout $$(git -C submodules/sonLib rev-parse HEAD)
-	cd submodules/paffy && LIBS="${jemallocLib}" ${MAKE}
+	cd submodules/paffy && ${archEnv} LIBS="${jemallocLib}" ${MAKE}
 	rm -rf submodules/paffy/bin/*.dSYM
 	ln -f submodules/paffy/bin/[a-zA-Z]* ${BINDIR}
 	ln -f submodules/paffy/lib/*.a ${LIBDIR}

--- a/build-tools/downloadMafTools
+++ b/build-tools/downloadMafTools
@@ -37,8 +37,14 @@ if [ -z "${CACTUS_ARCH_FLAGS}" ]; then
     echo "ERROR: 'make arch-flags' returned nothing; cannot determine the CPU baseline." >&2
     exit 1
 fi
-export CFLAGS="${CFLAGS:-} ${CACTUS_ARCH_FLAGS}"
-export CXXFLAGS="${CXXFLAGS:-} ${CACTUS_ARCH_FLAGS}"
+# autoconf's AC_PROG_CC supplies its default "-g -O2" only when CFLAGS is *unset*.  Setting
+# CFLAGS below to carry the arch flags therefore suppresses it, which would silently drop
+# samtools, bcftools and htslib to -O0 in any build that had not already chosen a level --
+# i.e. every non-release build, including the Docker image.  Choose the level here instead.
+case " ${CFLAGS:-} " in *" -O"*) ;; *) CFLAGS="${CFLAGS:-} -O2" ;; esac
+case " ${CXXFLAGS:-} " in *" -O"*) ;; *) CXXFLAGS="${CXXFLAGS:-} -O2" ;; esac
+export CFLAGS="${CFLAGS} ${CACTUS_ARCH_FLAGS}"
+export CXXFLAGS="${CXXFLAGS} ${CACTUS_ARCH_FLAGS}"
 
 rm -rf ${mafBuildDir}
 mkdir -p ${mafBuildDir}

--- a/build-tools/downloadMafTools
+++ b/build-tools/downloadMafTools
@@ -29,6 +29,17 @@ if [ -z ${CACTUS_LEGACY_ARCH+x} ]; then
     fi
 fi
 
+# CPU baseline.  include.mk is the single source of truth; ask make for it rather than
+# duplicating the arm/legacy/x86 selection here, where it would silently drift.
+# MAKEFLAGS is cleared because "make binRelease" reaches this from inside a make recipe.
+CACTUS_ARCH_FLAGS="${CACTUS_ARCH_FLAGS:-$(env -u MAKEFLAGS make -s -C "${CWD}" arch-flags)}"
+if [ -z "${CACTUS_ARCH_FLAGS}" ]; then
+    echo "ERROR: 'make arch-flags' returned nothing; cannot determine the CPU baseline." >&2
+    exit 1
+fi
+export CFLAGS="${CFLAGS:-} ${CACTUS_ARCH_FLAGS}"
+export CXXFLAGS="${CXXFLAGS:-} ${CACTUS_ARCH_FLAGS}"
+
 rm -rf ${mafBuildDir}
 mkdir -p ${mafBuildDir}
 mkdir -p ${binDir}

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -397,11 +397,17 @@ cd ${pangenomeBuildDir}
 wget -nv --tries=5 --waitretry=3 --timeout=60 --retry-connrefused https://github.com/pangenome/odgi/releases/download/v0.9.4/odgi-v0.9.4.tar.gz
 tar --no-same-owner -zxf odgi-v0.9.4.tar.gz
 cd odgi-v0.9.4
+# "Generic" is odgi's portable build type -- it exists to dodge the -Ofast -march=native
+# that CMAKE_BUILD_TYPE=Release injects (odgi CMakeLists.txt:77-91).  But odgi only sets
+# CMAKE_CXX_FLAGS under Release/RelWithDebInfo, and CMake has no CMAKE_CXX_FLAGS_GENERIC of
+# its own, so Generic ended up with no -O flag at all and odgi shipped at -O0.  Supplying
+# CMAKE_CXX_FLAGS_GENERIC adds -O3 for that config only; overriding CMAKE_CXX_FLAGS instead
+# would drop the -fopenmp that Generic does supply through it.
 if [[ $STATIC_CHECK -eq 1 ]]
 then
-    CXXFLAGS="" CFLAGS="" LDFLAGS="" LIBS="" cmake -DBUILD_STATIC=1 -DCMAKE_BUILD_TYPE=Generic -H. -Bbuild && CXXFLAGS="" CFLAGS="" LDFLAGS="" LIBS="" cmake --build build -- -j ${numcpu}
+    CXXFLAGS="" CFLAGS="" LDFLAGS="" LIBS="" cmake -DBUILD_STATIC=1 -DCMAKE_BUILD_TYPE=Generic -DCMAKE_C_FLAGS_GENERIC=-O3 -DCMAKE_CXX_FLAGS_GENERIC=-O3 -H. -Bbuild && CXXFLAGS="" CFLAGS="" LDFLAGS="" LIBS="" cmake --build build -- -j ${numcpu}
 else
-    cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Generic && cmake --build build -- -j ${numcpu}
+    cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Generic -DCMAKE_C_FLAGS_GENERIC=-O3 -DCMAKE_CXX_FLAGS_GENERIC=-O3 && cmake --build build -- -j ${numcpu}
 fi
 if [[ $STATIC_CHECK -ne 1 || $(ldd bin/odgi | grep so | wc -l) -eq 0 ]]
 then

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -431,7 +431,19 @@ cd ${pangenomeBuildDir}
 git clone https://gitlab.com/mcfrith/last.git --recursive
 cd last
 git checkout 1651
-sed -i makefile -e 's/CXXFLAGS=/CXXFLAGS+=/'
+# last writes "CXXFLAGS = ..." with spaces around the '=', so the old
+# 's/CXXFLAGS=/CXXFLAGS+=/' never matched line 1.  What it did match was the sub-make
+# override on line 3 ($(MAKE) CXXFLAGS="$(CXXFLAGS)" -> CXXFLAGS+="$(CXXFLAGS)"), which only
+# doubled last's own flags while its line-1 assignment carried on clobbering ours -- so
+# nothing cactus sets has ever reached lastal/lastdb.  Anchor to the line start and allow the
+# spaces; leave line 3 alone, since that override is how src/makefile receives the value.
+# Guarded: this sed was silently a no-op for years, which is exactly what we don't want twice.
+grep -qE '^CXXFLAGS *=' makefile || {
+    echo "ERROR: last: no 'CXXFLAGS =' assignment at the start of a line in makefile." >&2
+    echo "       Upstream changed its build; re-check that cactus's CXXFLAGS reach lastal." >&2
+    exit 1
+}
+sed -i makefile -e 's/^CXXFLAGS *= */CXXFLAGS += /'
 # last has no LIBS variable, so add one after the objects.  Order matters: a static archive
 # named before the objects resolves nothing and is discarded, and lastal would silently fall
 # back to glibc's allocator.

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -58,8 +58,14 @@ if [ -z "${CACTUS_ARCH_FLAGS}" ]; then
     echo "ERROR: 'make arch-flags' returned nothing; cannot determine the CPU baseline." >&2
     exit 1
 fi
-export CFLAGS="${CFLAGS:-} ${CACTUS_ARCH_FLAGS}"
-export CXXFLAGS="${CXXFLAGS:-} ${CACTUS_ARCH_FLAGS}"
+# autoconf's AC_PROG_CC supplies its default "-g -O2" only when CFLAGS is *unset*.  Setting
+# CFLAGS below to carry the arch flags therefore suppresses it, which would silently drop
+# samtools, bcftools and htslib to -O0 in any build that had not already chosen a level --
+# i.e. every non-release build, including the Docker image.  Choose the level here instead.
+case " ${CFLAGS:-} " in *" -O"*) ;; *) CFLAGS="${CFLAGS:-} -O2" ;; esac
+case " ${CXXFLAGS:-} " in *" -O"*) ;; *) CXXFLAGS="${CXXFLAGS:-} -O2" ;; esac
+export CFLAGS="${CFLAGS} ${CACTUS_ARCH_FLAGS}"
+export CXXFLAGS="${CXXFLAGS} ${CACTUS_ARCH_FLAGS}"
 
 rm -rf ${pangenomeBuildDir}
 mkdir -p ${pangenomeBuildDir}

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -47,6 +47,23 @@ if [ -z ${CACTUS_LEGACY_ARCH+x} ]; then
     fi
 fi
 
+# CPU baseline, mirroring include.mk (hand-kept in sync, like the jemalloc block above).
+# Needed because CACTUS_ARCH_FLAGS is a make variable and this is a shell script, so without
+# it nothing built here -- minigraph, minimap2, gfatools, last, samtools/bcftools -- sees an
+# arch flag at all.  Confirmed against the v3.3.0 tarball: minigraph carried zero AVX2 in its
+# own code, only glibc's runtime-dispatched string routines.
+if [ -z ${CACTUS_ARCH_FLAGS+x} ]; then
+    if [ -n "${arm+x}" ]; then
+        CACTUS_ARCH_FLAGS="-march=armv8-a+simd"
+    elif [ -n "${CACTUS_LEGACY_ARCH+x}" ]; then
+        CACTUS_ARCH_FLAGS="-msse2"
+    else
+        CACTUS_ARCH_FLAGS="-march=x86-64-v3"
+    fi
+fi
+export CFLAGS="${CFLAGS:-} ${CACTUS_ARCH_FLAGS}"
+export CXXFLAGS="${CXXFLAGS:-} ${CACTUS_ARCH_FLAGS}"
+
 rm -rf ${pangenomeBuildDir}
 mkdir -p ${pangenomeBuildDir}
 mkdir -p ${binDir}
@@ -405,9 +422,9 @@ cd odgi-v0.9.4
 # would drop the -fopenmp that Generic does supply through it.
 if [[ $STATIC_CHECK -eq 1 ]]
 then
-    CXXFLAGS="" CFLAGS="" LDFLAGS="" LIBS="" cmake -DBUILD_STATIC=1 -DCMAKE_BUILD_TYPE=Generic -DCMAKE_C_FLAGS_GENERIC=-O3 -DCMAKE_CXX_FLAGS_GENERIC=-O3 -H. -Bbuild && CXXFLAGS="" CFLAGS="" LDFLAGS="" LIBS="" cmake --build build -- -j ${numcpu}
+    CXXFLAGS="" CFLAGS="" LDFLAGS="" LIBS="" cmake -DBUILD_STATIC=1 -DCMAKE_BUILD_TYPE=Generic -DCMAKE_C_FLAGS_GENERIC="-O3 ${CACTUS_ARCH_FLAGS}" -DCMAKE_CXX_FLAGS_GENERIC="-O3 ${CACTUS_ARCH_FLAGS}" -H. -Bbuild && CXXFLAGS="" CFLAGS="" LDFLAGS="" LIBS="" cmake --build build -- -j ${numcpu}
 else
-    cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Generic -DCMAKE_C_FLAGS_GENERIC=-O3 -DCMAKE_CXX_FLAGS_GENERIC=-O3 && cmake --build build -- -j ${numcpu}
+    cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Generic -DCMAKE_C_FLAGS_GENERIC="-O3 ${CACTUS_ARCH_FLAGS}" -DCMAKE_CXX_FLAGS_GENERIC="-O3 ${CACTUS_ARCH_FLAGS}" && cmake --build build -- -j ${numcpu}
 fi
 if [[ $STATIC_CHECK -ne 1 || $(ldd bin/odgi | grep so | wc -l) -eq 0 ]]
 then

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -64,8 +64,8 @@ git clone https://github.com/lh3/minimap2.git
 cd minimap2
 git checkout v2.30
 # hack in flags support
-sed -i Makefile -e 's/CFLAGS=/CFLAGS+=/'
-make -j ${numcpu} ${MINI_ARM_FLAGS}
+sed -i Makefile -e 's/CFLAGS=/CFLAGS+=/' -e 's/LIBS=/LIBS+=/'
+LIBS="${jemallocLib}" make -j ${numcpu} ${MINI_ARM_FLAGS}
 if [[ $STATIC_CHECK -ne 1 || $(ldd minimap2 | grep so | wc -l) -eq 0 ]]
 then
 	 mv minimap2 ${binDir}
@@ -432,7 +432,11 @@ git clone https://gitlab.com/mcfrith/last.git --recursive
 cd last
 git checkout 1651
 sed -i makefile -e 's/CXXFLAGS=/CXXFLAGS+=/'
-make -j ${numcpu}
+# last has no LIBS variable, so add one after the objects.  Order matters: a static archive
+# named before the objects resolves nothing and is discarded, and lastal would silently fall
+# back to glibc's allocator.
+sed -i src/makefile -e '/LIBS/!s/ -lz$/ -lz $(LIBS)/'
+LIBS="${jemallocLib}" make -j ${numcpu}
 if [[ $STATIC_CHECK -ne 1 || $(ldd bin/lastal | grep so | wc -l) -eq 0 ]]
 then
     mv bin/lastal ${binDir}

--- a/build-tools/downloadPangenomeTools
+++ b/build-tools/downloadPangenomeTools
@@ -47,19 +47,16 @@ if [ -z ${CACTUS_LEGACY_ARCH+x} ]; then
     fi
 fi
 
-# CPU baseline, mirroring include.mk (hand-kept in sync, like the jemalloc block above).
-# Needed because CACTUS_ARCH_FLAGS is a make variable and this is a shell script, so without
-# it nothing built here -- minigraph, minimap2, gfatools, last, samtools/bcftools -- sees an
-# arch flag at all.  Confirmed against the v3.3.0 tarball: minigraph carried zero AVX2 in its
-# own code, only glibc's runtime-dispatched string routines.
-if [ -z ${CACTUS_ARCH_FLAGS+x} ]; then
-    if [ -n "${arm+x}" ]; then
-        CACTUS_ARCH_FLAGS="-march=armv8-a+simd"
-    elif [ -n "${CACTUS_LEGACY_ARCH+x}" ]; then
-        CACTUS_ARCH_FLAGS="-msse2"
-    else
-        CACTUS_ARCH_FLAGS="-march=x86-64-v3"
-    fi
+# CPU baseline.  include.mk is the single source of truth; ask make for it rather than
+# duplicating the arm/legacy/x86 selection here, where it would silently drift.  Without this
+# nothing built by this script -- minigraph, minimap2, gfatools, last, samtools/bcftools --
+# gets an arch flag at all: confirmed against the v3.3.0 tarball, where minigraph carried zero
+# AVX2 in its own code, only glibc's runtime-dispatched string routines.
+# MAKEFLAGS is cleared because "make binRelease" reaches this from inside a make recipe.
+CACTUS_ARCH_FLAGS="${CACTUS_ARCH_FLAGS:-$(env -u MAKEFLAGS make -s -C "${CWD}" arch-flags)}"
+if [ -z "${CACTUS_ARCH_FLAGS}" ]; then
+    echo "ERROR: 'make arch-flags' returned nothing; cannot determine the CPU baseline." >&2
+    exit 1
 fi
 export CFLAGS="${CFLAGS:-} ${CACTUS_ARCH_FLAGS}"
 export CXXFLAGS="${CXXFLAGS:-} ${CACTUS_ARCH_FLAGS}"

--- a/build-tools/downloadPhast
+++ b/build-tools/downloadPhast
@@ -33,6 +33,23 @@ git clone https://github.com/CshlSiepelLab/phast.git
 cd phast
 git checkout ${gitrel}
 
+# phast passes "-g -fno-inline -Wall -fno-strict-aliasing" to add_compile_options(), which
+# CMake places *after* CMAKE_C_FLAGS_RELEASE on the compile line, so -fno-inline beats the
+# Release build's -O3 and inlining is off across the whole suite.  Drop just that one flag;
+# -fno-strict-aliasing is deliberate and stays.
+#
+# Guarded, because a sed that silently stops matching is exactly how the unoptimised releases
+# went unnoticed in the first place.  If phast reformats the line we want to hear about it
+# here rather than quietly ship -fno-inline again; if they drop the flag themselves, this
+# block has done its job and can go.
+grep -q -- ' -fno-inline' CMakeLists.txt || {
+    echo "ERROR: phast ${gitrel} CMakeLists.txt no longer contains ' -fno-inline'." >&2
+    echo "       Check whether upstream still disables inlining under a Release build." >&2
+    echo "       If it no longer does, delete this check and the sed below." >&2
+    exit 1
+}
+sed -i CMakeLists.txt -e 's/ -fno-inline//'
+
 # Static linking strategy:
 #
 #   v1.9.7's CMakeLists uses find_package(BLAS REQUIRED) / find_package(LAPACK

--- a/build-tools/downloadPhast
+++ b/build-tools/downloadPhast
@@ -22,6 +22,17 @@ numcpu=$(getconf _NPROCESSORS_ONLN)
 submodulesDir=$(pwd)/submodules
 CWD=$(pwd)
 
+# CPU baseline.  include.mk is the single source of truth; ask make for it rather than
+# duplicating the arm/legacy/x86 selection here, where it would silently drift.
+# MAKEFLAGS is cleared because "make binRelease" reaches this from inside a make recipe.
+CACTUS_ARCH_FLAGS="${CACTUS_ARCH_FLAGS:-$(env -u MAKEFLAGS make -s -C "${CWD}" arch-flags)}"
+if [ -z "${CACTUS_ARCH_FLAGS}" ]; then
+    echo "ERROR: 'make arch-flags' returned nothing; cannot determine the CPU baseline." >&2
+    exit 1
+fi
+export CFLAGS="${CFLAGS:-} ${CACTUS_ARCH_FLAGS}"
+export CXXFLAGS="${CXXFLAGS:-} ${CACTUS_ARCH_FLAGS}"
+
 set -x
 
 mkdir -p ${binDir}

--- a/build-tools/downloadPhast
+++ b/build-tools/downloadPhast
@@ -30,8 +30,14 @@ if [ -z "${CACTUS_ARCH_FLAGS}" ]; then
     echo "ERROR: 'make arch-flags' returned nothing; cannot determine the CPU baseline." >&2
     exit 1
 fi
-export CFLAGS="${CFLAGS:-} ${CACTUS_ARCH_FLAGS}"
-export CXXFLAGS="${CXXFLAGS:-} ${CACTUS_ARCH_FLAGS}"
+# autoconf's AC_PROG_CC supplies its default "-g -O2" only when CFLAGS is *unset*.  Setting
+# CFLAGS below to carry the arch flags therefore suppresses it, which would silently drop
+# samtools, bcftools and htslib to -O0 in any build that had not already chosen a level --
+# i.e. every non-release build, including the Docker image.  Choose the level here instead.
+case " ${CFLAGS:-} " in *" -O"*) ;; *) CFLAGS="${CFLAGS:-} -O2" ;; esac
+case " ${CXXFLAGS:-} " in *" -O"*) ;; *) CXXFLAGS="${CXXFLAGS:-} -O2" ;; esac
+export CFLAGS="${CFLAGS} ${CACTUS_ARCH_FLAGS}"
+export CXXFLAGS="${CXXFLAGS} ${CACTUS_ARCH_FLAGS}"
 
 set -x
 

--- a/build-tools/downloadVCFWave
+++ b/build-tools/downloadVCFWave
@@ -28,7 +28,13 @@ cd vcflib
 git checkout 44eb97462eedc59365e8739103e2d5f7e2c76803
 mkdir build
 cd build
-cmake -DZIG=OFF -DWFA_GITMODULE=ON -DCMAKE_BUILD_TYPE=Debug ..
+# RelWithDebInfo, not Debug: Debug is -g with no -O, which built vcffixup, vcfwave and the
+# bundled WFA2-lib (vcfwave's alignment engine, an add_subdirectory so it inherits this) at
+# -O0.  Measured: vcffixup over 120k records x 60 samples, 53.2s at Debug vs 14.5s at
+# RelWithDebInfo, byte-identical output.  Not Release -- that injects -march=native
+# (vcflib CMakeLists.txt:77-78), which we cannot ship.  vcflib's own CMakeLists.txt:4
+# recommends RelWithDebInfo.
+cmake -DZIG=OFF -DWFA_GITMODULE=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
 cmake --build . -- -j ${numcpu}
 mv vcfwave vcfcreatemulti vcfbreakmulti vcfuniq vcffixup ${binDir}
 mv ./contrib/WFA2-lib/libwfa2.so.0 ${libDir}

--- a/build-tools/downloadVCFWave
+++ b/build-tools/downloadVCFWave
@@ -11,6 +11,19 @@ libDir=$(pwd)/lib
 # just use cactusRootPath for now
 dataDir=$(pwd)/src/cactus
 CWD=$(pwd)
+
+# CPU baseline.  include.mk is the single source of truth; ask make for it rather than
+# duplicating the arm/legacy/x86 selection here, where it would silently drift.
+# MAKEFLAGS is cleared because "make binRelease" reaches this from inside a make recipe.
+CACTUS_ARCH_FLAGS="${CACTUS_ARCH_FLAGS:-$(env -u MAKEFLAGS make -s -C "${CWD}" arch-flags)}"
+if [ -z "${CACTUS_ARCH_FLAGS}" ]; then
+    echo "ERROR: 'make arch-flags' returned nothing; cannot determine the CPU baseline." >&2
+    exit 1
+fi
+# vcflib's RelWithDebInfo supplies its own -O2, so unlike the other download scripts this one
+# does not need to pick an optimisation level, only to hand over the baseline.
+export CFLAGS="${CFLAGS:-} ${CACTUS_ARCH_FLAGS}"
+export CXXFLAGS="${CXXFLAGS:-} ${CACTUS_ARCH_FLAGS}"
 # works on MacOS and Linux
 if [ -z ${numcpu+x} ]; then
 	 numcpu=$(getconf _NPROCESSORS_ONLN)

--- a/build-tools/makeBinRelease
+++ b/build-tools/makeBinRelease
@@ -63,8 +63,24 @@ sed -i submodules/FASTGA/Makefile -e 's/CFLAGS = /CFLAGS = -static /g'
 sed -i submodules/FASTAN/Makefile -e 's/CFLAGS = /CFLAGS = -static /g'
 sed -i submodules/alntools/Makefile -e 's/CFLAGS = /CFLAGS = -static /g'
 
-export CFLAGS="-static"
-export CXXFLAGS="-static"
+# The -O2 is here because of autoconf, not because we are picking an optimisation level.
+# AC_PROG_CC supplies its default "-g -O2" only when CFLAGS is *unset*; setting CFLAGS to
+# anything -- even "-static", which says nothing about optimisation -- suppresses it.
+# bcftools' own Makefile does set "CFLAGS = -g -Wall -O2" (:29), but "include config.mk"
+# (:110) reassigns it from what configure recorded, so upstream's -O2 is overwritten rather
+# than appended to.  Without the -O2 below, every binary release shipped samtools, bcftools,
+# tabix and bgzip compiled at -O0.  Confirmed against the shipped v3.3.0 tarball, whose
+# main_vcfnorm, vcf_parse and main_vcfview match an -O0 build of bcftools 1.23 byte for byte,
+# and which still contains normalize_vcf and bcf_hdr_register_hrec as standalone symbols --
+# functions that -O2 inlines away entirely.  Measured: "bcftools norm -m +any" over 120k
+# records x 60 samples, 0.91s at -O0 vs 0.41s at -O2.
+#
+# Only the tarball was ever affected: the Dockerfile never exports CFLAGS, so the image got
+# autoconf's -O2 and this never showed up in Docker-based testing.  Tools built from plain
+# Makefiles were never affected either -- downloadPangenomeTools seds their "CFLAGS=" to
+# "CFLAGS+=", so their own -O2/-O3 lands after this and wins.
+export CFLAGS="-static -O2"
+export CXXFLAGS="-static -O2"
 export LDFLAGS="-static"
 export LIBS="-static"
 

--- a/build-tools/makeBinRelease
+++ b/build-tools/makeBinRelease
@@ -46,6 +46,9 @@ REL_TAG=$(getLatestReleaseTag)
 git checkout "${REL_TAG}"
 git submodule update --init --recursive
 
+# This build gets shipped, so take include.mk's portable baseline rather than -march=native.
+export CACTUS_PORTABLE_BUILD=1
+
 if [ -z ${CACTUS_LEGACY_ARCH+x} ]
 then
 # Make sure abpoa doesn't build with -march=native, but something more portable

--- a/include.mk
+++ b/include.mk
@@ -121,6 +121,20 @@ endif
 CFLAGS   += ${CACTUS_ARCH_FLAGS}
 CXXFLAGS += ${CACTUS_ARCH_FLAGS}
 
+# ...but only for what this makefile compiles itself.  CFLAGS and CXXFLAGS are ordinary make
+# variables here, not exported, so "cd submodules/x && ${MAKE}" starts a make that re-derives
+# them from sonLib's include.mk and sees no arch flag at all.  Only the release build ever
+# propagated them, by way of the "static:" target putting them in the environment -- so in a
+# plain build sonLib, cPecan, pinchesAndCacti, matchingAndOrdering, paffy, lastz, hal and
+# cactus2hal were all still at the bare baseline, which is most of the tree.
+#
+# Prefix a sub-make with ${archEnv} to hand them over.  Every submodule we do this for appends
+# with +=, so its own -O3 and include paths survive; the arch flags simply land in front.
+# Deliberately not "export CFLAGS": that would also push --pedantic, -D__AVX2__ -DUSE_SIMDE
+# and our libxml2 include path into every submodule, and abPOA already has to filter
+# --pedantic back out.  This hands over the baseline and nothing else.
+archEnv = CFLAGS="$${CFLAGS} ${CACTUS_ARCH_FLAGS}" CXXFLAGS="$${CXXFLAGS} ${CACTUS_ARCH_FLAGS}"
+
 # flags needed to include simde abpoa in cactus on any architecture
 ifdef CACTUS_LEGACY_ARCH
 	CFLAGS+= -D__SSE2__ -DUSE_SIMDE -DSIMDE_ENABLE_NATIVE_ALIASES

--- a/include.mk
+++ b/include.mk
@@ -79,23 +79,47 @@ endif
 ifeq ($(shell arch || true), arm64)
 	arm=1
 endif
+# CPU baseline for the code we generate.  Override for a machine-specific build:
+#   CACTUS_ARCH_FLAGS="-march=native" make
+#   CACTUS_ARCH_FLAGS="-march=x86-64-v3 -mtune=znver3" make
+#
+# x86-64-v3 rather than the bare -mavx2 this used to be.  That is not a portability change:
+# the release has required AVX2 since 2021, and the shipped v3.3.0 cactus_consolidated proves
+# it -- simd_abpoa_align_sequence_to_subgraph and paf_write_to_buffer carry unguarded AVX2,
+# so it already SIGILLs on anything pre-Haswell.  v3 is exactly that AVX2 baseline plus the
+# rest of the same CPU generation (FMA, BMI1/2, LZCNT, MOVBE, F16C), which every AVX2-capable
+# CPU has.  Measured: minigraph 1.3% faster, lastz 2.1%, output byte-identical in both.
+#
+# Deliberately NOT x86-64-v4.  AVX-512 would emit binaries that will not run on the
+# Skylake-class machines we develop and test on, and it is worth little anyway: abPOA is the
+# only hand-vectorised code in the tree, and doubling its vector width 128->256 bits bought
+# 8.8%, so 256->512 would be a few percent at best, before AVX-512 downclocking.
+#
+# No -mtune here.  -mtune=skylake measured a further 2.7% on minigraph and emits no new
+# instructions, so it costs no portability -- but it is a bet on one microarchitecture that
+# may go the other way on AMD, which we have not measured.  Set it per-cluster via the knob.
 ifdef arm
 #	flags to build abpoa
 	export armv8 = 1
 	export aarch64 = 1
 #	flags to include simde abpoa in cactus on ARM
-	CFLAGS+= -march=armv8-a+simd
+	CACTUS_ARCH_FLAGS ?= -march=armv8-a+simd
+else ifdef CACTUS_LEGACY_ARCH
+	export sse2 = 1
+	CACTUS_ARCH_FLAGS ?= -msse2
 else
-	ifdef CACTUS_LEGACY_ARCH
-		export sse2 = 1
-		CFLAGS+= -msse2
-	else
-#		flags to build abpoa
-		export avx2 = 1
-#		flags to include simde abpoa in cactus on X86
-		CFLAGS+= -mavx2
+#	flags to build abpoa
+	export avx2 = 1
+#	flags to include simde abpoa in cactus on X86
+	CACTUS_ARCH_FLAGS ?= -march=x86-64-v3
 endif
-endif
+
+# Both, deliberately.  Until now only CFLAGS carried an arch flag, so Red, hal's C++ and
+# cactus2hal were built at the plain x86-64 baseline -- confirmed against the shipped
+# binaries, where Red's only AVX2 is glibc's runtime-dispatched strcasecmp, never its own
+# code.  They are the components with the most headroom here, having had none at all.
+CFLAGS   += ${CACTUS_ARCH_FLAGS}
+CXXFLAGS += ${CACTUS_ARCH_FLAGS}
 
 # flags needed to include simde abpoa in cactus on any architecture
 ifdef CACTUS_LEGACY_ARCH

--- a/include.mk
+++ b/include.mk
@@ -122,6 +122,13 @@ ifeq ($(jemalloc),on)
 	jemallocDepends = ${LIBDIR}/libjemalloc.a
 endif
 
+# jemalloc flags for submodules that are built by cd'ing into their own tree.  jemallocLib
+# deliberately carries no -L, because cactus's own link lines pick up -L${LIBDIR} from LDLIBS
+# below -- but a submodule that has already cd'd elsewhere cannot resolve a bare -ljemalloc
+# against the copy we build into lib/, and ${LIBDIR} is relative to the cactus root so it
+# would point at the wrong directory from there.  Empty when jemalloc is off.
+jemallocSubLibs = $(if ${jemallocLib},-L$(abspath ${LIBDIR}) ${jemallocLib})
+
 # note: the CACTUS_STATIC_LINK_FLAGS below can generally be empty -- it's used by the static builder script only
 LDLIBS += ${cactusLibs} ${sonLibLibs} ${LIBS} -L${rootPath}/lib -Wl,-rpath,${rootPath}/lib -labpoa ${jemallocLib} -lz -lbz2 -lpthread -lm -lstdc++ -lm -lxml2 ${CACTUS_STATIC_LINK_FLAGS}
 LIBDEPENDS = ${sonLibDir}/sonLib.a ${sonLibDir}/cuTest.a ${jemallocDepends}

--- a/include.mk
+++ b/include.mk
@@ -98,20 +98,42 @@ endif
 # No -mtune here.  -mtune=skylake measured a further 2.7% on minigraph and emits no new
 # instructions, so it costs no portability -- but it is a bet on one microarchitecture that
 # may go the other way on AMD, which we have not measured.  Set it per-cluster via the knob.
+# Two baselines, and which you get depends on whether the build will be shipped.
+#
+# PORTABLE is for anything we distribute.  NATIVE is for a plain "make", which is someone
+# compiling cactus for the machine in front of them and should use that machine.  Anything
+# that ships its output sets CACTUS_PORTABLE_BUILD=1 -- makeBinRelease and the Dockerfile
+# both do -- so the portable value lives in exactly one place and cannot drift.
+#
+# -march=native is not reliably faster: measured here it gained 4.6% on minigraph and lost
+# 5.7% on lastz, the loss isolating to -mtune, which native implies.  It is still the right
+# default for a machine-specific build; measure on your own hardware if it matters.
+#
+# NOT native on ARM: Apple's clang spells it -mcpu=native and rejects -march=native.
+# NOT native for CACTUS_LEGACY_ARCH either: that build exists precisely to be portable.
 ifdef arm
 #	flags to build abpoa
 	export armv8 = 1
 	export aarch64 = 1
 #	flags to include simde abpoa in cactus on ARM
-	CACTUS_ARCH_FLAGS ?= -march=armv8-a+simd
+	CACTUS_PORTABLE_ARCH_FLAGS = -march=armv8-a+simd
+	CACTUS_NATIVE_ARCH_FLAGS = ${CACTUS_PORTABLE_ARCH_FLAGS}
 else ifdef CACTUS_LEGACY_ARCH
 	export sse2 = 1
-	CACTUS_ARCH_FLAGS ?= -msse2
+	CACTUS_PORTABLE_ARCH_FLAGS = -msse2
+	CACTUS_NATIVE_ARCH_FLAGS = ${CACTUS_PORTABLE_ARCH_FLAGS}
 else
 #	flags to build abpoa
 	export avx2 = 1
 #	flags to include simde abpoa in cactus on X86
-	CACTUS_ARCH_FLAGS ?= -march=x86-64-v3
+	CACTUS_PORTABLE_ARCH_FLAGS = -march=x86-64-v3
+	CACTUS_NATIVE_ARCH_FLAGS = -march=native
+endif
+
+ifdef CACTUS_PORTABLE_BUILD
+	CACTUS_ARCH_FLAGS ?= ${CACTUS_PORTABLE_ARCH_FLAGS}
+else
+	CACTUS_ARCH_FLAGS ?= ${CACTUS_NATIVE_ARCH_FLAGS}
 endif
 
 # Both, deliberately.  Until now only CFLAGS carried an arch flag, so Red, hal's C++ and

--- a/include.mk
+++ b/include.mk
@@ -157,6 +157,22 @@ CXXFLAGS += ${CACTUS_ARCH_FLAGS}
 # --pedantic back out.  This hands over the baseline and nothing else.
 archEnv = CFLAGS="$${CFLAGS} ${CACTUS_ARCH_FLAGS}" CXXFLAGS="$${CXXFLAGS} ${CACTUS_ARCH_FLAGS}"
 
+# ...but CFLAGS specifically must not be handed to a submodule that recursively builds bundled
+# third-party C.  Doing so makes CFLAGS environment-origin, and make then exports it onward
+# from that submodule's own make, carrying sonLib's -Werror --pedantic down into code that has
+# never compiled clean under them: sonLib/quicktree, sonLib/cutest, cPecan/lastz,
+# pinchesAndCacti/threeEdgeConnected and matchingAndOrdering/matchGraph are all in that
+# position, and CGL_DEBUG=ultra then fails on unrelated fscanf and format warnings -- which is
+# how CI broke.  paffy is in the same position at one remove: it builds its own nested
+# sonLib, quicktree and all.  Bundled C++ (blossom) is fine, since CXXFLAGS_ultraDbg
+# carries no -Werror.
+#
+# Hand the baseline to those four through CC instead.  A command-line override reaches the
+# nested makes through MAKEFLAGS just as effectively, but carries nothing but the arch flag.
+# Not CXX, which would clobber sonLib's own clang++/g++ selection.
+archEnvExt = CXXFLAGS="$${CXXFLAGS} ${CACTUS_ARCH_FLAGS}"
+archCC = CC="$${CC:-cc} ${CACTUS_ARCH_FLAGS}"
+
 # flags needed to include simde abpoa in cactus on any architecture
 ifdef CACTUS_LEGACY_ARCH
 	CFLAGS+= -D__SSE2__ -DUSE_SIMDE -DSIMDE_ENABLE_NATIVE_ALIASES

--- a/preprocessor/cactus_redPrefilter.c
+++ b/preprocessor/cactus_redPrefilter.c
@@ -53,7 +53,11 @@ static void redfilter(void* min_length_p, const char* name, const char* seq, int
         ++base_hist[c];
     }
     bool is_monomer = length == 0;
-    char monomer;
+    // initialised because length == 0 sets is_monomer without the search loop ever running,
+    // so monomer is formally live-uninitialised at the read below.  Harmless in practice --
+    // that read sits inside a "i < length" loop that cannot execute when length is 0 -- but
+    // -Werror=maybe-uninitialized rightly objects under CGL_DEBUG.
+    char monomer = 0;
     for (int64_t i = 0; i < 256 && !is_monomer; ++i) {
         if ((double)base_hist[i] / (double)length > max_base_frac) {
             is_monomer = true;


### PR DESCRIPTION
In order to make stat binaries, the release builder script messes with all kinds of build flags.  But there are some cases where optimizations were unwittingly turned off by this process.  

| Tool | Was | Now | Measured |
|---|---|---|---|
| `bcftools`, `samtools`, `tabix`, `bgzip` | `-Wall -static` (no `-O` → `-O0`) | `-Wall -static -O2` | `bcftools norm -m +any` 0.91s → 0.41s (2.2×) |
| `hdf5`, `libxml2` | `-static` (no `-O`) | `-static -O2` | HAL's backing store |
| `odgi` | `-fopenmp` only (`CMAKE_BUILD_TYPE=Generic` matches no branch) | `+ -O3` via `CMAKE_CXX_FLAGS_GENERIC` | — |
| `vcffixup`, `vcfwave`, WFA2-lib | `CMAKE_BUILD_TYPE=Debug` → `-g`, no `-O` | `RelWithDebInfo` → `-O2 -g -DNDEBUG` | `vcffixup` 53.2s → 14.5s (3.7×) |
| ~40 phast binaries (`phyloP`, `phyloFit`, `phastCons`, `msa_view`, …) | `-O3 -fno-inline` (upstream appends it *after* `-O3`) | `-O3` | inlining enabled |

Also, `jemalloc` was added to `lastz`, `Red`, `FastGA`

And arch flags passed (which apparently give a little boost)

| Tool | Was | Now |
|---|---|---|
| cactus's own C | `-mavx2` | `-march=x86-64-v3` |
| `Red`, hal C++, `cactus2hal` | **no arch flag at all** (only `CFLAGS` carried one, never `CXXFLAGS`) | `-march=x86-64-v3` — Red: 0 → 525 AVX2 instrs in its own code |
| `FASTGA`, `FASTAN`, `alntools` | **none** (hard-assign `CFLAGS`) | via a `CC` make-override |
| `minigraph` | **none** | `-march=x86-64-v3` — 0 → 1319 AVX2 instrs in its own code |
| `minimap2`, `gfatools`, `last`, `samtools`/`bcftools` | **none** | `-march=x86-64-v3` |
| phast, `taffy`, mafTools | **none** | `-march=x86-64-v3` |