### PR TITLE
Update Red

### DIFF
--- a/test/evolverTest.py
+++ b/test/evolverTest.py
@@ -213,12 +213,13 @@ class TestCase(unittest.TestCase):
 
     def _run_evolver_in_docker(self, seqFile = './examples/evolverMammals.txt'):
 
+        # --maskMode red: only test that runs cactus inside the released image
         out_hal = self._out_hal('in_docker')
         cmd = ['docker', 'run', '--rm', '-v', '{}:{}'.format(os.path.dirname(out_hal), '/data'),
                '-v', '{}:{}'.format(os.getcwd(), '/workdir'), 
                '-u', '{}:{}'.format(os.getuid(), os.getgid()),
                'evolvertestdocker/cactus:latest',
-               'cactus /data/js /workdir/{} /data/{} --maskMode fastan'.format(seqFile, os.path.basename(out_hal))]
+               'cactus /data/js /workdir/{} /data/{} --maskMode red'.format(seqFile, os.path.basename(out_hal))]
         sys.stderr.write('Running {}\n'.format(' '.format(cmd)))
         subprocess.check_call(' '.join(cmd), shell=True)
 


### PR DESCRIPTION
A previous PR turned jemalloc on for Red.  And his broke it.  This PR fixes 2 things:
1) Make sure Red is run with jemalloc on at least once in CI
2) Update Red submodule to version that fixes memory error that caused jemalloc issue in the first place