### PR TITLE
Pass memory to cutheaders job

### DIFF
--- a/src/cactus/preprocessor/cutHeaders.py
+++ b/src/cactus/preprocessor/cutHeaders.py
@@ -18,7 +18,7 @@ class CutHeadersJob(RoundedJob):
     def __init__(self, fastaID, cutBefore, cutBeforeOcc, cutAfter):
         disk = 2*(fastaID.size)
         memory = fastaID.size
-        RoundedJob.__init__(self, disk=disk, preemptable=True)
+        RoundedJob.__init__(self, memory=memory, disk=disk, preemptable=True)
         self.fastaID = fastaID
         self.cutBefore = cutBefore
         self.cutBeforeOcc = cutBeforeOcc


### PR DESCRIPTION
Fixes bug where toil memory specification was set, but never actually given to the `cutHeaders` preprocessor job. 

Note: the memory specification is a bit conservative, it uses the whole file when it really only needs the largest contig.  But we don't know the largest contig without scanning the file anyway...