### PR TITLE
Option to use whole-genome ref for mgSplit

### DIFF
--- a/doc/pangenome.md
+++ b/doc/pangenome.md
@@ -176,6 +176,8 @@ cactus-align js ./out-map/chromfile.gm.txt out-align --reference simChimp --outV
 cactus-graphmap-join js --vg out-align/*.vg --hal out-align/*.hal --sv-gfa out-construct/*.gfa.gz --reference simChimp --outDir out-join --outName ep --gb
 ```
 
+Splitting this way costs some inter-chromosome context: a region homologous to several chromosomes (the acrocentric short arms, say) has nothing to compete against in a chromosome-level graph, where the whole-genome pipeline would have filtered it out as ambiguous.  `cactus-pangenome --mgSplitWholeGenomeRef` (which implies `--mgSplit`, and has no step-by-step equivalent) builds each chromosome's second-pass minigraph against the whole reference genome(s) instead, restoring that competition and pruning the off-chromosome material back out before `cactus-align`, at the cost of indexing a whole reference per chromosome.
+
 ### Pipeline
 
 The Minigraph-Cactus pipeline is run via the `cactus-pangenome` command. It consists of five stages which can also be run individually (below). `cactus-pangenome` writes output files into `--outDir` at the end of each stage. So different stages can be rerun with if necessary using the lower-level commands.

--- a/src/cactus/refmap/cactus_graphmap.py
+++ b/src/cactus/refmap/cactus_graphmap.py
@@ -501,9 +501,15 @@ def minigraph_map_all(job, options, config, gfa_id, fa_id_map, graph_event):
         gaf_id_map[event] = minigraph_map_job.rv(0)
         paf_id_map[event] = minigraph_map_job.rv(1)
 
-    # merge up
-    paf_merge_job = top_job.addFollowOnJobFn(merge_pafs, paf_id_map)
-    gaf_merge_job = top_job.addFollowOnJobFn(merge_pafs, gaf_id_map, gzip=True)
+    # merge up.  these two are the merges whose inputs scale with the number of genomes, so they get
+    # sized off them rather than taking the default; the GAF one also bgzips, so give it the mapping
+    # cores instead of leaving bgzip single-threaded
+    merge_name = getattr(options, 'mg_chrom_name', None) if options.batch else None
+    merge_name = merge_name if merge_name else 'merged'
+    paf_merge_job = top_job.addFollowOnJobFn(merge_pafs_sized, paf_id_map,
+                                             name='{}.paf'.format(merge_name))
+    gaf_merge_job = top_job.addFollowOnJobFn(merge_pafs_sized, gaf_id_map, gzip=True,
+                                             name='{}.gaf'.format(merge_name), cores=mg_cores)
 
     return paf_merge_job.rv(), gaf_merge_job.rv()
 
@@ -601,15 +607,24 @@ def minigraph_map_one(job, config, event_name, fa_file_id, gfa_file_id):
     # return the stable gaf (minigraph output) and the unstable paf
     return job.fileStore.writeGlobalFile(pansn_gaf_path), job.fileStore.writeGlobalFile(unstable_paf_path)
 
-def merge_pafs(job, paf_file_id_map, gzip=False):
-    """ merge up some pafs """
+def merge_pafs(job, paf_file_id_map, gzip=False, name=None):
+    """ merge up some pafs.  name is what the merged file is called on disk: getLocalTempFile() would
+    give it an anonymous .tmp, which is all anyone reading the log of the bgzip below would see """
     paf_paths = [job.fileStore.readGlobalFile(paf_id) for paf_id in paf_file_id_map.values()]
-    merged_path = job.fileStore.getLocalTempFile()
+    merged_path = os.path.join(job.fileStore.getLocalTempDir(), name if name else 'merged.paf')
     catFiles(paf_paths, merged_path)
     if gzip:
         cactus_call(parameters=['bgzip', merged_path, '--threads', str(job.cores)])
         merged_path += '.gz'                    
     return job.fileStore.writeGlobalFile(merged_path)
+
+def merge_pafs_sized(job, paf_file_id_map, gzip=False, name=None, cores=1):
+    """ merge_pafs, sized off its inputs.  callers upstream of the mapping jobs hold promises and so
+    cannot measure them; by the time this job runs they are resolved.  the merge holds every input
+    plus the merged copy, and bgzip then writes a compressed copy alongside """
+    total_size = sum(paf_id.size for paf_id in paf_file_id_map.values() if paf_id)
+    return job.addChildJobFn(merge_pafs, paf_file_id_map, gzip=gzip, name=name,
+                             cores=cores, disk=max(total_size * 3, 2**31)).rv()
 
 def extract_paf_from_gfa(job, gfa_id, gfa_path, ref_event, graph_event, ignore_paf_id):
     """ make a paf directly from the rGFA tags.  rgfa2paf supports other ranks, but we're only

--- a/src/cactus/refmap/cactus_graphmap.py
+++ b/src/cactus/refmap/cactus_graphmap.py
@@ -321,7 +321,8 @@ def add_separate_ref_contigs_job(batch_job, options, config, input_dict):
     from cactus.refmap.cactus_graphmap_split import separate_ref_contigs_batch
     reference = options.reference[0] if type(options.reference) is list else options.reference
     return batch_job.addFollowOnJobFn(separate_ref_contigs_batch, config, input_dict, batch_job.rv(), reference,
-                                      getattr(options, 'permissiveContigFilter', None))
+                                      getattr(options, 'permissiveContigFilter', None),
+                                      whole_genome_ref=getattr(options, 'mgSplitWholeGenomeRef', False))
 
 def minigraph_batch_separate_workflow(job, options, config, input_dict, graph_event, sanitize, pansn_gfa_input=True):
     """ minigraph_batch_workflow followed by the separation pass, for callers that just want the final
@@ -480,8 +481,15 @@ def minigraph_map_all(job, options, config, gfa_id, fa_id_map, graph_event):
     gaf_id_map = {}
     paf_id_map = {}
                 
+    # the estimate below is anchored on the query, which holds while the graph is no bigger than the
+    # chromosome the query came from.  the --mgSplitWholeGenomeRef second pass breaks that -- the graph
+    # is whole-genome while the query stays one chromosome, so the index dominates and the graph term
+    # has to carry it: measured at ~5.5x the (already decompressed) GFA on HPRC, against the 2x below.
+    # it must be gated on batch as well as the option: the option's own first pass maps whole-genome
+    # queries against a whole-genome graph, where the query anchor still holds and 2x is right
+    gfa_coefficient = 6 if options.batch and getattr(options, 'mgSplitWholeGenomeRef', False) else 2
     for event, fa_id in fa_id_map.items():
-        mem = 72*fa_id.size + 2*gfa_id.size
+        mem = 72*fa_id.size + gfa_coefficient*gfa_id.size
         event_name = event
         if options.batch:
             # the memory heuristc seems to drastically underestimate some chromosomes in batch mode...

--- a/src/cactus/refmap/cactus_graphmap_split.py
+++ b/src/cactus/refmap/cactus_graphmap_split.py
@@ -9,6 +9,7 @@ import copy
 import timeit
 import shutil
 import re
+import gzip
 
 from operator import itemgetter
 
@@ -25,11 +26,12 @@ from cactus.shared.common import getOptionalAttrib, findRequiredNode
 from cactus.shared.common import unzip_gz, write_s3
 from cactus.shared.common import get_faidx_subpath_rename_cmd
 from cactus.shared.common import cactus_clamp_memory
+from cactus.shared.common import clean_jobstore_files
 from cactus.shared.version import cactus_commit
 from cactus.preprocessor.fileMasking import get_mask_bed_from_fasta
 from cactus.preprocessor.checkUniqueHeaders import sanitize_fasta_headers
 from cactus.refmap.cactus_graphmap import filter_paf, apply_mgsplit_filter_overrides
-from cactus.refmap.cactus_minigraph import check_sample_names, minigraph_gfa_from_pansn
+from cactus.refmap.cactus_minigraph import check_sample_names, minigraph_gfa_from_pansn, minigraph_gfa_to_pansn
 from toil.job import Job
 from toil.common import Toil
 from toil.statsAndLogging import logger
@@ -468,8 +470,8 @@ def split_gfa(job, config, gfa_id, paf_ids, ref_contigs, other_contig, reference
             
     return output_id_map, job.fileStore.writeGlobalFile(log_path)
 
-def count_ref_contigs(gfa_path):
-    """ the number of distinct reference contigs in a minigraph GFA, ie its rank-0 (SR:i:0) sources """
+def ref_contig_names(gfa_path):
+    """ the distinct reference contigs in a minigraph GFA, ie its rank-0 (SR:i:0) sources """
     ref_contigs = set()
     with open(gfa_path, 'r') as gfa_file:
         for line in gfa_file:
@@ -479,46 +481,126 @@ def count_ref_contigs(gfa_path):
                 sr = [t[5:] for t in toks if t.startswith('SR:i:')]
                 if sn and sr and sr[0] == '0':
                     ref_contigs.add(sn[0])
-    return len(ref_contigs)
+    return ref_contigs
+
+def strip_event_prefix(name):
+    """ turn an rgfa-split bin name like id=CHM13|chr2 into chr2, the way split_gfa does """
+    if name.startswith('id=') and name.find('|') > 3:
+        return name[name.find('|') + 1:]
+    return name
+
+def cat_paths(in_paths, out_path):
+    """ catFiles() interpolates its arguments into a shell command unquoted, so it cannot take a path
+    holding a shell metacharacter.  these paths are rgfa-split bins, named after reference contigs
+    whose sanitized form is id=EVENT|CONTIG -- don't make the concatenation depend on whether the
+    prefix survives into the filename """
+    with open(out_path, 'wb') as out_file:
+        for in_path in in_paths:
+            with open(in_path, 'rb') as in_file:
+                shutil.copyfileobj(in_file, out_file)
+
+def read_fasta_names(path):
+    """ the sequence names in a fasta, which may or may not be compressed """
+    with open(path, 'rb') as fa_file:
+        is_gzipped = fa_file.read(2) == b'\x1f\x8b'
+    opener = gzip.open if is_gzipped else open
+    names = set()
+    with opener(path, 'rt') as fa_file:
+        for line in fa_file:
+            if line.startswith('>'):
+                names.add(line[1:].split()[0])
+    return names
+
+def bins_for_chrom(chrom, ref_contigs, bin_ref_contigs):
+    """ which of a graph's reference contigs belong to one chromosome's bin.  a normal chromosome owns
+    the contig it is named after; the --otherContig lump owns whichever reference contigs its own
+    fasta holds.  only needed when the graph holds more of the reference than the chromosome it was
+    built for, ie under --mgSplitWholeGenomeRef.
+
+    the lump is read off its fasta rather than inferred from the surviving bin names because the two
+    disagree: export_split_data drops a reference contig that fewer than two genomes align to
+    ("Omitting reference contig ..."), so it names no bin, and inferring would hand it to the lump --
+    whose seqfile has no fasta for it, leaving cactus-align with PAF rows for an absent query """
+    stripped = set(strip_event_prefix(name) for name in ref_contigs)
+    if chrom in stripped:
+        return {chrom}
+    return stripped & set(strip_event_prefix(name) for name in (bin_ref_contigs or set()))
 
 def separate_ref_contigs_batch(job, config, graphmap_input_dict, graphmap_batch_results, reference_event,
-                              permissive_contig_filter):
+                              permissive_contig_filter, whole_genome_ref=False):
     """ --otherContig lumps every leftover reference contig into a single bin, so with --mgSplit that
     bin gets one minigraph covering all of them.  minigraph keeps those contigs disjoint, but the
     per-chromosome graphmap that follows can align a sample contig across two, which welds them into
     one component in the final graph.  Run rgfa-split over each bin to hold the contigs apart.
 
+    With --mgSplitWholeGenomeRef every bin's graph carries the whole reference, so this pass runs on
+    all of them and does the real work of the option: dropping the mappings that landed on another
+    chromosome, and cutting the graph artifacts back down to this chromosome.
+
     Appends the rgfa-split log to each chromosome's graphmap results, or None where the pass didn't
-    run, so it can be exported alongside the PAFs. """
+    run, so it can be exported alongside the PAFs, and (in whole-genome-reference mode) the pruned
+    PanSN GFA after it. """
     # the first pass applies this inside its own job, so its copy of the config never reaches us
     apply_permissive_contig_filter(config, permissive_contig_filter)
+    # the pruned fasta's bgzip and the PanSN rename both compress a whole-genome-scale GFA here
+    mg_cores = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap"), "cpu", typeFn=int, default=1)
     output_dict = {}
     for chrom, gm_result in graphmap_batch_results.items():
-        gfa_id = graphmap_input_dict[chrom][1]
+        seq_id_map, gfa_id = graphmap_input_dict[chrom][0], graphmap_input_dict[chrom][1]
         paf_id = gm_result[0]
         if not paf_id or not gfa_id:
+            if whole_genome_ref:
+                # every artifact this chromosome has is still whole-genome, and passing them through
+                # would publish a whole reference under its name and hand cactus-align the same.
+                # there is no correct thing to emit here, so say so rather than emit the wrong thing
+                raise RuntimeError('{} reached the separation pass with no {}, so its whole-genome '
+                                   'reference cannot be pruned away'.format(chrom, 'PAF' if not paf_id else 'GFA'))
             output_dict[chrom] = tuple(gm_result) + (None,)
             continue
         # the per-chromosome GFA comes in bgzipped, and we decompress it here: budget for that the
-        # same way the first-pass split does
+        # same way the first-pass split does.  rgfa-split's working set is what sets the memory, so
+        # the extra whole-genome-reference files below are added to the disk budget alone -- this job
+        # writes the minigraph fasta and streams the reference fasta for its names, it holds neither
         tot_size = gfa_id.size * 10 + paf_id.size
+        disk_size = tot_size
+        ref_fa_id = None
+        if whole_genome_ref:
+            disk_size += (gm_result[1].size if gm_result[1] else 0) * 10
+            ref_fa_id = seq_id_map.get(reference_event) if reference_event else None
+            disk_size += (ref_fa_id.size if ref_fa_id else 0) * 4
         output_dict[chrom] = job.addChildJobFn(separate_ref_contigs, config, chrom, gfa_id, gm_result, reference_event,
-                                               disk=tot_size * 5,
+                                               whole_genome_ref=whole_genome_ref, ref_fa_id=ref_fa_id,
+                                               genome_names=sorted(seq_id_map.keys()),
+                                               cores=mg_cores,
+                                               disk=disk_size * 5,
                                                memory=cactus_clamp_memory(tot_size * 3)).rv()
     return output_dict
 
-def separate_ref_contigs(job, config, chrom, gfa_id, gm_result, reference_event):
+def separate_ref_contigs(job, config, chrom, gfa_id, gm_result, reference_event,
+                         whole_genome_ref=False, ref_fa_id=None, genome_names=None):
     """ Use rgfa-split to assign each query in one chromosome's PAF to a single reference contig, and
     drop the alignments that don't fit that assignment.  Bins with a single reference contig -- every
     normal chromosome -- are left untouched.  A query that straddles two contigs evenly is ambiguous
     and loses all its alignments; one with a clear best contig keeps those and loses the rest.  Either
     way the sequence stays in the bin's fasta, so cactus-align sees it as unaligned and the usual
-    non-minigraph clipping takes it out. """
+    non-minigraph clipping takes it out.
+
+    Under --mgSplitWholeGenomeRef the graph holds the whole reference rather than one chromosome, so
+    every bin lands here with something to do: a query that maps better to another chromosome loses
+    its alignments to this one, which is the inter-chromosome competition the whole-genome pipeline
+    gets for free.  In that mode this pass is required for correctness, not just quality:
+    extract_paf_from_gfa synthesizes rGFA-derived rows for every reference contig genome-wide, and it
+    is the binning here that keeps the ones belonging to other chromosomes out of this PAF.  Only the bins this chromosome owns are kept, and the minigraph fasta and PanSN
+    GFA are rebuilt off the pruned graph so nothing off-chromosome reaches cactus-align or the
+    merged .sv.gfa.gz. """
     work_dir = job.fileStore.getLocalTempDir()
     gfa_path = os.path.join(work_dir, 'mg.gfa')
     paf_path = os.path.join(work_dir, 'mg.paf')
     out_prefix = os.path.join(work_dir, 'separate_')
     log_path = os.path.join(work_dir, 'separate.log')
+    # what a bypass returns: the results as they came in, plus the log slot, plus (in whole-genome
+    # reference mode) the pruned PanSN GFA slot
+    passthrough = tuple(gm_result) + (None,) + ((None,) if whole_genome_ref else ())
     job.fileStore.readGlobalFile(gfa_id, gfa_path)
     with open(gfa_path, 'rb') as gfa_file:
         is_gzipped = gfa_file.read(2) == b'\x1f\x8b'
@@ -527,10 +609,13 @@ def separate_ref_contigs(job, config, chrom, gfa_id, gm_result, reference_event)
         cactus_call(parameters=['gzip', '-dc', os.path.basename(gfa_path)], work_dir=work_dir, outfile=unzipped_path)
         gfa_path = unzipped_path
 
-    # nothing to hold apart on a normal chromosome: get out before touching the PAF, which is big
-    num_ref_contigs = count_ref_contigs(gfa_path)
+    # nothing to hold apart on a normal chromosome: get out before touching the PAF, which is big.
+    # a single-contig reference has nothing off-chromosome to prune either, so this is still the
+    # right bypass in whole-genome reference mode
+    ref_contigs = ref_contig_names(gfa_path)
+    num_ref_contigs = len(ref_contigs)
     if num_ref_contigs < 2:
-        return tuple(gm_result) + (None,)
+        return passthrough
 
     job.fileStore.readGlobalFile(gm_result[0], paf_path)
     coverage_opts, query_uniqueness, amb_name = get_split_specificity_opts(config)
@@ -542,6 +627,9 @@ def separate_ref_contigs(job, config, chrom, gfa_id, gm_result, reference_event)
            '-a', amb_name,
            '-L', log_path]
     cmd += coverage_opts
+    if whole_genome_ref:
+        # we need the per-bin GFAs too, to cut the whole reference back down to this chromosome
+        cmd += ['-G']
     if reference_event:
         cmd += ['-r', 'id={}|'.format(reference_event)]
     min_mapq = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap"), "minMAPQ")
@@ -549,29 +637,82 @@ def separate_ref_contigs(job, config, chrom, gfa_id, gm_result, reference_event)
         cmd += ['-A', min_mapq]
     cactus_call(parameters=cmd, work_dir=work_dir, job_memory=job.memory)
 
+    # which bins belong to this chromosome?  normally every non-ambiguous one: the bin was a
+    # chromosome going in and rgfa-split only subdivided it.  with the whole reference in the graph
+    # it split by every reference contig, so keep this chromosome's own contig -- or, for the
+    # --otherContig lump, every reference contig that isn't some other chromosome's
+    keep_names = None
+    if whole_genome_ref:
+        bin_ref_contigs = None
+        if chrom not in set(strip_event_prefix(name) for name in ref_contigs) and ref_fa_id:
+            bin_ref_path = os.path.join(work_dir, 'bin_reference.fa')
+            job.fileStore.readGlobalFile(ref_fa_id, bin_ref_path)
+            bin_ref_contigs = read_fasta_names(bin_ref_path)
+        keep_names = bins_for_chrom(chrom, ref_contigs, bin_ref_contigs)
+
     # stitch the per-contig PAFs back into one: the bin stays whole, but no query is left
     # straddling two reference contigs.  the ambiguous bin is what we're dropping
-    keep_pafs = []
+    keep_pafs, keep_gfas = [], []
     for out_name in sorted(os.listdir(work_dir)):
         file_name, ext = os.path.splitext(out_name)
-        if ext == '.paf' and file_name.startswith(os.path.basename(out_prefix)) and \
+        if ext in ['.paf', '.gfa'] and file_name.startswith(os.path.basename(out_prefix)) and \
            os.path.isfile(os.path.join(work_dir, file_name + '.fa_contigs')):
             name = file_name[len(os.path.basename(out_prefix)):]
-            if name != amb_name:
-                keep_pafs.append(os.path.join(work_dir, out_name))
+            if name == amb_name:
+                continue
+            if keep_names is not None and strip_event_prefix(name) not in keep_names:
+                continue
+            (keep_pafs if ext == '.paf' else keep_gfas).append(os.path.join(work_dir, out_name))
 
     separated_paf_path = os.path.join(work_dir, 'separated.paf')
-    catFiles(keep_pafs, separated_paf_path)
+    cat_paths(keep_pafs, separated_paf_path)
 
     def line_count(path):
         with open(path, 'r') as paf_file:
             return sum(1 for line in paf_file if line.strip())
     before, after = line_count(paf_path), line_count(separated_paf_path)
-    RealtimeLogger.info('Separating {} reference contigs in {}: kept {} of {} PAF records'.format(
-        num_ref_contigs, chrom, after, before))
+    RealtimeLogger.info('Separating {} reference contigs in {}: kept {} of them and {} of {} PAF records'.format(
+        num_ref_contigs, chrom, len(keep_pafs), after, before))
 
-    return (job.fileStore.writeGlobalFile(separated_paf_path),) + tuple(gm_result[1:]) + \
-        (job.fileStore.writeGlobalFile(log_path),)
+    out_fa_id, pansn_gfa_id = gm_result[1], None
+    if whole_genome_ref:
+        if not keep_gfas:
+            raise RuntimeError('rgfa-split left no reference contig assigned to {}: it cannot be pruned back '
+                               'to a chromosome'.format(chrom))
+        # a contig we meant to keep but that rgfa-split gave no bin contributes no rank-0 backbone to
+        # the pruned graph, while the bin's seqfile still carries its fasta.  every reference contig
+        # should have at least its own rgfa2paf row and so a bin, but say so rather than drop it quietly
+        missing = keep_names - set(strip_event_prefix(os.path.splitext(os.path.basename(g))[0][len(os.path.basename(out_prefix)):])
+                                   for g in keep_gfas)
+        if missing:
+            RealtimeLogger.warning('No rgfa-split bin for reference contig(s) {} in {}: they are absent from its '
+                                   'pruned graph and minigraph fasta'.format(sorted(missing), chrom))
+        graph_event = getOptionalAttrib(findRequiredNode(config.xmlRoot, "graphmap"), "assemblyName", default="_MINIGRAPH_")
+        # rgfa-split's GFA splitter re-emits only S and L lines, which is all minigraph wrote: its
+        # GFAs carry no header, here or in any other run
+        separated_gfa_path = os.path.join(work_dir, 'separated.gfa')
+        cat_paths(keep_gfas, separated_gfa_path)
+
+        # the minigraph fasta cactus-align consumes has to describe the pruned graph, not the
+        # whole-genome one it was made from.  same command as make_minigraph_fasta()
+        if gm_result[1]:
+            out_fa_path = os.path.join(work_dir, 'separated.sv.gfa.fa.gz')
+            cactus_call(outfile=out_fa_path,
+                        parameters=[['gfatools', 'gfa2fa', separated_gfa_path],
+                                    ['sed', '-e', r's/^>\(.\)/>id={}|\1/g'.format(graph_event)],
+                                    ['bgzip', '--threads', str(job.cores)]])
+            out_fa_id = job.fileStore.writeGlobalFile(out_fa_path)
+            # the whole-genome one it replaces is nobody's input from here on.  deleted from a
+            # follow-on rather than inline so a retry of this job doesn't trip over its own delete
+            job.addFollowOnJobFn(clean_jobstore_files, file_ids=[gm_result[1]])
+
+        # and the published per-chromosome graph, which graphmap-join merges
+        pansn_gfa_path = os.path.join(work_dir, 'separated.sv.gfa.gz')
+        minigraph_gfa_to_pansn(set(genome_names or []), separated_gfa_path, pansn_gfa_path, job.cores)
+        pansn_gfa_id = job.fileStore.writeGlobalFile(pansn_gfa_path)
+
+    return (job.fileStore.writeGlobalFile(separated_paf_path), out_fa_id) + tuple(gm_result[2:]) + \
+        (job.fileStore.writeGlobalFile(log_path),) + ((pansn_gfa_id,) if whole_genome_ref else ())
 
 def split_fas(job, seq_id_map, seq_name_map, split_id_map):
     """ Use samtools to split a bunch of fasta files into reference contigs, using the output of rgfa-split as a guide"""

--- a/src/cactus/refmap/cactus_minigraph.py
+++ b/src/cactus/refmap/cactus_minigraph.py
@@ -214,8 +214,13 @@ def export_minigraph_construct_output(options, input_seqfiles, output_dict, toil
             train_path = gfa_path.replace('.gfa.gz', '.gfa').replace('.gfa', '.train')
         else:
             train_path = None
-        #export the gfa            
-        toil.exportFile(pansn_gfa_id, makeURL(gfa_path))
+        #export the gfa
+        # with --mgSplitWholeGenomeRef this graph is still whole-genome: it only becomes
+        # chromosome-only after the post-mapping prune, which writes it to this same path
+        # (export_pruned_minigraph_gfa_wrapper in cactus_pangenome.py).  the chromfile below is
+        # still written now -- downstream only ever reads its .train column
+        if not getattr(options, 'mgSplitWholeGenomeRef', False):
+            toil.exportFile(pansn_gfa_id, makeURL(gfa_path))
         if train_path:
             # export the scoring model (.train)
             toil.exportFile(train_id, makeURL(train_path))
@@ -255,23 +260,45 @@ def check_sample_names(sample_names, references):
         if sample_ext and (len(sample_ext) == 1 or not sample_ext[1:].isnumeric()):
             raise RuntimeError("Sample name {} with \"{}\" suffix is not supported. You must either remove this suffix or use .N where N is an integer to specify haplotype".format(sample, sample_ext))
 
-def minigraph_construct_batch_workflow(job, options, config_node, input_dict, gfa_path, sanitize=True):
-    """ run the construction workflow on individual chromosomes """
+def minigraph_construct_batch_workflow(job, options, config_node, input_dict, gfa_path, sanitize=True,
+                                       construct_ref_id_map=None):
+    """ run the construction workflow on individual chromosomes.  construct_ref_id_map, if given,
+    swaps the whole-genome reference fastas in for the chromosome's own slice of them (--mgSplit
+    --mgSplitWholeGenomeRef).  the merge happens here rather than inside minigraph_construct_workflow
+    because both dicts are resolved job arguments at this point, whereas the sanitized map down there
+    can still be an unresolved promise """
     output_dict = {}
     for chrom, input_info in input_dict.items():
         seq_id_map, seq_order = input_info
+        construct_seq_id_map = None
+        if construct_ref_id_map:
+            construct_seq_id_map = dict(seq_id_map)
+            construct_seq_id_map.update(construct_ref_id_map)
         if options.batch:
             gfa_path = os.path.join(options.outputGFA, '{}.gfa.gz'.format(chrom))
         else:
             gfa_path = options.outputGFA
-        mgwf_job = job.addChildJobFn(minigraph_construct_workflow, options, config_node, seq_id_map, seq_order, gfa_path, sanitize)
+        mgwf_job = job.addChildJobFn(minigraph_construct_workflow, options, config_node, seq_id_map, seq_order, gfa_path, sanitize,
+                                     construct_seq_id_map=construct_seq_id_map)
         output_dict[chrom] = mgwf_job.rv()
     return output_dict
                                     
-def minigraph_construct_workflow(job, options, config_node, seq_id_map, seq_order, gfa_path, sanitize=True):
-    """ minigraph can handle bgzipped files but not gzipped; so unzip everything in case before running"""
+def minigraph_construct_workflow(job, options, config_node, seq_id_map, seq_order, gfa_path, sanitize=True,
+                                 construct_seq_id_map=None):
+    """ minigraph can handle bgzipped files but not gzipped; so unzip everything in case before running
+
+    construct_seq_id_map, when given, replaces seq_id_map for the graph construction alone.  it is how
+    --mgSplitWholeGenomeRef hands each chromosome the whole reference: mash sorting and last-training
+    (and the size estimate for last-training's own job) keep using the chromosome's own much smaller
+    reference slice, since training against a whole genome would be both expensive and
+    cross-chromosome contaminated -- and would silently produce no model at all, as last_train()
+    requires its partner sequence to be at least half the size of the database it trains against.
+    The construction job itself is sized off the substituted map, since that is what it runs on. """
     assert type(options.reference) is list
     assert options.reference[0] == seq_order[0]
+    # the substituted map is a plain dict here, but sanitized_seq_id_map below is a promise when
+    # sanitize is on, so the two can't be reconciled in this job
+    assert not (construct_seq_id_map and sanitize)
     if options.refOnly:
         refonly_seq_id_map = {}
         refonly_seq_order = []
@@ -280,6 +307,8 @@ def minigraph_construct_workflow(job, options, config_node, seq_id_map, seq_orde
                 refonly_seq_order.append(seq)
                 refonly_seq_id_map[seq] = seq_id_map[seq]
         seq_id_map, seq_order = refonly_seq_id_map, refonly_seq_order
+        if construct_seq_id_map:
+            construct_seq_id_map = {seq: construct_seq_id_map[seq] for seq in refonly_seq_order}
     ref_size = seq_id_map[options.reference[0]].size
     if sanitize:
         sanitize_job = job.addChildJobFn(sanitize_fasta_headers, seq_id_map, pangenome=True)
@@ -296,7 +325,10 @@ def minigraph_construct_workflow(job, options, config_node, seq_id_map, seq_orde
         prev_job = sort_job
     else:
         prev_job = sanitize_job
-    minigraph_job = prev_job.addFollowOnJobFn(minigraph_construct_in_batches, options, config_node, sanitized_seq_id_map, seq_order, gfa_path)
+    minigraph_job = prev_job.addFollowOnJobFn(minigraph_construct_in_batches, options, config_node,
+                                              construct_seq_id_map if construct_seq_id_map else sanitized_seq_id_map,
+                                              seq_order, gfa_path,
+                                              whole_genome_ref=bool(construct_seq_id_map))
     train_id = None
     if options.lastTrain and len(seq_id_map) > 1:
         # note: somehow last training memory overruns don't seem to be detected by slurm so we
@@ -449,14 +481,21 @@ def mash_distance_order(job, options, config_node, seq_order, mash_output_maps):
 
     return mash_order
             
-def minigraph_construct_in_batches(job, options, config_node, seq_id_map, seq_order, gfa_path):
+def minigraph_construct_in_batches(job, options, config_node, seq_id_map, seq_order, gfa_path, whole_genome_ref=False):
     """ Make minigraph in sequential batches"""
 
     max_size = max([x.size for x in seq_id_map.values()])
     total_size = sum([x.size for x in seq_id_map.values()])
     disk = total_size * 2
     mem = cactus_clamp_memory(60 * max_size + int(total_size / 4))
-    if options.batch:
+    if whole_genome_ref:
+        # with --mgSplitWholeGenomeRef the largest input is the whole reference, so the estimate above
+        # is already the whole-genome one, calibrated against a graph carrying far more sample
+        # material than one chromosome's.  applying the batch multiple on top would ask for more
+        # memory than most machines have.  --mgMemory overrides either way
+        RealtimeLogger.info('Sizing whole-genome-reference minigraph_construct for {} at {}'.format(
+            os.path.basename(gfa_path), bytes2human(mem)))
+    elif options.batch:
         # the memory heuristc seems to drastically underestimate some chromosomes in batch mode...
         mem *= 3
     if options.mgMemory is not None:

--- a/src/cactus/refmap/cactus_pangenome.py
+++ b/src/cactus/refmap/cactus_pangenome.py
@@ -68,6 +68,8 @@ def pangenome_options(parser):
                         help = "File containing scoring parameters (output of last-train)")
     parser.add_argument("--mgSplit", action="store_true", default=False,
                         help = "Run minigraph construction and mapping independently on each chromosome")                        
+    parser.add_argument("--mgSplitWholeGenomeRef", action="store_true", default=False,
+                        help = "Implies --mgSplit, and builds each chromosome's second-pass minigraph against the whole reference genome(s) rather than just that chromosome, so off-chromosome mappings can compete and be filtered the way they are in the whole-genome pipeline. The off-chromosome material is pruned back out before cactus-align.")
 
     # cactus-graphmap options
     parser.add_argument("--mapCores", type=int, help = "Number of cores for minigraph map.  Overrides graphmap cpu in configuration")
@@ -182,6 +184,13 @@ def pangenome_validate_options(options):
 
     if options.lastTrain and options.scoresFile:
         raise RuntimeError('you cannot use both --lastTrain and --scoresFile together: pick one')
+
+    if options.mgSplitWholeGenomeRef:
+        # it only elaborates the second minigraph pass, so it turns that on rather than making you
+        # ask for both
+        if options.noSplit:
+            raise RuntimeError('you cannot use both --mgSplitWholeGenomeRef and --noSplit together: pick one')
+        options.mgSplit = True
 
     if options.mgSplit and options.noSplit:
         raise RuntimeError('you cannot use both --mgSplit and --noSplit together: pick one')
@@ -357,6 +366,24 @@ def phony_chromfile(job, options, paf_path):
         chromfile.write('all\t{}\t{}'.format(seqfile_path, paf_path))
     return chromfile_path
 
+def split_reference_ids(job, seq_id_map, references):
+    """ separate the whole-genome reference fastas from everything else, so --mgSplitWholeGenomeRef
+    can hold them back from the post-split cleanup and build the second-pass minigraphs against them.
+
+    every --reference goes in, matching the first pass: --refOnly builds that graph from all of them,
+    and it is the graph the chromosome bins were decided against.  only reference[0] is rank-0, but a
+    secondary reference still carries sequence the primary lacks, and minigraph maps against the whole
+    graph -- so it contributes competition for exactly the off-chromosome material this is here to
+    catch, and leaving it out would let the two passes disagree about what a chromosome contains.
+
+    they are already sanitized, and they must also bypass sanitize_fasta_headers_batch below: that
+    deletes its input (sanitize_fasta_header in checkUniqueHeaders.py), and every chromosome shares
+    one file id here, so the first chromosome to sanitize would destroy the reference the other
+    chromosomes' construct jobs are still waiting on """
+    refs = set(references)
+    return {k: v for k, v in seq_id_map.items() if k in refs}, \
+           {k: v for k, v in seq_id_map.items() if k not in refs}
+
 def export_split_wrapper(job, wf_output, out_dir, config_node):
     """ toil job wrapper for cactus_graphmap_split's exporter """
     if not out_dir.startswith('s3://') and not os.path.isdir(out_dir):
@@ -402,6 +429,7 @@ def export_minigraph_batch_wrapper(job, options, config_node, input_seqfiles, in
     # regualar gfas
     output_dict = {}
     pansn_gfas = []
+    unpruned_pansn_gfas = {}
     output_file_ids = []
     output_file_maps = []
     for chrom, val in minigraph_batch_results.items():
@@ -410,10 +438,16 @@ def export_minigraph_batch_wrapper(job, options, config_node, input_seqfiles, in
                               os.path.join(out_dir, chrom + '.sv.gfa.gz'))
         output_file_maps += [input_seqid_map[chrom][0]]
         output_file_ids += [val[0]]
-        pansn_gfas += [val[1]]
+        if options.mgSplitWholeGenomeRef:
+            # this graph still carries the whole reference, so the join gets the pruned one the
+            # separation pass makes.  it's kept as the fallback for a chromosome that pass bypasses,
+            # and export_pruned_minigraph_gfa_wrapper frees whichever copies go unused
+            unpruned_pansn_gfas[chrom] = val[1]
+        else:
+            pansn_gfas += [val[1]]
         if options.lastTrain:
             output_file_ids += [val[2]]
-    return output_dict, output_file_maps, output_file_ids, pansn_gfas
+    return output_dict, output_file_maps, output_file_ids, pansn_gfas, unpruned_pansn_gfas
 
 def export_graphmap_batch_wrapper(job, options, config_node, graphmap_batch_results, input_seqfiles):
     """ export the graphmap results, which are another chromfile alongside new seqfiles and a bunch
@@ -434,12 +468,43 @@ def export_graphmap_batch_wrapper(job, options, config_node, graphmap_batch_resu
     output_list = []
     for chrom, gm_output in graphmap_batch_results.items():
         #chrom -> paf_id, gfa_fa_id, gaf_id, unfiltered_paf_id, paf_filter_log, paf_was_filtered, separate_log_id
-        for fid in gm_output:
+        # anything past that is the pruned PanSN GFA the join has yet to merge: leave it alone
+        for fid in gm_output[:7]:
             if fid and fid != True:
                 output_list.append(fid)
 
     return output_list, chromfile_path    
     
+def export_pruned_minigraph_gfa_wrapper(job, options, graphmap_batch_results, unpruned_pansn_gfas):
+    """ with --mgSplitWholeGenomeRef the per-chromosome graph is only chromosome-only once the
+    separation pass has cut the rest of the reference out of it, so it's written here rather than in
+    export_minigraph_batch_wrapper.  same paths chromfile.mg.txt already names """
+    out_dir = os.path.join(options.outDir, 'chrom-minigraph')
+    if not out_dir.startswith('s3://') and not os.path.isdir(out_dir):
+        os.makedirs(out_dir)
+    pansn_gfa_ids = []
+    unused_ids = []
+    for chrom, gm_output in sorted(graphmap_batch_results.items()):
+        pansn_gfa_id = gm_output[7] if len(gm_output) > 7 else None
+        if pansn_gfa_id:
+            unused_ids.append(unpruned_pansn_gfas.get(chrom))
+        else:
+            # the separation pass bypassed this chromosome -- a single-contig reference has nothing
+            # off-chromosome to prune -- so the graph as built is already the right one
+            pansn_gfa_id = unpruned_pansn_gfas.get(chrom)
+        if not pansn_gfa_id:
+            # chromfile.mg.txt already names this path, and graphmap-join is about to merge whatever
+            # is here, so a chromosome silently missing its graph would leave both wrong
+            raise RuntimeError('no minigraph GFA to publish for {}: neither the separation pass nor '
+                               'the construction it prunes produced one'.format(chrom))
+        job.fileStore.exportFile(pansn_gfa_id, makeURL(os.path.join(out_dir, chrom + '.sv.gfa.gz')))
+        pansn_gfa_ids.append(pansn_gfa_id)
+    # the whole-genome graphs the pruned ones replaced.  freed from a follow-on rather than inline so
+    # a retry of this job doesn't trip over its own delete
+    if unused_ids:
+        job.addFollowOnJobFn(clean_jobstore_files, file_ids=unused_ids, allow_none=True)
+    return pansn_gfa_ids
+
 def make_batch_align_jobs_wrapper(job, options, chromfile_path, config_wrapper, last_scores_id):
     """ toil job wrapper for make_batch_align_jobs from cactus_align """
     work_dir = job.fileStore.getLocalTempDir()
@@ -592,8 +657,17 @@ def pangenome_end_to_end_workflow(job, options, config_wrapper, seq_id_map, seq_
         split_export_job = split_job.addFollowOnJobFn(export_split_wrapper, wf_output, split_out_path, split_config_wrapper)
         chromfile_path = os.path.join(split_out_path, 'chromfile.txt')
 
+    # with --mgSplitWholeGenomeRef the second pass builds each chromosome's graph against the whole
+    # reference, so hold the (already sanitized) reference fastas back from the cleanup just below
+    wg_ref_id_map = None
+    clean_seq_id_map = seq_id_map
+    if options.mgSplitWholeGenomeRef:
+        split_ref_job = split_export_job.addFollowOnJobFn(split_reference_ids, seq_id_map, options.reference)
+        wg_ref_id_map, clean_seq_id_map = split_ref_job.rv(0), split_ref_job.rv(1)
+        split_export_job = split_ref_job
+
     # clean out some jobstore files we no longer need
-    clean_jobstore_job = split_export_job.addFollowOnJobFn(clean_jobstore_files, file_id_maps=[seq_id_map] if not options.noSplit else None,
+    clean_jobstore_job = split_export_job.addFollowOnJobFn(clean_jobstore_files, file_id_maps=[clean_seq_id_map] if not options.noSplit else None,
                                                            file_ids=[sv_gfa_id, paf_id])
 
     options.batch = True
@@ -608,7 +682,8 @@ def pangenome_end_to_end_workflow(job, options, config_wrapper, seq_id_map, seq_
         input_map = sanitize_job.rv()
         options.outputGFA=''
         minigraph_batch_job = sanitize_job.addFollowOnJobFn(minigraph_construct_batch_workflow, options, config_node,
-                                                            input_map, None,  sanitize=False)
+                                                            input_map, None,  sanitize=False,
+                                                            construct_ref_id_map=wg_ref_id_map)
         minigraph_batch_results = minigraph_batch_job.rv()
         minigraph_batch_export_job = minigraph_batch_job.addFollowOnJobFn(export_minigraph_batch_wrapper, options, config_node,
                                                                           input_seqfiles, input_map, minigraph_batch_results)
@@ -618,6 +693,7 @@ def pangenome_end_to_end_workflow(job, options, config_wrapper, seq_id_map, seq_
         minigraph_output_maps = minigraph_batch_export_job.rv(1)
         minigraph_output_ids = minigraph_batch_export_job.rv(2)
         minigraph_pansn_sv_gfa_ids = minigraph_batch_export_job.rv(3)
+        unpruned_pansn_sv_gfa_map = minigraph_batch_export_job.rv(4)
         graphmap_batch_job = minigraph_batch_export_job.addFollowOnJobFn(minigraph_batch_workflow, options, config_wrapper,
                                                                          graphmap_input_dict, graph_event, sanitize=False,
                                                                          pansn_gfa_input=False)
@@ -626,7 +702,15 @@ def pangenome_end_to_end_workflow(job, options, config_wrapper, seq_id_map, seq_
         # pass's children are still going and reads their promises unresolved
         separate_job = add_separate_ref_contigs_job(graphmap_batch_job, options, config_wrapper, graphmap_input_dict)
         graphmap_batch_results = separate_job.rv()
-        graphmap_batch_export_job = separate_job.addFollowOnJobFn(export_graphmap_batch_wrapper, options, config_node,
+        prev_batch_job = separate_job
+        if options.mgSplitWholeGenomeRef:
+            # that pass is what cut the rest of the reference out of each chromosome's graph, so the
+            # published .sv.gfa.gz files only exist to write once it's done
+            pruned_gfa_export_job = separate_job.addFollowOnJobFn(export_pruned_minigraph_gfa_wrapper, options,
+                                                                  graphmap_batch_results, unpruned_pansn_sv_gfa_map)
+            minigraph_pansn_sv_gfa_ids = pruned_gfa_export_job.rv()
+            prev_batch_job = pruned_gfa_export_job
+        graphmap_batch_export_job = prev_batch_job.addFollowOnJobFn(export_graphmap_batch_wrapper, options, config_node,
                                                                         graphmap_batch_results, input_seqfiles)
         graphmap_file_ids = graphmap_batch_export_job.rv(0)
         chromfile_path = graphmap_batch_export_job.rv(1)
@@ -634,6 +718,11 @@ def pangenome_end_to_end_workflow(job, options, config_wrapper, seq_id_map, seq_
         clean_jobstore_job = graphmap_batch_export_job.addFollowOnJobFn(clean_jobstore_files, file_ids=graphmap_file_ids)
         clean_jobstore_job = clean_jobstore_job.addFollowOnJobFn(clean_jobstore_files, file_id_maps=minigraph_output_maps,
                                                                  file_ids=minigraph_output_ids, allow_none=True)
+        if options.mgSplitWholeGenomeRef:
+            # the whole-genome reference fastas held back above: every construct that wanted them
+            # has long since run by here
+            clean_jobstore_job = clean_jobstore_job.addFollowOnJobFn(clean_jobstore_files,
+                                                                     file_id_maps=[wg_ref_id_map], allow_none=True)
         
     # cactus_align
     options.scoresFromChromfile = options.lastTrain and options.mgSplit

--- a/src/cactus/refmap/pangenome_exclusions.py
+++ b/src/cactus/refmap/pangenome_exclusions.py
@@ -26,6 +26,7 @@ import re
 import shutil
 
 from cactus.shared.common import cactus_call, getOptionalAttrib, findRequiredNode
+from cactus.shared.common import cactus_clamp_memory
 from toil.realtimeLogger import RealtimeLogger
 
 logger = logging.getLogger(__name__)
@@ -1134,7 +1135,13 @@ def contig_sizes_job(job, seq_id_map, graph_event):
             continue
         safe_event_filename(event)
         fa_id = seq_id_map[event]
+        # samtools faidx itself needs almost nothing (a few MiB), but the job stages the whole
+        # sanitized fasta first, and cgroup accounting charges that page cache to the job -- which is
+        # what killed one of these with MEMLIMIT on a 3GB genome under the 2GiB default.  size it off
+        # the fasta the way sanitize_fasta_header, which stages the same file, already does, but keep
+        # the old default as a floor: scaling alone would ask a small genome for less than the worker
         per_event[event] = job.addChildJobFn(contig_sizes_for_event, fa_id, event,
+                                             memory=cactus_clamp_memory(max(fa_id.size * 2, 2**31)),
                                              disk=fa_id.size * 3).rv()
     return job.addFollowOnJobFn(merge_contig_sizes, per_event).rv()
 

--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -648,7 +648,7 @@ class TestCase(unittest.TestCase):
                                '--vg'] +  vg_files + ['--hal'] + hal_files +
                                ['--xg', '--vcf', '--giraffe', 'clip', 'filter', '--lrGiraffe'] + cactus_opts + ['--indexCores', '4'])
 
-    def _run_yeast_pangenome(self, binariesMode, mgSplit=False, collapse=False, gref=None, vcfL=None):
+    def _run_yeast_pangenome(self, binariesMode, mgSplit=False, wholeGenomeRef=False, collapse=False, gref=None, vcfL=None):
         """ yeast pangenome chromosome by chromosome pipeline, as run through a single invocations
         """
 
@@ -667,6 +667,9 @@ class TestCase(unittest.TestCase):
                                                             '--lastTrain', '--snarlStats']
         if mgSplit:
             cactus_pangenome_cmd += ['--mgSplit']
+        if wholeGenomeRef:
+            # implies --mgSplit
+            cactus_pangenome_cmd += ['--mgSplitWholeGenomeRef']
         if collapse:
             cactus_pangenome_cmd += ['--collapse']
         if gref:
@@ -912,6 +915,34 @@ class TestCase(unittest.TestCase):
         self.assertNotIn('INTERNAL', warning_text)
         for quiet in ['DBVPG6044', 'Y12', 'YPS128']:
             self.assertNotIn(quiet + ':', warning_text)
+
+    def _check_pruned_chrom_minigraphs(self, join_path):
+        """ --mgSplitWholeGenomeRef builds each chromosome's minigraph against the whole reference and
+        prunes it back afterwards.  a prune that silently did nothing would leave every chromosome's
+        published graph carrying all 16 S288C contigs, and the rest of the pipeline would not notice,
+        so this is what separates the option working from the option merely running. """
+        import gzip
+        mg_dir = os.path.join(join_path, 'chrom-minigraph')
+        self.assertTrue(os.path.isdir(mg_dir), 'no chrom-minigraph directory in {}'.format(join_path))
+        gfa_names = sorted(f for f in os.listdir(mg_dir) if f.endswith('.sv.gfa.gz'))
+        self.assertTrue(gfa_names, 'no per-chromosome minigraphs in {}'.format(mg_dir))
+        for gfa_name in gfa_names:
+            chrom = gfa_name[:-len('.sv.gfa.gz')]
+            ref_contigs = set()
+            with gzip.open(os.path.join(mg_dir, gfa_name), 'rt') as gfa_file:
+                for line in gfa_file:
+                    if not line.startswith('S\t'):
+                        continue
+                    toks = line.rstrip('\n').split('\t')
+                    sn = [t[5:] for t in toks if t.startswith('SN:Z:')]
+                    if sn and 'SR:i:0' in toks:
+                        ref_contigs.add(sn[0])
+            self.assertTrue(ref_contigs, '{} has no rank-0 reference contigs'.format(gfa_name))
+            # names are PanSN here (S288C#0#chrI), so match on the contig suffix
+            self.assertEqual(len(ref_contigs), 1,
+                             '{} was not pruned back to one reference contig: {}'.format(gfa_name, sorted(ref_contigs)))
+            self.assertTrue(next(iter(ref_contigs)).endswith('#' + chrom),
+                            '{} kept the wrong reference contig: {}'.format(gfa_name, sorted(ref_contigs)))
 
     def _check_yeast_pangenome(self, binariesMode, other_ref=None, expect_odgi=False, expect_haplo=False, expect_unchopped_gfa=False, expect_gref=False, vcfL=None, expect_report=True):
         """ yeast pangenome chromosome by chromosome pipeline
@@ -1995,12 +2026,17 @@ class TestCase(unittest.TestCase):
         self.assertEqual(orig_vcf_records, bypass_vcf_records)
 
     def testYeastPangenomeSplitLocal(self):
-        """ Run pangenome pipeline (including contig splitting!) on yeast dataset using cactus-pangenome """
+        """ Run pangenome pipeline (including contig splitting!) on yeast dataset using cactus-pangenome.
+
+        Uses --mgSplitWholeGenomeRef, which implies --mgSplit: it runs everything the plain option
+        does and adds the whole-genome reference substitution and the prune that undoes it, so it is
+        the stricter of the two to keep in CI. """
         name = "local"
-        self._run_yeast_pangenome(name, mgSplit=True, gref='clip', vcfL=0.95)
+        self._run_yeast_pangenome(name, wholeGenomeRef=True, gref='clip', vcfL=0.95)
 
         # check the output
         self._check_yeast_pangenome(name, other_ref='DBVPG6044', expect_odgi=True, expect_haplo=True, expect_unchopped_gfa=True, expect_gref=True, vcfL=0.95)
+        self._check_pruned_chrom_minigraphs(os.path.join(self.tempDir, 'join'))
 
         # Test bypass re-indexing with --vgClip and --vgFilter
         self._test_vg_bypass(name)


### PR DESCRIPTION
`--mgSplit` bins everything into chromosomes using the reference(s).  Then does everything independently after that.  The issue is that sequence that might map to other chromosomes (happens especially in acrocentrics) doesn't carry a signal after splitting. 

This PR adds `--mgSplitWholeGenomeRef`.  This does `--mgSplit` but carries the whole reference into each chromosome.  More expensive and annoying, but you get a proper mapq for the accrocentrics.  Seems to work as designed, but still pending a full hprcv2 eval. 