### PR TITLE
Default a plain "make" to the portable baseline, make native opt-in

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -5,6 +5,32 @@ A file include.local.mk can be created in the root directory
 to override make variables, including setting environment variables.
 This should not be committed.
 
+It is included before any build decision is made, so it is the tidiest place for a setting
+that belongs to one checkout rather than to your shell.  For instance, put
+`CACTUS_NATIVE_BUILD = 1` there on a workstation whose binaries never leave it, and there is
+nothing to remember or unset later.  It cannot leak into anything we distribute: the
+Dockerfile deletes it before building, and `build-tools/makeBinRelease` builds a fresh clone.
+
+## Environment variables controlling how cactus is built
+- CACTUS_NATIVE_BUILD - compile for the machine doing the compiling (`-march=native`)?
+  - unset <default> - portable: the baseline in include.mk, which any reasonably modern
+    CPU of the same architecture can run
+  - 1 - native.  Only for binaries that stay on the build machine.  A native binary
+    SIGILLs on any older CPU, which is the normal outcome of building on a cluster head
+    node and running on a worker.  No effect on ARM or with CACTUS_LEGACY_ARCH.
+
+- CACTUS_PORTABLE_BUILD - force the portable baseline, overriding CACTUS_NATIVE_BUILD.
+  Set by the Dockerfile and by build-tools/makeBinRelease, since those builds get shipped.
+  Redundant otherwise, as portable is the default.
+
+- CACTUS_LEGACY_ARCH - build for pre-AVX2 CPUs (`-msse2`), for the legacy binary release.
+
+- CACTUS_ARCH_FLAGS - the baseline as literal compiler flags, e.g.
+  `CACTUS_ARCH_FLAGS="-march=x86-64-v3 -mtune=znver3"`.  Overrides all of the above.
+
+Run `make arch-flags` to print what the baseline resolves to without building anything.
+The reasoning behind each value is in the comments in include.mk.
+
 ## Environment variables controlling how cactus is run
 - CACTUS_BINARIES_MODE - how are cactus programs found?
   - docker <default>

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,10 @@ RUN find /home/cactus -name include.local.mk -exec rm -f {} \; && \
 # https://github.com/yangao07/abPOA/issues/26
 ENV avx2 1
 
-# This image is distributed, so build it the way the binary release is built: include.mk's
-# portable baseline rather than the -march=native a plain "make" would otherwise pick.  The
-# value itself stays in include.mk; this only selects it.
+# This image is distributed, so pin include.mk's portable baseline explicitly rather than
+# leaning on it being the default: it says what this build requires, it keeps the image and
+# the binary release selecting the same thing, and it beats CACTUS_NATIVE_BUILD if that ever
+# arrives from the environment.  The value itself stays in include.mk; this only selects it.
 ENV CACTUS_PORTABLE_BUILD 1
 
 # install Phast and enable halPhyloP compilation

--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ If you want to work with MAF, including running `cactus-hal2maf`, you must also 
 build-tools/downloadMafTools
 ```
 
+These compile for a portable CPU baseline, so the binaries run on any reasonably modern
+machine and not just the one that built them.  To target the build machine specifically,
+`export CACTUS_NATIVE_BUILD=1` first; that binary will not run on an older CPU, though, such
+as a cluster node older than the head node you built on.  `make arch-flags` prints the
+baseline you will get, and DEVELOPMENT.md documents the rest of the build variables.
+
 In order to toggle between local and Docker binaries, use the `--binariesMode` command line option. If `--binariesMode` is not specified, local binaries will be used if found in `PATH`, otherwise a Docker image will be used.
 
 ### Building on Mac

--- a/build-tools/makeBinRelease
+++ b/build-tools/makeBinRelease
@@ -26,7 +26,15 @@ set -beEu -o pipefail
 # outright when the two disagree -- which is how it first showed up, as an
 # undefined reference to st_fclose against a working tree whose submodules
 # predated it, while the correct library sat unused in bin-tmp.
-unset sonLibRootDir PYTHONPATH
+#
+# The two arch knobs go for a different reason: they are not exported by the
+# invoking make, but they are exactly the kind of thing a developer keeps
+# exported in their own shell, and this script runs in that shell.  Either one
+# would end up in a public tarball -- CACTUS_ARCH_FLAGS in particular outranks
+# the CACTUS_PORTABLE_BUILD set below, so it would also strip the legacy
+# tarball of the -msse2 that is its only reason to exist.  CACTUS_LEGACY_ARCH
+# is deliberately not in this list: "make binRelease" passes it in on purpose.
+unset sonLibRootDir PYTHONPATH CACTUS_ARCH_FLAGS CACTUS_NATIVE_BUILD
 # the Makefile prepends exactly "${CWD}/bin:", so take that one prefix back off
 PATH=${PATH#"$(pwd)/bin:"}
 export PATH
@@ -46,7 +54,9 @@ REL_TAG=$(getLatestReleaseTag)
 git checkout "${REL_TAG}"
 git submodule update --init --recursive
 
-# This build gets shipped, so take include.mk's portable baseline rather than -march=native.
+# This build gets shipped, so pin include.mk's portable baseline.  That is the default now,
+# and the scrub above has already dropped the two knobs that could change it, but this is the
+# one build whose output goes to other people's machines, so say it rather than inherit it.
 export CACTUS_PORTABLE_BUILD=1
 
 if [ -z ${CACTUS_LEGACY_ARCH+x} ]

--- a/include.mk
+++ b/include.mk
@@ -97,8 +97,15 @@ endif
 ifeq ($(shell arch || true), arm64)
 	arm=1
 endif
-# CPU baseline for the code we generate.  Override for a machine-specific build:
-#   CACTUS_ARCH_FLAGS="-march=native" make
+# CPU baseline for the code we generate.  A plain "make" is portable.  Opt into a
+# machine-specific build, for binaries that will only ever run on the machine that compiled
+# them:
+#   CACTUS_NATIVE_BUILD=1 make
+# or, per-checkout and with no shell state to remember, put
+#   CACTUS_NATIVE_BUILD = 1
+# in include.local.mk, which is included at the top of this file, before the choice below is
+# made.  To pin an exact baseline by hand -- this beats both knobs, since CACTUS_ARCH_FLAGS
+# is taken with ?= below:
 #   CACTUS_ARCH_FLAGS="-march=x86-64-v3 -mtune=znver3" make
 #
 # x86-64-v3 rather than the bare -mavx2 this used to be.  That is not a portability change:
@@ -108,6 +115,16 @@ endif
 # rest of the same CPU generation (FMA, BMI1/2, LZCNT, MOVBE, F16C), which every AVX2-capable
 # CPU has.  Measured: minigraph 1.3% faster, lastz 2.1%, output byte-identical in both.
 #
+# The psABI level names -march=x86-64-v2/v3/v4 only arrived in gcc 11 and clang 12, and an
+# -march value the compiler does not recognise is a hard error rather than a warning, so
+# anything older falls back to the bare -mavx2 this baseline replaced.  That matters now that
+# portable is what a plain "make" gets: before, x86-64-v3 was reached only by builds we ship,
+# which are built on 22.04, whereas the README still names Ubuntu 20.04, whose gcc is 9.  The
+# fallback is safe to take silently because it cannot weaken the portability contract -- both
+# spellings require AVX2 and nothing newer, so the oldest CPU that can run the result is the
+# same either way.  What is lost is the rest of the v3 generation, i.e. the 1-2% above.
+# "make arch-flags" prints which one you got.
+#
 # Deliberately NOT x86-64-v4.  AVX-512 would emit binaries that will not run on the
 # Skylake-class machines we develop and test on, and it is worth little anyway: abPOA is the
 # only hand-vectorised code in the tree, and doubling its vector width 128->256 bits bought
@@ -115,20 +132,32 @@ endif
 #
 # No -mtune here.  -mtune=skylake measured a further 2.7% on minigraph and emits no new
 # instructions, so it costs no portability -- but it is a bet on one microarchitecture that
-# may go the other way on AMD, which we have not measured.  Set it per-cluster via the knob.
-# Two baselines, and which you get depends on whether the build will be shipped.
+# may go the other way on AMD, which we have not measured.  Set it per-cluster with
+# CACTUS_ARCH_FLAGS.
 #
-# PORTABLE is for anything we distribute.  NATIVE is for a plain "make", which is someone
-# compiling cactus for the machine in front of them and should use that machine.  Anything
-# that ships its output sets CACTUS_PORTABLE_BUILD=1 -- makeBinRelease and the Dockerfile
-# both do -- so the portable value lives in exactly one place and cannot drift.
+# Two baselines.  PORTABLE is the default; NATIVE is opt-in.
+#
+# PORTABLE, because a development build is not usually run where it was built.  Compiling on a
+# cluster head node and running on whatever worker picks up the job is the normal case, and an
+# -march=native binary SIGILLs on any worker older than the head node -- which is most of a
+# heterogeneous cluster, and a confusing failure to read when it happens.  It is also what the
+# README tells a from-source user to type, so what a bare "make" emits has to be the safe
+# thing.  NATIVE is for binaries that stay on the machine that built them.
+#
+# CACTUS_PORTABLE_BUILD=1 forces PORTABLE and beats CACTUS_NATIVE_BUILD, so makeBinRelease and
+# the Dockerfile -- which both still set it -- ship the portable baseline even when a developer
+# has the native knob exported.  Both are now defence in depth rather than the only barrier --
+# a docker build inherits nothing from the shell that started it, and makeBinRelease unsets
+# the arch knobs itself -- but what we distribute is worth saying twice, and the portable value
+# lives in exactly one place either way and cannot drift.
 #
 # -march=native is not reliably faster: measured here it gained 4.6% on minigraph and lost
-# 5.7% on lastz, the loss isolating to -mtune, which native implies.  It is still the right
-# default for a machine-specific build; measure on your own hardware if it matters.
+# 5.7% on lastz, the loss isolating to -mtune, which native implies.  So it is worth asking
+# for only when the binaries stay put; measure on your own hardware if it matters.
 #
-# NOT native on ARM: Apple's clang spells it -mcpu=native and rejects -march=native.
-# NOT native for CACTUS_LEGACY_ARCH either: that build exists precisely to be portable.
+# NATIVE is just PORTABLE on ARM: Apple's clang spells it -mcpu=native and rejects
+# -march=native.  Same under CACTUS_LEGACY_ARCH, which exists precisely to be portable.  On
+# both, CACTUS_NATIVE_BUILD=1 is accepted and changes nothing.
 ifdef arm
 #	flags to build abpoa
 	export armv8 = 1
@@ -144,14 +173,26 @@ else
 #	flags to build abpoa
 	export avx2 = 1
 #	flags to include simde abpoa in cactus on X86
-	CACTUS_PORTABLE_ARCH_FLAGS = -march=x86-64-v3
+	archV3 := $(shell ${CC} -march=x86-64-v3 -E -x c /dev/null > /dev/null 2>&1 && echo 1)
+	CACTUS_PORTABLE_ARCH_FLAGS = $(if ${archV3},-march=x86-64-v3,-mavx2)
 	CACTUS_NATIVE_ARCH_FLAGS = -march=native
 endif
 
+# PORTABLE tested first, so it beats the native knob: a shipping build stays portable however
+# CACTUS_NATIVE_BUILD is set.  An explicit CACTUS_ARCH_FLAGS still wins over both -- see the
+# ?= below, which is what allows that and so must stay on every branch.
+#
+# The native knob is tested for exactly 1, not with ifdef, which is true of any non-empty
+# value: CACTUS_NATIVE_BUILD=0 under ifdef would select native.  The same misparse of
+# CACTUS_PORTABLE_BUILD lands on the portable side, which is why that one can stay an ifdef,
+# but here it would hand you the dangerous answer for a value that plainly means "no".
+# Anything but 1, unset and 0 included, is portable.
 ifdef CACTUS_PORTABLE_BUILD
 	CACTUS_ARCH_FLAGS ?= ${CACTUS_PORTABLE_ARCH_FLAGS}
-else
+else ifeq ($(strip ${CACTUS_NATIVE_BUILD}),1)
 	CACTUS_ARCH_FLAGS ?= ${CACTUS_NATIVE_ARCH_FLAGS}
+else
+	CACTUS_ARCH_FLAGS ?= ${CACTUS_PORTABLE_ARCH_FLAGS}
 endif
 
 # Both, deliberately.  Until now only CFLAGS carried an arch flag, so Red, hal's C++ and


### PR DESCRIPTION
I recently made the default build use native compiler flags.  But this turned out to be really annoying (this has probably bitten me before) becuase binaries built on our cluster's head nodes wouldn't run on all worker nodes.  Anyway, this PR reverts the default back to something more portable.  Setting various env vars can toggle between if needed...
-----

Inverts ad95c54b.  A development build is not usually run where it was built: compiling on a cluster head node and running on whatever worker picks up the job is the normal case, and an -march=native binary SIGILLs on any worker older than the head node, which is most of a heterogeneous cluster.  It is also what the README tells a from-source user to type, so what a bare "make" emits has to be the safe thing.

Native is now CACTUS_NATIVE_BUILD=1, tested for exactly 1 rather than with ifdef.  ifdef is true of any non-empty value, so CACTUS_NATIVE_BUILD=0 would have selected native; the same misparse of CACTUS_PORTABLE_BUILD lands on the portable side, which is why that one stays an ifdef.

CACTUS_PORTABLE_BUILD keeps working and still beats the native knob.  Both it and the Dockerfile's copy are defence in depth now rather than the only barrier, but what we distribute is worth saying twice.

Resolved baselines, all verified with "make arch-flags":

  plain make                          -march=x86-64-v3
  CACTUS_NATIVE_BUILD=1               -march=native
  CACTUS_PORTABLE_BUILD=1             -march=x86-64-v3
  portable + native                   -march=x86-64-v3
  CACTUS_LEGACY_ARCH=1                -msse2
  legacy or ARM + native              unchanged, the knob is a no-op there
  explicit CACTUS_ARCH_FLAGS          wins over all of the above

CACTUS_NATIVE_BUILD = 1 in include.local.mk works too, and is the tidier answer for a workstation whose binaries never leave it: no shell state to forget, and it cannot reach a release, since the Dockerfile deletes that file and makeBinRelease builds a fresh clone.  Verified, along with the knob surviving the "env -u MAKEFLAGS make -s arch-flags" hop the download* scripts use, the flags landing in CFLAGS, CXXFLAGS, archEnv and archCC, and api/impl/cactusBlock.c compiling under every baseline above.

Two things the inversion drags in.

-march=x86-64-v2/v3/v4 only arrived in gcc 11 and clang 12, and an -march value the compiler does not recognise is a hard error, not a warning.  That flag was previously reached only by builds we ship, which are built on 22.04; the flip puts it on the path the README tells people to type, and the README still names Ubuntu 20.04, whose gcc is 9.  So x86 probes the compiler and falls back to the bare -mavx2 this baseline replaced.  Safe to take silently because it cannot weaken the portability contract: both spellings require AVX2 and nothing newer, so the oldest CPU that can run the result is the same either way.  What is lost is the rest of the v3 generation, the 1-2% b14b4a29 measured.

makeBinRelease now unsets CACTUS_ARCH_FLAGS and CACTUS_NATIVE_BUILD next to sonLibRootDir and PYTHONPATH.  It runs in the developer's own shell, and exporting the native knob is what the README now suggests -- but CACTUS_ARCH_FLAGS is the worse of the two, since it outranks the CACTUS_PORTABLE_BUILD the script sets and would also strip the legacy tarball of the -msse2 that is its only reason to exist.  CACTUS_LEGACY_ARCH is deliberately not in that list: "make binRelease" passes it in on purpose.

CI needs no edit.  Its plain "make" steps switch from -march=native to -march=x86-64-v3, so it starts compiling the ISA that actually ships instead of whatever the runner happened to be; nothing in the repo pins which machine a run gets.  The legacy image and the evolver test stay on -msse2, and the Dockerfile sed still matches.

Neither knob was documented anywhere a user reads, so DEVELOPMENT.md gains an "Environment variables controlling how cactus is built" section beside its two siblings, and README's compile section gains five lines naming the default and the opt-in.

