### PR TITLE
BAR Memory tuning

### DIFF
--- a/bar/impl/bar.c
+++ b/bar/impl/bar.c
@@ -17,6 +17,12 @@
 #include <omp.h>
 #endif
 
+#include <sys/resource.h>
+#include <time.h>
+
+// How often to report progress through the flower list, in seconds.
+#define BAR_PROGRESS_INTERVAL 600
+
 PairwiseAlignmentParameters *pairwiseAlignmentParameters_constructFromCactusParams(CactusParams *params) {
     PairwiseAlignmentParameters *p = pairwiseAlignmentBandingParameters_construct();
     p->gapGamma = cactusParams_get_float(params, 3, "bar", "pecan", "gapGamma");
@@ -92,15 +98,24 @@ void bar(stList *flowers, CactusParams *params, CactusDisk *cactusDisk, stList *
      * one block per segment, at three names again.  Doubling that covers the ends,
      * groups, chains and nested flowers, which are all bounded by the number of
      * blocks.  A flower's bases are its unaligned length plus two per adjacency.
+     *
+     * The same pass totals the bases, for the progress report below.  The list is
+     * sorted largest-first, so the fraction of flowers done is a poor guide to the
+     * fraction of work done -- the first flowers are enormous and the last millions
+     * are tiny -- and weighting by sequence tracks it far better.  The length is
+     * already being read here, so the total costs nothing.
      */
     int64_t flowerNumber = stList_length(flowers);
     int64_t *nameOffsets = st_malloc(sizeof(int64_t) * (flowerNumber + 1));
+    int64_t totalBases = 0;
 #if defined(_OPENMP)
-#pragma omp parallel for schedule(dynamic, 1)
+#pragma omp parallel for schedule(dynamic, 1) reduction(+:totalBases)
 #endif
     for (int64_t j = 0; j < flowerNumber; j++) {
         Flower *flower = stList_get(flowers, j);
-        nameOffsets[j] = 12 * (flower_getTotalBaseLength(flower) + flower_getCapNumber(flower)) + 4096;
+        int64_t flowerBaseLength = flower_getTotalBaseLength(flower);
+        nameOffsets[j] = 12 * (flowerBaseLength + flower_getCapNumber(flower)) + 4096;
+        totalBases += flowerBaseLength;
     }
     int64_t nameTotal = 0; // Turn the sizes into offsets
     for (int64_t j = 0; j < flowerNumber; j++) {
@@ -111,13 +126,14 @@ void bar(stList *flowers, CactusParams *params, CactusDisk *cactusDisk, stList *
     nameOffsets[flowerNumber] = nameTotal;
     Name nameBase = cactusDisk_reserveNames(cactusDisk, nameTotal);
 
+    const bool reportProgress = st_getLogLevel() >= info && flowerNumber > 1;
+    const time_t barStartTime = time(NULL);
+    time_t lastReportTime = barStartTime;
+    int64_t lastReportBases = 0;
+    int64_t flowersDone = 0, basesDone = 0;
+    int64_t flowersInFlight = 0;   // started but not finished: below the outer team size means the tail
+
 #if defined(_OPENMP)
-    // Enable nested parallelism for large flowers with many ends
-    // Level 0: serial (main thread)
-    // Level 1: this parallel region (flower-level parallelism)
-    // Level 2: nested parallel regions in make_consistent_partial_order_alignments
-    omp_set_max_active_levels(2);
-    
 #pragma omp parallel for schedule(dynamic, 1)
 #endif
     for (int64_t j = 0; j<stList_length(flowers); j++) {
@@ -125,6 +141,13 @@ void bar(stList *flowers, CactusParams *params, CactusDisk *cactusDisk, stList *
 
         cactusDisk_pushNameInterval(cactusDisk, nameBase + nameOffsets[j], nameOffsets[j+1] - nameOffsets[j]);
         st_randomSeed(flower_getName(flower)); // Any random choices below are the flower's own, not the thread's
+
+        // Must be read before stCaf_finish, which adds block ends to the flower
+        const int64_t flowerBases = reportProgress ? flower_getTotalBaseLength(flower) : 0;
+        if (reportProgress) {
+#pragma omp atomic
+            ++flowersInFlight;
+        }
 
         // These are all variables used by the filter fns
         FilterArgs *fa = st_calloc(1, sizeof(FilterArgs));
@@ -195,6 +218,62 @@ void bar(stList *flowers, CactusParams *params, CactusDisk *cactusDisk, stList *
         cactusDisk_popNameInterval(cactusDisk);
 
         st_logDebug("Finished filling in the alignments for the flower\n");
+
+        if (reportProgress) {
+            int64_t done, bases, inFlight;
+#pragma omp atomic capture
+            { --flowersInFlight; inFlight = flowersInFlight; }
+#pragma omp atomic capture
+            done = ++flowersDone;
+#pragma omp atomic capture
+            { basesDone += flowerBases; bases = basesDone; }
+
+            time_t now = time(NULL), lastSeen;
+#pragma omp atomic read
+            lastSeen = lastReportTime;
+            if (now - lastSeen >= BAR_PROGRESS_INTERVAL) {
+#if defined(_OPENMP)
+#pragma omp critical(barProgress)
+#endif
+                {
+                    // re-check now that we hold the lock, so only one thread reports
+                    if (now - lastReportTime >= BAR_PROGRESS_INTERVAL) {
+                        // capture the window before advancing the marks
+                        int64_t windowSeconds = now - lastReportTime;
+                        int64_t windowBases = bases - lastReportBases;
+#pragma omp atomic write
+                        lastReportTime = now;
+                        lastReportBases = bases;
+                        struct rusage ru;
+                        getrusage(RUSAGE_SELF, &ru);
+#ifdef __APPLE__
+                        int64_t peakMemMB = ru.ru_maxrss / (1024 * 1024); // bytes on macOS
+#else
+                        int64_t peakMemMB = ru.ru_maxrss / 1024;          // kilobytes on Linux
+#endif
+                        int64_t elapsed = now - barStartTime;
+                        double baseFraction = totalBases > 0 ? (double)bases / (double)totalBases : 0.0;
+                        /*
+                         * Estimate from the rate over the last interval, not from the average
+                         * since the phase began.  The list is sorted largest-first, so the
+                         * average is dominated by the huge flowers at the head and stays
+                         * pessimistic for hours -- and while one of those is in flight nothing
+                         * completes at all, which an average reads as "slow" rather than as
+                         * "no information".  A zero-progress interval gives no estimate.
+                         */
+                        int64_t eta = (windowSeconds > 0 && windowBases > 0) ?
+                            (int64_t)((double)(totalBases - bases) * windowSeconds / windowBases) : -1;
+                        st_logInfo("Bar progress: %" PRIi64 "/%" PRIi64 " flowers (%.2f%%), "
+                                   "%" PRIi64 "/%" PRIi64 " bases (%.2f%%), %" PRIi64 " seconds in bar, "
+                                   "eta %" PRIi64 " seconds, peak memory %" PRIi64 " MB, "
+                                   "%" PRIi64 " in flight\n",
+                                   done, flowerNumber, 100.0 * (double)done / (double)flowerNumber,
+                                   bases, totalBases, 100.0 * baseFraction,
+                                   elapsed, eta, peakMemMB, inFlight);
+                    }
+                }
+            }
+        }
     }
     free(nameOffsets);
 

--- a/bar/impl/poaBarAligner.c
+++ b/bar/impl/poaBarAligner.c
@@ -749,6 +749,17 @@ Msa *msa_make_partial_order_alignment(char **seqs, int *seq_lens, int64_t seq_no
     return output_msa;
 }
 
+/*
+ * The partial order alignments below used to run under a nested OpenMP region for flowers
+ * with at least 50 ends.  That is gone.  A nested num_threads(k) region creates k new
+ * threads per outer thread rather than subdividing the outer team, so it multiplied the
+ * number of concurrent abPOA instances -- and with them this phase's peak memory -- while
+ * buying no wall-clock time.  Measured on VGP data at equal runtime: 2.2x the memory on
+ * MammalsAnc0 (208 ends at most) and 4.9x on AnuraAnc6 (847 ends), the penalty growing
+ * with flower size, so it cost most on exactly the largest problems.  The parallelism
+ * belongs in the flower loop in bar.c, which already saturates the thread count.
+ */
+
 Msa **make_consistent_partial_order_alignments(int64_t end_no, int64_t *end_lengths, char ***end_strings,
         int **end_string_lengths, int64_t **right_end_indexes, int64_t **right_end_row_indexes, int64_t **overlaps,
         int64_t window_size, int64_t max_prog_rows, double max_prog_length_diff, abpoa_para_t *poa_parameters) {
@@ -756,22 +767,6 @@ Msa **make_consistent_partial_order_alignments(int64_t end_no, int64_t *end_leng
     float *column_scores[end_no];
     Msa **msas = st_malloc(sizeof(Msa *) * end_no);
 
-#if defined(_OPENMP)
-    // Only use nested parallelism for ≥50 ends
-    static const int min_ends_for_nesting = 50;
-    static const int max_threads_for_nesting = 8;
-    int nested_threads = 1;
-    if (end_no >= min_ends_for_nesting) {
-        // never use more than an eighth of our threads    
-        int max_threads = omp_get_max_threads() / 8;
-        nested_threads = end_no < max_threads ? end_no : max_threads;
-        if (nested_threads > max_threads_for_nesting) {
-            nested_threads = max_threads_for_nesting;
-        }
-    }
-    
-#pragma omp parallel for schedule(dynamic, 1) if(nested_threads > 1) num_threads(nested_threads)
-#endif
     for(int64_t i=0; i<end_no; i++) {
         msas[i] = msa_make_partial_order_alignment(end_strings[i], end_string_lengths[i], end_lengths[i], window_size,
                                                    max_prog_rows, max_prog_length_diff, poa_parameters);

--- a/doc/progressive.md
+++ b/doc/progressive.md
@@ -408,12 +408,13 @@ Cactus supports [SLURM](https://github.com/SchedMD/slurm) since [version 2.6.1](
 These are the most relevant options for running on a cluster
 
 * `--batchSystem slurm` (required): enable slurm.
-* `--consCores` (required): set the number of cores for each `cactus_consolidated` job. 64 is usually a good value here, but you cannot exceed what's available on your system.
+* `--consCores` (required): set the number of cores for each `cactus_consolidated` job. 64 is usually a good value here, but you cannot exceed what's available on your system. Memory rises with the core count while runtime barely improves above about 24, so use fewer cores if you are memory-limited.
 * `--doubleMem true` (highly recommended): if slurm kills a job because it used more memory than it asked for, retry it asking for double the memory.
 * `--batchLogsDir` (highly recommended): a scratch directory for additional slurm logging.
 * `--workDir`: a local scratch directory available on each worker node (will default to `TEMPDIR` or `TMPDIR`). This could be on a shared filesystem, but it's much better if it's a local, physical disk on the worker node. 
 * `--maxMemory` (optional): when running on slurm, Cactus now queries the cluster with `sinfo` at startup and automatically clamps every job's memory request to the largest available node, just as it does using the host's physical memory on `--batchSystem single_machine`. This keeps Toil from scheduling a job that asks for more memory than any node can provide (which would otherwise sit pending forever and stall the workflow), so you no longer need to set this by hand. Pinning `--slurmPartition` (and/or `--slurmTime`) narrows the clamp to the node(s) those jobs will actually run on; you can also still pass `--maxMemory` to impose an even lower ceiling.
 * `--consMemory`: Override the memory for each `cactus_consolidated` job. Can be useful if Cactus's estimates are wrong, but `--maxMemory/--doubleMem` should be enough to work around this type of issue.
+* **Large, repeat-rich genomes**: turn on `partialOrderAlignmentMaskFilter` in the `<bar><poa>` section of the config (e.g. `1000`; the default `-1` is off). On 20-30 Gb salamander genomes, leaving it off cost ~38x the BAR time and ran out of memory on a 2 TB node; with it on, BAR took under an hour. `partialOrderAlignmentWindow` is a far cheaper lever: halving it to `5000` saved ~25% memory and ~30% BAR time.
 
 On a cluster with partitions and/or time limits, make sure to use
 

--- a/pipeline/cactus_consolidated.c
+++ b/pipeline/cactus_consolidated.c
@@ -4,6 +4,8 @@
 
 #include <time.h>
 #include <getopt.h>
+#include <dlfcn.h>
+#include <sys/types.h>
 #include "sonLib.h"
 #include "cactus.h"
 #include "cactus_setup.h"
@@ -28,6 +30,92 @@
  * cleanup input alignment format
  *
  */
+
+/*
+ * Retain freed pages instead of returning them to the OS.  abPOA allocates its DP matrix
+ * with posix_memalign at gigabyte sizes and frees it per alignment window; by default
+ * jemalloc hands those pages back and the next window faults them all in again.  Keeping
+ * them trades memory for that fault traffic, and on real workloads the trade is lopsided.
+ *
+ * Every setting below was measured on VGP data (cactus_consolidated wall time, 64 cores,
+ * nesting off).  The two marked "chosen" are what this function sets.
+ *
+ *   MammalsAnc0  dirty 10s  muzzy 0   (stock)      13433 s    90 GiB
+ *                dirty 10s  muzzy 30s..5min     17700-19552 s ~92 GiB   REJECTED: slower than stock
+ *                dirty 10s  muzzy -1               5573 s   282 GiB    2.4x
+ *                dirty -1   muzzy -1               3224 s   299 GiB    4.2x   chosen
+ *   AnuraAnc6    dirty -1   muzzy 0                9726 s   702 GiB   REJECTED: all the memory, half the speed
+ *                dirty -1   muzzy -1               5483 s   686 GiB    1.8x   chosen
+ *   oversize_threshold raised above the matrix size          +66% memory, +25% time   REJECTED
+ *
+ * Why the positive muzzy values lose to stock 0: a page then pays MADV_FREE *and* later
+ * MADV_DONTNEED and still refaults, so it is strictly worse than either extreme.  Note the
+ * stock muzzy_decay_ms in this build really is 0, not the 10000 the jemalloc docs suggest --
+ * an explicit 10000 is the *worst* case, not a no-op.  Both decays are set because dirty
+ * alone carries the entire memory cost for under half the speed, and muzzy on top of it is
+ * nearly free.  oversize_threshold is additionally read-only after startup.
+ *
+ * On salamander Anc3 (22 Gb genomes) this and the nesting removal together took bar from
+ * 76130 s to 6031 s and, unexpectedly, CAF from 29767 s to 23866 s.
+ *
+ * MALLOC_CONF only takes effect before main, and an environment variable set by a Toil
+ * leader may not reach the worker, so this is done at runtime instead.  mallctl is looked
+ * up rather than linked: builds with jemalloc off (Mac, CGL_DEBUG=ultra, legacy arch) then
+ * simply find nothing and carry on.
+ */
+// A weak reference resolves to jemalloc's mallctl when it is linked and stays null when it
+// is not, with no dlfcn and no _GNU_SOURCE (RTLD_DEFAULT is a GNU extension, and defining
+// _GNU_SOURCE for this one call would change other declarations in this file).
+extern int mallctl(const char *, void *, size_t *, void *, size_t) __attribute__((weak));
+
+static void cactus_jemalloc_retain_pages(void) {
+    int (*mallctl_fn)(const char *, void *, size_t *, void *, size_t) = mallctl;
+    if (mallctl_fn == NULL) {
+        // a statically linked jemalloc may not pull ctl.o in on a weak reference alone,
+        // so ask the dynamic loader before giving up.  dlopen(NULL) and RTLD_LAZY are POSIX.
+        void *self = dlopen(NULL, RTLD_LAZY);
+        if (self != NULL) {
+            *(void **)(&mallctl_fn) = dlsym(self, "mallctl");
+        }
+    }
+    if (mallctl_fn == NULL) {
+        st_logInfo("no jemalloc in this build, so page retention is not available\n");
+        return;
+    }
+
+    const char *names[2] = { "dirty_decay_ms", "muzzy_decay_ms" };
+    for (int w = 0; w < 2; w++) {
+        ssize_t v = -1;   // never purge
+        char key[64];
+        // the default every arena created from here on inherits -- most of them, since
+        // arenas are made lazily as threads first allocate and the OMP threads do not exist yet
+        snprintf(key, sizeof(key), "arenas.%s", names[w]);
+        int rc_default = mallctl_fn(key, NULL, NULL, &v, sizeof(v));
+
+        // and the handful that already exist, one at a time: MALLCTL_ARENAS_ALL is
+        // rejected here (EFAULT), so relying on it would silently leave them purging
+        unsigned narenas = 0;
+        size_t nsz = sizeof(narenas);
+        int set = 0, declined = 0;
+        if (mallctl_fn("arenas.narenas", &narenas, &nsz, NULL, 0) == 0) {
+            for (unsigned i = 0; i < narenas; i++) {
+                snprintf(key, sizeof(key), "arena.%u.%s", i, names[w]);
+                if (mallctl_fn(key, NULL, NULL, &v, sizeof(v)) == 0) {
+                    set++;
+                } else {
+                    declined++;   // uninitialised arenas refuse, harmlessly: they inherit
+                }
+            }
+        }
+        ssize_t readback = 0;
+        size_t sz = sizeof(readback);
+        snprintf(key, sizeof(key), "arenas.%s", names[w]);
+        mallctl_fn(key, &readback, &sz, NULL, 0);
+        st_logInfo("jemalloc %s set to -1: default for new arenas rc=%i (reads back %" PRIi64 "), "
+                   "%i of %u existing arenas set, %i declined\n",
+                   names[w], rc_default, (int64_t)readback, set, narenas, declined);
+    }
+}
 
 void usage() {
     fprintf(stderr, "cactus_consolidated, version 0.2\n");
@@ -350,6 +438,8 @@ int main(int argc, char *argv[]) {
     //////////////////////////////////////////////
 
     st_setLogLevelFromString(logLevelString);
+
+    cactus_jemalloc_retain_pages();
 
     //////////////////////////////////////////////
     //Log the inputs

--- a/src/cactus/cactus_progressive_config.xml
+++ b/src/cactus/cactus_progressive_config.xml
@@ -552,28 +552,41 @@
 			allow_multifurcations="0"
 	 	/>
   	</multi_cactus>
-	<!-- memory_core_scale_pct: percentage to increase memory per core above baseline (default 0.5 means 0.5% more memory per extra core) -->
-	<!-- memory_core_scale_baseline: number of cores at which scaling begins (default 32) -->
-	<!-- memory_core_scale_max_pct: maximum percentage increase allowed (default 100 means memory can at most double) -->
+	<!-- cactus_consolidated memory is estimated as
+	     memory_coefficient_gb * (paf_GB + total_sequence_GB)^memory_input_exponent,
+	     then scaled for the poa window and the core count.  Fitted to 575 VGP alignments
+	     (64 cores, stock bar parameters).  The exponent is well under 1 because peak memory
+	     saturates: it is set by the largest flowers bar builds rather than by input volume.
+	     AnuraAnc6 with a 0.44 GB paf peaked at 685.9 GiB and salamander Anc3 with a 45x larger
+	     19.8 GB paf peaked at 682.3 GiB, so anything linear in the input overshoots badly on
+	     large genomes. -->
+	<!-- memory_ramp_gb: taper the estimate to zero below this much input.  The smallest
+	     alignment in the fit had 0.027 GB, so below that the power law is extrapolation and
+	     would hand a toy test tens of GiB.  Set under every point in the fit, so it moves none
+	     of them. -->
+	<!-- memory_core_scale_pct: percent memory change per core away from the baseline, applied in
+	     both directions.  Concurrent abpoa instances equal the core count, so fewer cores really
+	     do need less memory.  0.65 measured on AnuraAnc6: 465.5 GiB at 24 cores, 542.2 at 32,
+	     685.9 at 64 -->
+	<!-- memory_core_scale_baseline: core count the estimate is calibrated at (the fit data was
+	     all run at 64) -->
+	<!-- memory_core_scale_max_pct: cap on the increase (100 = memory can at most double) -->
+	<!-- memory_poa_window_exponent: memory scales as (window/10000)^this.  NOT quadratic despite
+	     what the poa comment says: halving the window to 5000 measured 858.4 -> 639.4 GiB, since
+	     halving it also halves the number of windows.  Nothing is subtracted for
+	     partialOrderAlignmentMaskFilter, which matters more but was disabled in all the fit
+	     data, so enabling it only makes the estimate conservative -->
 	<!-- og_size_scale: scale outgroup sizes by this factor (percent) when computing total sequence size -->
 	<consolidated
-		 memory_core_scale_pct="0.5"
-		 memory_core_scale_baseline="32"
+		 memory_coefficient_gb="220"
+		 memory_input_exponent="0.30"
+		 memory_ramp_gb="0.02"
+		 memory_core_scale_pct="0.65"
+		 memory_core_scale_baseline="64"
 		 memory_core_scale_max_pct="100"
+		 memory_poa_window_exponent="0.43"
 		 og_size_scale_pct="75"
 		 >
-	       <!-- consolidatedMemory: Specify memory requirement (in bytes) for cactus_conslidated. Each attribute corresponds to an interval start, and must be in the form seq_size_TOTAL_INPUT_SEQUENCE_SIZE=MEMORY.  So if cactus_consolidated is getting N input bytes, the first interval containing N is found, and the value of that attribute is used as the Toil memory. The idea is that it will be easier to fiddle with these than a single polynomial function while attempting to learn decent defaults by trial and error. By default, the memory requirement is linearly interpolated based on the endpoints of the interval.  If consMemory CLI option is used, then it overrides everything here.   -->
-	 	<consolidatedMemory
-	 		seq_size_0="1000000"
-			seq_size_10000000="16000000000"
-			seq_size_50000000="64000000000"
-			seq_size_1000000000="128000000000"
-			seq_size_4000000000="256000000000"
-			seq_size_10000000000="512000000000"
-			seq_size_15000000000="1000000000000"
-			seq_size_17500000000="1500000000000"
-			seq_size_20000000000="1990000000000"
-	 	/>
 	</consolidated>
 	<consolidated2></consolidated2>
 </cactusWorkflowConfig>

--- a/src/cactus/paf/local_alignment.py
+++ b/src/cactus/paf/local_alignment.py
@@ -453,8 +453,14 @@ def make_ingroup_to_outgroup_alignments_0(job, ingroup_event, outgroup_events, e
     alignment_file = job.addChildJobFn(make_ingroup_to_outgroup_alignments_1, ingroup_event, outgroup_events,
                                             event_names_to_sequences, distances, params).rv()
 
-    # Invert the final alignment so that the query is the outgroup and the target is the ingroup
-    return job.addFollowOnJobFn(invert_alignments, alignment_file).rv()
+    # Invert the final alignment so that the query is the outgroup and the target is the ingroup.
+    # paffy invert holds the alignment and its inverse on local disk at once. The alignment's size
+    # is a promise here, so estimate it from the sequence that went into it: on a repeat-rich
+    # genome the ingroup-to-outgroups paf runs to several times the sequence, and this job
+    # otherwise falls back on the 2 Gi default and overruns it by orders of magnitude.
+    alignment_disk = 10 * (event_names_to_sequences[ingroup_event.iD].size +
+                           sum(event_names_to_sequences[outgroup.iD].size for outgroup in outgroup_events))
+    return job.addFollowOnJobFn(invert_alignments, alignment_file, disk=alignment_disk).rv()
 
 
 def make_ingroup_to_outgroup_alignments_1(job, ingroup_event, outgroup_events, event_names_to_sequences, distances, params):
@@ -679,7 +685,7 @@ def chain_alignments(job, alignment_files, alignment_names, reference_event_name
                               memory=cactus_clamp_memory(4 * split_size)).rv()
         )
 
-    return job.addFollowOnJobFn(merge_processed_alignments, processed_rvs).rv()
+    return job.addFollowOnJobFn(merge_processed_alignments, processed_rvs, disk=2 * merged_size).rv()
 
 
 def chain_tile_trim_filter_one_contig(job, split_file_id, reference_event_name, params):

--- a/src/cactus/pipeline/cactus_workflow.py
+++ b/src/cactus/pipeline/cactus_workflow.py
@@ -9,7 +9,6 @@
 
 import os
 import sys
-import bisect
 from toil.lib.bioio import system
 from toil.lib.bioio import getLogLevelString
 from toil.realtimeLogger import RealtimeLogger
@@ -49,52 +48,72 @@ def cactus_cons_with_resources(job, tree, ancestor_event, config_node, seq_id_ma
         
     disk = 5 * total_sequence_size + 2 * paf_id.size
 
-    # get the size from the config
-    mem = None
-    cons_memory_node = findRequiredNode(cons_node, 'consolidatedMemory')
-    cons_memory_intervals = []
-    for key, val in cons_memory_node.items():
-        try:
-            assert key.startswith('seq_size_')
-            interval_start = int(key[len('seq_size_'):])
-            interval_mem = int(val)
-            cons_memory_intervals.append((interval_start, interval_mem))
-        except:
-            raise RuntimeError('Unable to parse attribute {}={} from <consolidatedMemory> node in configuration XML'.format(key, value))
-    cons_memory_intervals = sorted(cons_memory_intervals)
-    interval_idx = bisect.bisect(cons_memory_intervals, (total_sequence_size + 0.5, 0)) - 1
-    interval = cons_memory_intervals[interval_idx]
-    mem = interval[1]
-    if interval_idx < len(cons_memory_intervals) - 1:
-        next_interval = cons_memory_intervals[interval_idx + 1]
-        interval_delta = (next_interval[0] - interval[0], next_interval[1] - interval[1])
-        mem += int(((total_sequence_size - interval[0]) / interval_delta[0]) * interval_delta[1])
-    
-    if not mem:
-        raise RuntimeError('Unable to parse memory requirement from <consolidatedMemory> node in configuration XML')
-    
-    # abPOA needs a bunch of memory for its table, even for tiny alignments
-    if getOptionalAttrib(findRequiredNode(config_node, 'bar'), 'partialOrderAlignment', typeFn=bool, default=True):
-        mem = max(mem, int(4e9))
-    # add function of paf size
-    mem = max(mem, 10 * paf_id.size)
+    # Peak memory saturates: it is set by the largest flowers bar builds, not by input volume.
+    # AnuraAnc6 (0.44 GB paf) peaked at 685.9 GiB and salamander Anc3 (19.8 GB paf, 45x larger)
+    # at 682.3 GiB.  So the estimate is a power of the input, not linear in it -- a linear term
+    # fitted on the VGP range extrapolates to roughly double the truth at salamander scale.
+    #
+    # Fitted to 575 VGP alignments (64 cores, stock bar parameters), against the old table:
+    #
+    #   old seq_size table   14.3% under-provisioned, 1.7% still short at 2x, 2.37x allocated
+    #   this model           14.3% under-provisioned, 0.7% still short at 2x, 1.85x allocated
+    #
+    # The middle column is the one that costs a run: --doubleMem retries at twice the request,
+    # so an under-estimate only loses the work when 2x misses too.  The old table keyed off
+    # total sequence size, which correlates just 0.27 with peak -- two of those alignments
+    # peaked within 1% of each other (989 and 980 GiB) and were estimated 2150 and 373 GiB
+    # purely on their sequence sizes.  Held-out check: this predicts salamander Anc3 at 1.01x
+    # its measured peak, where the table gave 3.15x.
+    mem_coef = getOptionalAttrib(cons_node, 'memory_coefficient_gb', typeFn=float, default=220.0)
+    mem_exp = getOptionalAttrib(cons_node, 'memory_input_exponent', typeFn=float, default=0.30)
+    mem_ramp_gb = getOptionalAttrib(cons_node, 'memory_ramp_gb', typeFn=float, default=0.02)
+    input_gb = (paf_id.size + total_sequence_size) / 1e9
+    # Below the smallest alignment in the fit (0.027 GB of input) the power law is pure
+    # extrapolation and would hand an evolver-sized test tens of GiB, so taper it to zero.
+    # The taper ends at 0.02 GB, under every point in the fit, so it changes none of them.
+    ramp = min(1.0, input_gb / mem_ramp_gb) if mem_ramp_gb > 0 else 1.0
+    mem = int(mem_coef * (input_gb ** mem_exp) * ramp * 2**30) if input_gb > 0 else 0
 
-    # scale memory based on number of cores (memory usage increases with more cores)
-    core_scale_pct = getOptionalAttrib(cons_node, 'memory_core_scale_pct', typeFn=float, default=0.5)
-    core_scale_baseline = getOptionalAttrib(cons_node, 'memory_core_scale_baseline', typeFn=int, default=32)
+    # Memory is *not* quadratic in the poa window, whatever the config comment says: halving it
+    # from 10000 to 5000 measured 858.4 -> 639.4 GiB on salamander Anc3, a 0.745x ratio, because
+    # halving the window also halves the number of windows and peak is bounded by how many run
+    # at once.  That ratio is an exponent of 0.43, not 2.  Nothing is subtracted for
+    # partialOrderAlignmentMaskFilter even though it matters more, because every alignment in
+    # the fit ran with it disabled -- so enabling it can only make the estimate conservative.
+    poa_node = findRequiredNode(config_node, 'bar').find('poa')
+    poa_window = getOptionalAttrib(poa_node, 'partialOrderAlignmentWindow', typeFn=int, default=10000) if poa_node is not None else 10000
+    window_exp = getOptionalAttrib(cons_node, 'memory_poa_window_exponent', typeFn=float, default=0.43)
+    if poa_window > 0 and poa_window != 10000:
+        mem = int(mem * (poa_window / 10000.0) ** window_exp)
+
+    # Scale with the core count in BOTH directions.  Concurrent abPOA instances now equal
+    # the core count exactly (bar's nested parallelism is gone), so a job given fewer cores
+    # genuinely needs less memory and should say so -- the old form only ever scaled up, so a
+    # 24-core job asked for the 32-core figure.  Measured on AnuraAnc6 with the current
+    # defaults: 465.5 GiB at 24 cores, 542.2 at 32, 685.9 at 64, which is ~0.65%/core against
+    # a 64-core baseline (exact at 32, 9% conservative at 24).  The baseline is 64 because
+    # that is where the 575 alignments the model was fitted to were run.
+    core_scale_pct = getOptionalAttrib(cons_node, 'memory_core_scale_pct', typeFn=float, default=0.65)
+    core_scale_baseline = getOptionalAttrib(cons_node, 'memory_core_scale_baseline', typeFn=int, default=64)
     core_scale_max_pct = getOptionalAttrib(cons_node, 'memory_core_scale_max_pct', typeFn=float, default=100.0)
-    if cons_cores and cons_cores > core_scale_baseline and core_scale_pct > 0:
+    if cons_cores and cons_cores != core_scale_baseline and core_scale_pct > 0:
         extra_cores = cons_cores - core_scale_baseline
         scale_factor = 1.0 + (extra_cores * core_scale_pct / 100.0)
-        # cap scale factor at max percentage increase (default 100% = doubling)
+        # cap the increase (default 100% = doubling); never scale below a quarter
         scale_factor = min(scale_factor, 1.0 + core_scale_max_pct / 100.0)
+        scale_factor = max(scale_factor, 0.25)
         scaled_mem = int(mem * scale_factor)
-        RealtimeLogger.info('Scaling cactus_consolidated({}) memory by {:.1f}% for {} extra cores (above {} baseline): {} -> {}'.format(
-            chrom_name if chrom_name else ancestor_event, (scale_factor - 1) * 100, extra_cores, core_scale_baseline,
+        RealtimeLogger.info('Scaling cactus_consolidated({}) memory by {:.1f}% for {} cores ({:+d} against the {} baseline): {} -> {}'.format(
+            chrom_name if chrom_name else ancestor_event, (scale_factor - 1) * 100, cons_cores, extra_cores, core_scale_baseline,
             bytes2human(mem), bytes2human(scaled_mem)))
         mem = scaled_mem
 
-    RealtimeLogger.info('Estimating cactus_consolidated({}) memory as {} from {} sequences with total-sequence-size {} and paf-size {} using <conslidatedMemory> configuration settings'.format(chrom_name if chrom_name else ancestor_event, bytes2human(mem), len(seq_id_map), bytes2human(total_sequence_size), paf_id.size))
+    # abPOA needs a table even for tiny alignments; apply the floor last so neither the window
+    # nor the core scaling can push a small job below it
+    if getOptionalAttrib(findRequiredNode(config_node, 'bar'), 'partialOrderAlignment', typeFn=bool, default=True):
+        mem = max(mem, int(4e9))
+
+    RealtimeLogger.info('Estimating cactus_consolidated({}) memory as {} from {} sequences with total-sequence-size {} and paf-size {} using <consolidated> configuration settings'.format(chrom_name if chrom_name else ancestor_event, bytes2human(mem), len(seq_id_map), bytes2human(total_sequence_size), paf_id.size))
 
     if cons_memory is not None and cons_memory != mem:
         RealtimeLogger.info('Overriding cactus_conslidated({}) memory estimate of {} with {} value {} from --consMemory'.format(


### PR DESCRIPTION
* turns off nested openmp for once and all in BAR
* set jemalloc to retain pages in `cactus_consolidated`.  This helps `abPOA` get its big memory blocks a lot faster. 
* tune consolidated memory estimator a bit better in light of new parameters

Upshot of this is much faster BAR (3x-10x on tests so far).  Helps CAF a bit too, but have separate PR with more radical improvements. 